### PR TITLE
x86_64: Detect Intel chips from target-cpu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,26 @@ jobs:
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-feature=+cmpxchg16b
         if: matrix.target == '' || startsWith(matrix.target, 'x86_64')
 
+      # Sandy Bridge (the first Intel chip that introduced AVX)
+      - run: cargo test -vv --workspace --exclude bench --all-features $TARGET $BUILD_STD $DOCTEST_XCOMPILE
+        env:
+          RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-cpu=sandybridge
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-cpu=sandybridge
+        if: matrix.target == '' || startsWith(matrix.target, 'x86_64')
+      - run: cargo test -vv --workspace --exclude bench --all-features --release $TARGET $BUILD_STD $DOCTEST_XCOMPILE
+        env:
+          RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-cpu=sandybridge
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-cpu=sandybridge
+        if: matrix.target == '' || startsWith(matrix.target, 'x86_64')
+      # LTO + doctests is very slow on some platforms
+      - run: cargo test -vv --workspace --exclude bench --all-features --release $TARGET $BUILD_STD $DOCTEST_XCOMPILE --tests
+        env:
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
+          CARGO_PROFILE_RELEASE_LTO: fat
+          RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-cpu=sandybridge
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-cpu=sandybridge
+        if: matrix.target == '' || startsWith(matrix.target, 'x86_64')
+
       # +lse
       - run: cargo test -vv --workspace --exclude bench --all-features $TARGET $BUILD_STD $DOCTEST_XCOMPILE
         env:
@@ -353,6 +373,7 @@ jobs:
         with:
           components: rust-src
       - uses: taiki-e/install-action@valgrind
+
       # doctests on Valgrind are very slow
       - run: cargo test -vv --workspace --exclude bench --all-features --tests
         env:
@@ -368,6 +389,7 @@ jobs:
           CARGO_PROFILE_RELEASE_LTO: fat
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} --cfg valgrind
           RUSTFLAGS: ${{ env.RUSTFLAGS }} --cfg valgrind
+
       # +cmpxchg16b
       - run: cargo test -vv --workspace --exclude bench --all-features --tests
         env:
@@ -383,6 +405,22 @@ jobs:
           CARGO_PROFILE_RELEASE_LTO: fat
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-feature=+cmpxchg16b --cfg valgrind
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-feature=+cmpxchg16b --cfg valgrind
+
+      # Sandy Bridge (the first Intel chip that introduced AVX)
+      - run: cargo test -vv --workspace --exclude bench --all-features --tests
+        env:
+          RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-cpu=sandybridge --cfg valgrind
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-cpu=sandybridge --cfg valgrind
+      - run: cargo test -vv --workspace --exclude bench --all-features --release --tests
+        env:
+          RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-cpu=sandybridge --cfg valgrind
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-cpu=sandybridge --cfg valgrind
+      - run: cargo test -vv --workspace --exclude bench --all-features --release --tests
+        env:
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
+          CARGO_PROFILE_RELEASE_LTO: fat
+          RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-cpu=sandybridge --cfg valgrind
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-cpu=sandybridge --cfg valgrind
 
   codegen:
     runs-on: ubuntu-latest

--- a/src/imp/atomic128/cpuid.rs
+++ b/src/imp/atomic128/cpuid.rs
@@ -4,8 +4,9 @@
     any(
         not(feature = "outline-atomics"),
         not(target_feature = "sse"),
+        portable_atomic_intel_cpu,
         miri,
-        portable_atomic_sanitize_thread
+        portable_atomic_sanitize_thread,
     ),
     allow(dead_code)
 )]

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -258,6 +258,9 @@ build() {
         x86_64*)
             RUSTFLAGS="${target_rustflags} -C target-feature=+cmpxchg16b" \
                 x cargo "${args[@]}" --target-dir target/cmpxchg16b "$@"
+            # Sandy Bridge (the first Intel chip that introduced AVX)
+            RUSTFLAGS="${target_rustflags} -C target-cpu=sandybridge" \
+                x cargo "${args[@]}" --target-dir target/sandybridge "$@" -vv
             ;;
         aarch64* | arm64*)
             RUSTFLAGS="${target_rustflags} -C target-feature=+lse" \


### PR DESCRIPTION
Implement an approach mentioned in https://github.com/taiki-e/portable-atomic/pull/16#discussion_r900695941.

A potential concern is that some users may be using `target-cpu=haswell` in `target-cpu=x86-64-v3`-like sense.