### PR TITLE
aarch64: Use CASP instead of LDXP/STXP for load if available

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ env:
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: '10'
 
-aarch64_linux_task:
+aarch64_linux_test_task:
   name: test (aarch64-unknown-linux-gnu)
   env:
     TARGET: aarch64-unknown-linux-gnu
@@ -28,7 +28,7 @@ aarch64_linux_task:
     - RUSTFLAGS="$RUSTFLAGS -C target-feature=+lse" RUSTDOCFLAGS="$RUSTDOCFLAGS -C target-feature=+lse" CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 CARGO_PROFILE_RELEASE_LTO=fat cargo -Z build-std test -vv --workspace --exclude bench --all-features --release --tests --target $TARGET
     # TODO: lse2 is not available on Graviton2 (armv8.2-a)
 
-aarch64_macos_task:
+aarch64_macos_test_task:
   name: test (aarch64-apple-darwin)
   env:
     TARGET: aarch64-apple-darwin
@@ -43,7 +43,7 @@ aarch64_macos_task:
     # Use -Z build-std because the prebuilt libtest seems to be incompatible with LTO, causing miscompilation: https://gist.github.com/taiki-e/9713f8e02e8f9f852ccee8d6f089ec24
     - CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 CARGO_PROFILE_RELEASE_LTO=fat cargo -Z build-std test -vv --workspace --exclude bench --all-features --release --tests --target $TARGET
 
-valgrind_task:
+aarch64_linux_valgrind_task:
   name: valgrind (aarch64-unknown-linux-gnu)
   env:
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER: valgrind -v --error-exitcode=1 --error-limit=no --leak-check=full --show-leak-kinds=all --track-origins=yes
@@ -80,3 +80,30 @@ valgrind_task:
     # Use -Z build-std because the prebuilt libtest seems to be incompatible with LTO, causing miscompilation: https://gist.github.com/taiki-e/9713f8e02e8f9f852ccee8d6f089ec24
     - RUSTFLAGS="$RUSTFLAGS -C target-feature=+lse" RUSTDOCFLAGS="$RUSTDOCFLAGS -C target-feature=+lse" CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 CARGO_PROFILE_RELEASE_LTO=fat cargo -Z build-std test -vv --workspace --exclude bench --all-features --release --tests --target $TARGET
     # TODO: lse2 is not available on Graviton2 (armv8.2-a)
+
+# aarch64_linux_bench_task:
+#   name: bench (aarch64-unknown-linux-gnu)
+#   env:
+#     TARGET: aarch64-unknown-linux-gnu
+#   arm_container:
+#     image: rust:latest
+#     cpu: 4
+#     memory: 12G
+#   setup_script:
+#     - rustup toolchain add nightly && rustup default nightly
+#   test_script:
+#     - cargo bench -vv --manifest-path bench/Cargo.toml
+#     - RUSTFLAGS="${RUSTFLAGS} -C target-feature=+lse" cargo bench -vv --manifest-path bench/Cargo.toml
+
+# aarch64_macos_bench_task:
+#   name: bench (aarch64-apple-darwin)
+#   env:
+#     TARGET: aarch64-apple-darwin
+#   macos_instance:
+#     image: ghcr.io/cirruslabs/macos-monterey-xcode:latest
+#   setup_script:
+#     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly --component rust-src
+#   test_script:
+#     - sysctl -a | grep machdep.cpu
+#     - source $HOME/.cargo/env
+#     - cargo bench -vv --manifest-path bench/Cargo.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Optimize aarch64 128-bit load. ([#20](https://github.com/taiki-e/portable-atomic/pull/20))
+
 ## [0.3.9] - 2022-08-03
 
 - Fix build error on old Miri.


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/issues/55199 for the motivation.

In CAS we have already done this; in RMW and store we still use LDXP/STXP even if LSE is available because [the performance benefits do not seem clear yet](https://github.com/taiki-e/portable-atomic/pull/20#issuecomment-1204208980).