### PR TITLE
Provide stable equivalent of #![feature(strict_provenance_atomic_ptr)]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Provide stable equivalent of [`#![feature(strict_provenance_atomic_ptr)]`](https://github.com/rust-lang/rust/issues/99108).
+
+  - `AtomicPtr::fetch_ptr_{add,sub}`
+  - `AtomicPtr::fetch_byte_{add,sub}`
+  - `AtomicPtr::fetch_{or,and,xor}`
+
+  These APIs are compatible with strict-provenance on `cfg(miri)`. Otherwise, they are compatible with permissive-provenance.
+  Once `#![feature(strict_provenance_atomic_ptr)]` is stabilized, these APIs will be strict-provenance compatible in all cases from the version in which it is stabilized.
+
 ## [0.3.6] - 2022-07-26
 
 - Fix build failure due to the existence of the `specs` directory.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,4 +67,5 @@ paste = "1"
 quickcheck = { default-features = false, git = "https://github.com/taiki-e/quickcheck.git", branch = "dev" } # https://github.com/BurntSushi/quickcheck/pull/304 + https://github.com/BurntSushi/quickcheck/pull/282 + lower MSRV
 serde = { version = "1", features = ["derive"] }
 serde_test = "1"
+sptr = "0.3"
 static_assertions = "1"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Portable atomic types including support for 128-bit atomics, atomic float, etc.
 <!-- - Provide generic `Atomic<T>` type. (optional) -->
 - Provide atomic load/store for targets where atomic is not available at all in the standard library. (riscv without A-extension, msp430, avr)
 - Provide atomic CAS for targets where atomic CAS is not available in the standard library. (thumbv6m, riscv without A-extension, msp430, avr) (optional, [single-core only](#optional-cfg))
+- Provide stable equivalents of the standard library atomic types' unstable APIs, such as [`AtomicPtr::fetch_*`](https://github.com/rust-lang/rust/issues/99108).
 - Make features that require newer compilers, such as [fetch_max](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_max), [fetch_min](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_min), [fetch_update](https://doc.rust-lang.org/nightly/std/sync/atomic/struct.AtomicPtr.html#method.fetch_update), and [stronger CAS failure ordering](https://github.com/rust-lang/rust/pull/98383) available on Rust 1.34+.
 
 ## 128-bit atomics support

--- a/build.rs
+++ b/build.rs
@@ -112,6 +112,11 @@ fn main() {
     if version.nightly {
         println!("cargo:rustc-cfg=portable_atomic_nightly");
 
+        // https://github.com/rust-lang/rust/pull/96935 merged in Rust 1.64 (nightly-2022-07-07).
+        if version.probe(64, 2022, 7, 6) {
+            println!("cargo:rustc-cfg=portable_atomic_unstable_strict_provenance_atomic_ptr");
+        }
+
         // `cfg(sanitize = "..")` is not stabilized.
         let sanitize = std::env::var("CARGO_CFG_SANITIZE").unwrap_or_default();
         if sanitize.contains("thread") {


### PR DESCRIPTION
This provides stable equivalent of [`#![feature(strict_provenance_atomic_ptr)]`](https://github.com/rust-lang/rust/issues/99108).

- `AtomicPtr::fetch_ptr_{add,sub}`
- `AtomicPtr::fetch_byte_{add,sub}`
- `AtomicPtr::fetch_{or,and,xor}`

These APIs are compatible with strict-provenance on `cfg(miri)`.
Otherwise, they are compatible with permissive-provenance.

Once `#![feature(strict_provenance_atomic_ptr)]` is stabilized, these APIs will be strict-provenance compatible in all cases from the version in which it is stabilized.

(This is also a generalization of what [I did in crossbeam-epoch](https://github.com/crossbeam-rs/crossbeam/pull/796).)