### PR TITLE
Use SSE for 128-bit atomic load/store on Intel CPU with AVX

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Native 128-bit atomic operations are available on x86_64 (Rust 1.59+), aarch64 (
 
 On x86_64, when the `outline-atomics` optional feature is not enabled and `cmpxchg16b` target feature is not enabled at compile-time, this uses the fallback implementation. `cmpxchg16b` target feature is enabled by default only on macOS.
 
+See [this list](https://github.com/taiki-e/portable-atomic/issues/10#issuecomment-1159368067) for details.
+
 ## Optional features
 
 - **`fallback`** *(enabled by default)*<br>
@@ -35,7 +37,7 @@ On x86_64, when the `outline-atomics` optional feature is not enabled and `cmpxc
   This allows maintaining support for older CPUs while using features that are not supported on older CPUs, such as cmpxchg16b (x86_64) and LSE (aarch64).
 
   Note:
-  - Dynamic detection is currently only enabled in Rust 1.61+ for aarch64 and in nightly for other platforms, otherwise it works the same as the default.
+  - Dynamic detection is currently only enabled in Rust 1.61+ for aarch64, in 1.58+ (avx) or nightly (cmpxchg16b) for x86_64, and in nightly for other platforms, otherwise it works the same as the default.
   - If the required target features are enabled at compile-time, the atomic operations are inlined.
   - This is compatible with no-std (as with all features except `std`).
 

--- a/src/imp/atomic128/cpuid.rs
+++ b/src/imp/atomic128/cpuid.rs
@@ -1,29 +1,106 @@
-#[inline]
-fn _has_cmpxchg16b() -> bool {
-    // https://github.com/rust-lang/stdarch/blob/bcbe010614f398ec86f3a9274d22e33e5f2ee60b/crates/core_arch/src/x86/cpuid.rs#L102-L105
-    #[cfg(target_env = "sgx")]
-    {
-        false
+// Adapted from https://github.com/rust-lang/stdarch/blob/bcbe010614f398ec86f3a9274d22e33e5f2ee60b/crates/std_detect/src/detect/os/x86.rs.
+
+#![cfg_attr(
+    any(not(feature = "outline-atomics"), not(target_feature = "sse"), miri, sanitize_thread),
+    allow(dead_code)
+)]
+
+use core::{
+    arch::x86_64::{CpuidResult, __cpuid},
+    sync::atomic::{AtomicU32, Ordering},
+};
+
+#[derive(Clone, Copy)]
+struct CpuInfo(u32);
+
+impl CpuInfo {
+    const INIT: u32 = 0;
+    const HAS_CMPXCHG16B: u32 = 1;
+    const IS_INTEL_AND_HAS_AVX: u32 = 2;
+
+    #[inline]
+    fn set(&mut self, bit: u32) {
+        self.0 = set(self.0, bit);
     }
+    #[inline]
+    fn test(self, bit: u32) -> bool {
+        test(self.0, bit)
+    }
+}
+
+#[inline]
+fn set(x: u32, bit: u32) -> u32 {
+    x | 1 << bit
+}
+#[inline]
+fn test(x: u32, bit: u32) -> bool {
+    x & (1 << bit) != 0
+}
+
+#[inline]
+unsafe fn _vendor_id() -> [u8; 12] {
+    // SAFETY: the caller must guarantee that CPU supports `cpuid`.
+    // transmute is safe because `[u8; 12]` and `[[u8; 4]; 3]` has the same layout.
+    unsafe {
+        // https://github.com/rust-lang/stdarch/blob/bcbe010614f398ec86f3a9274d22e33e5f2ee60b/crates/std_detect/src/detect/os/x86.rs#L40-L59
+        let CpuidResult { ebx, ecx, edx, .. } = __cpuid(0);
+        let vendor_id: [[u8; 4]; 3] = [ebx.to_ne_bytes(), edx.to_ne_bytes(), ecx.to_ne_bytes()];
+        core::mem::transmute(vendor_id)
+    }
+}
+
+#[inline]
+fn _cpuid(info: &mut CpuInfo) {
+    info.set(CpuInfo::INIT);
     // Miri doesn't support inline assembly used in __cpuid
     #[cfg(miri)]
     {
-        true
+        info.set(CpuInfo::HAS_CMPXCHG16B);
     }
+    // sgx doesn't support `cpuid`: https://github.com/rust-lang/stdarch/blob/bcbe010614f398ec86f3a9274d22e33e5f2ee60b/crates/core_arch/src/x86/cpuid.rs#L102-L105
     #[cfg(not(any(target_env = "sgx", miri)))]
     {
-        // Adapted from https://github.com/rust-lang/stdarch/blob/bcbe010614f398ec86f3a9274d22e33e5f2ee60b/crates/std_detect/src/detect/os/x86.rs.
-        use core::arch::x86_64::__cpuid;
+        use core::arch::x86_64::_xgetbv;
+
+        // SAFETY: Calling `_vendor_id`` is safe because the CPU has `cpuid` support.
+        let vendor_id = unsafe { _vendor_id() };
 
         // SAFETY: Calling `__cpuid`` is safe because the CPU has `cpuid` support.
-        //
-        // EAX = 1, ECX = 0: Queries "Processor Info and Feature Bits";
-        // Contains information about most x86 features.
         let proc_info_ecx = unsafe { __cpuid(0x0000_0001_u32).ecx };
 
         // https://github.com/rust-lang/stdarch/blob/bcbe010614f398ec86f3a9274d22e33e5f2ee60b/crates/std_detect/src/detect/os/x86.rs#L111
-        proc_info_ecx & (1 << 13) != 0
+        if test(proc_info_ecx, 13) {
+            info.set(CpuInfo::HAS_CMPXCHG16B);
+        }
+
+        if vendor_id == *b"GenuineIntel" {
+            // https://github.com/rust-lang/stdarch/blob/bcbe010614f398ec86f3a9274d22e33e5f2ee60b/crates/std_detect/src/detect/os/x86.rs#L131-L224
+            let cpu_xsave = test(proc_info_ecx, 26);
+            if cpu_xsave {
+                let cpu_osxsave = test(proc_info_ecx, 27);
+                if cpu_osxsave {
+                    // SAFETY: Calling `_xgetbv`` is safe because the CPU has `xsave` support.
+                    let xcr0 = unsafe { _xgetbv(0) };
+                    let os_avx_support = xcr0 & 6 == 6;
+                    if os_avx_support && test(proc_info_ecx, 28) {
+                        info.set(CpuInfo::IS_INTEL_AND_HAS_AVX);
+                    }
+                }
+            }
+        }
     }
+}
+
+#[inline]
+fn cpuid() -> CpuInfo {
+    static CACHE: AtomicU32 = AtomicU32::new(0);
+    let mut info = CpuInfo(CACHE.load(Ordering::Relaxed));
+    if info.0 != 0 {
+        return info;
+    }
+    _cpuid(&mut info);
+    CACHE.store(info.0, Ordering::Relaxed);
+    info
 }
 
 #[inline]
@@ -35,23 +112,48 @@ pub(crate) fn has_cmpxchg16b() -> bool {
     }
     #[cfg(not(any(target_feature = "cmpxchg16b", portable_atomic_target_feature = "cmpxchg16b")))]
     {
-        fn t() -> bool {
-            true
-        }
-        #[cold]
-        fn f() -> bool {
-            false
-        }
-        ifunc!(fn() -> bool = if _has_cmpxchg16b() { t } else { f })
+        cpuid().test(CpuInfo::HAS_CMPXCHG16B)
     }
 }
 
+#[inline]
+pub(crate) fn is_intel_and_has_avx() -> bool {
+    cpuid().test(CpuInfo::IS_INTEL_AND_HAS_AVX)
+}
+
+#[allow(clippy::undocumented_unsafe_blocks)]
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
-    #[cfg_attr(miri, ignore)] // Miri doesn't support inline assembly
-    fn test() {
-        assert_eq!(std::is_x86_feature_detected!("cmpxchg16b"), super::_has_cmpxchg16b());
-        assert_eq!(std::is_x86_feature_detected!("cmpxchg16b"), super::has_cmpxchg16b());
+    fn test_bit_flags() {
+        let mut x = CpuInfo(0);
+        assert!(!x.test(CpuInfo::INIT));
+        assert!(!x.test(CpuInfo::HAS_CMPXCHG16B));
+        assert!(!x.test(CpuInfo::IS_INTEL_AND_HAS_AVX));
+        x.set(CpuInfo::INIT);
+        assert!(x.test(CpuInfo::INIT));
+        assert!(!x.test(CpuInfo::HAS_CMPXCHG16B));
+        assert!(!x.test(CpuInfo::IS_INTEL_AND_HAS_AVX));
+        x.set(CpuInfo::HAS_CMPXCHG16B);
+        assert!(x.test(CpuInfo::INIT));
+        assert!(x.test(CpuInfo::HAS_CMPXCHG16B));
+        assert!(!x.test(CpuInfo::IS_INTEL_AND_HAS_AVX));
+        x.set(CpuInfo::IS_INTEL_AND_HAS_AVX);
+        assert!(x.test(CpuInfo::INIT));
+        assert!(x.test(CpuInfo::HAS_CMPXCHG16B));
+        assert!(x.test(CpuInfo::IS_INTEL_AND_HAS_AVX));
+    }
+
+    #[test]
+    // Miri doesn't support inline assembly
+    // sgx doesn't support `cpuid`
+    #[cfg_attr(any(target_env = "sgx", miri), ignore)]
+    fn test_cpuid() {
+        assert_eq!(std::is_x86_feature_detected!("cmpxchg16b"), has_cmpxchg16b());
+        if unsafe { _vendor_id() } == *b"GenuineIntel" {
+            assert_eq!(std::is_x86_feature_detected!("avx"), is_intel_and_has_avx());
+        }
     }
 }


### PR DESCRIPTION
x86_64 part of #10

The following are the results of a simple microbenchmark:

```
bench_portable_atomic_arch/u128_load
                        time:   [1.4598 ns 1.4671 ns 1.4753 ns]
                        change: [-81.510% -81.210% -80.950%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe
bench_portable_atomic_arch/u128_store
                        time:   [1.3852 ns 1.3937 ns 1.4024 ns]
                        change: [-82.318% -81.989% -81.621%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe
bench_portable_atomic_arch/u128_concurrent_load
                        time:   [56.422 us 56.767 us 57.204 us]
                        change: [-70.807% -70.143% -69.443%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe
bench_portable_atomic_arch/u128_concurrent_load_store
                        time:   [136.53 us 139.96 us 145.39 us]
                        change: [-82.570% -81.879% -80.820%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  4 (4.00%) high mild
  11 (11.00%) high severe
bench_portable_atomic_arch/u128_concurrent_store
                        time:   [146.03 us 147.67 us 149.98 us]
                        change: [-90.486% -90.124% -89.483%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) high mild
  8 (8.00%) high severe
bench_portable_atomic_arch/u128_concurrent_store_swap
                        time:   [765.11 us 766.69 us 768.29 us]
                        change: [-51.204% -50.967% -50.745%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
```

Closes #10