### PR TITLE
interrupt: Support no-std pre-v6 ARM targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Support atomic CAS on no-std pre-v6 ARM targets (e.g., thumbv4t-none-eabi) under unsafe cfg `portable_atomic_unsafe_assume_single_core`. ([#28](https://github.com/taiki-e/portable-atomic/pull/28))
+
 ## [0.3.11] - 2022-08-12
 
 - Always provide atomic CAS for MSP430 and AVR. ([#31](https://github.com/taiki-e/portable-atomic/pull/31))

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Portable atomic types including support for 128-bit atomics, atomic float, etc.
 - Provide `AtomicF32` and `AtomicF64`. (optional)
 <!-- - Provide generic `Atomic<T>` type. (optional) -->
 - Provide atomic load/store for targets where atomic is not available at all in the standard library. (RISC-V without A-extension, MSP430, AVR)
-- Provide atomic CAS for targets where atomic CAS is not available in the standard library. (thumbv6m, RISC-V without A-extension, MSP430, AVR) (optional and [single-core only](#optional-cfg) for ARM and RISC-V, always enabled for MSP430 and AVR)
+- Provide atomic CAS for targets where atomic CAS is not available in the standard library. (thumbv6m, pre-v6 ARM, RISC-V without A-extension, MSP430, AVR) (optional and [single-core only](#optional-cfg) for ARM and RISC-V, always enabled for MSP430 and AVR)
 - Provide equivalents on the target that the standard library's atomic-related APIs cause LLVM errors. (fence/compiler_fence on MSP430)
 - Provide stable equivalents of the standard library atomic types' unstable APIs, such as [`AtomicPtr::fetch_*`](https://github.com/rust-lang/rust/issues/99108), [`AtomicBool::fetch_not`](https://github.com/rust-lang/rust/issues/98485).
 - Make features that require newer compilers, such as [fetch_max](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_max), [fetch_min](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_min), [fetch_update](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicPtr.html#method.fetch_update), and [stronger CAS failure ordering](https://github.com/rust-lang/rust/pull/98383) available on Rust 1.34+.
@@ -74,12 +74,14 @@ See [this list](https://github.com/taiki-e/portable-atomic/issues/10#issuecommen
   - Enabling this cfg for multi-core systems is always **unsound**.
   - This uses privileged instructions to disable interrupts, so it usually doesn't work on unprivileged mode.
     Enabling this cfg in an environment where privileged instructions are not available is also usually considered **unsound**, although the details are system-dependent.
+  - On pre-v6 ARM, this currently disables only IRQs.
+    Enabling this cfg in an environment where FIQs must also be disabled is also considered **unsound**.
 
   This is intentionally not an optional feature. (If this is an optional feature, dependencies can implicitly enable the feature, resulting in the use of unsound code without the end-user being aware of it.)
 
   Enabling this cfg for targets that have atomic CAS will result in a compile error.
 
-  ARMv6-M (thumbv6m), RISC-V without A-extension are currently supported. See [#26] for support of no-std pre-v6 ARM and multi-core systems.
+  ARMv6-M (thumbv6m), pre-v6 ARM (e.g., thumbv4t), RISC-V without A-extension are currently supported. See [#26] for support of multi-core systems.
 
   Since all MSP430 and AVR are single-core, we always provide atomic CAS for them without this cfg.
 

--- a/src/imp/interrupt/armv4t.rs
+++ b/src/imp/interrupt/armv4t.rs
@@ -1,0 +1,44 @@
+// Refs: https://developer.arm.com/documentation/ddi0406/cb/System-Level-Architecture/The-System-Level-Programmers--Model/ARM-processor-modes-and-ARM-core-registers/Program-Status-Registers--PSRs-?lang=en#CIHJBHJA
+
+#[cfg(not(portable_atomic_no_asm))]
+use core::arch::asm;
+
+#[derive(Clone, Copy)]
+pub(super) struct State(u32);
+
+/// Disables interrupts and returns the previous interrupt state.
+#[inline]
+#[instruction_set(arm::a32)]
+pub(super) fn disable() -> State {
+    let cpsr: u32;
+    // SAFETY: reading CPSR and disabling interrupts are safe.
+    // (see module-level comments of interrupt/mod.rs on the safety of using privileged instructions)
+    unsafe {
+        // Do not use `nomem` and `readonly` because prevent subsequent memory accesses from being reordered before interrupts are disabled.
+        asm!(
+            "mrs {0}, cpsr",
+            // We disable only IRQs. See also https://github.com/taiki-e/portable-atomic/pull/28#issuecomment-1214146912.
+            "orr {1}, {0}, 0x80",
+            "msr cpsr_c, {1}",
+            out(reg) cpsr,
+            out(reg) _,
+            options(nostack),
+        );
+    }
+    State(cpsr)
+}
+
+/// Restores the previous interrupt state.
+#[inline]
+#[instruction_set(arm::a32)]
+pub(super) unsafe fn restore(State(prev): State) {
+    // SAFETY: the caller must guarantee that the state was retrieved by the previous `disable`,
+    unsafe {
+        // Do not use `nomem` and `readonly` because prevent preceding memory accesses from being reordered after interrupts are enabled.
+        asm!(
+            "msr cpsr_c, {0}",
+            in(reg) prev,
+            options(nostack),
+        );
+    }
+}

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -112,6 +112,10 @@ mod fallback;
 )]
 #[cfg(any(
     portable_atomic_armv6m,
+    all(
+        target_arch = "arm",
+        not(any(target_feature = "v6", portable_atomic_target_feature = "v6"))
+    ),
     target_arch = "avr",
     target_arch = "msp430",
     target_arch = "riscv32",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ Portable atomic types including support for 128-bit atomics, atomic float, etc.
 - Provide `AtomicF32` and `AtomicF64`. (optional)
 <!-- - Provide generic `Atomic<T>` type. (optional) -->
 - Provide atomic load/store for targets where atomic is not available at all in the standard library. (RISC-V without A-extension, MSP430, AVR)
-- Provide atomic CAS for targets where atomic CAS is not available in the standard library. (thumbv6m, RISC-V without A-extension, MSP430, AVR) (optional and [single-core only](#optional-cfg) for ARM and RISC-V, always enabled for MSP430 and AVR)
+- Provide atomic CAS for targets where atomic CAS is not available in the standard library. (thumbv6m, pre-v6 ARM, RISC-V without A-extension, MSP430, AVR) (optional and [single-core only](#optional-cfg) for ARM and RISC-V, always enabled for MSP430 and AVR)
 - Provide equivalents on the target that the standard library's atomic-related APIs cause LLVM errors. (fence/compiler_fence on MSP430)
 - Provide stable equivalents of the standard library atomic types' unstable APIs, such as [`AtomicPtr::fetch_*`](https://github.com/rust-lang/rust/issues/99108), [`AtomicBool::fetch_not`](https://github.com/rust-lang/rust/issues/98485).
 - Make features that require newer compilers, such as [fetch_max](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_max), [fetch_min](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_min), [fetch_update](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicPtr.html#method.fetch_update), and [stronger CAS failure ordering](https://github.com/rust-lang/rust/pull/98383) available on Rust 1.34+.
@@ -66,12 +66,14 @@ See [this list](https://github.com/taiki-e/portable-atomic/issues/10#issuecommen
   - Enabling this cfg for multi-core systems is always **unsound**.
   - This uses privileged instructions to disable interrupts, so it usually doesn't work on unprivileged mode.
     Enabling this cfg in an environment where privileged instructions are not available is also usually considered **unsound**, although the details are system-dependent.
+  - On pre-v6 ARM, this currently disables only IRQs.
+    Enabling this cfg in an environment where FIQs must also be disabled is also considered **unsound**.
 
   This is intentionally not an optional feature. (If this is an optional feature, dependencies can implicitly enable the feature, resulting in the use of unsound code without the end-user being aware of it.)
 
   Enabling this cfg for targets that have atomic CAS will result in a compile error.
 
-  ARMv6-M (thumbv6m), RISC-V without A-extension are currently supported. See [#26] for support of no-std pre-v6 ARM and multi-core systems.
+  ARMv6-M (thumbv6m), pre-v6 ARM (e.g., thumbv4t), RISC-V without A-extension are currently supported. See [#26] for support of multi-core systems.
 
   Since all MSP430 and AVR are single-core, we always provide atomic CAS for them without this cfg.
 
@@ -176,6 +178,17 @@ See [this list](https://github.com/taiki-e/portable-atomic/issues/10#issuecommen
     ),
     feature(asm_experimental_arch)
 )]
+// non-Linux armv4t (tier 3)
+#![cfg_attr(
+    all(
+        portable_atomic_nightly,
+        target_arch = "arm",
+        not(target_has_atomic = "ptr"),
+        not(any(target_feature = "v6", portable_atomic_target_feature = "v6")),
+        any(test, portable_atomic_unsafe_assume_single_core)
+    ),
+    feature(isa_attribute)
+)]
 // Old nightly only
 // These features are already stable or have already been removed from compilers,
 // and can safely be enabled for old nightly as long as version detection works.
@@ -247,6 +260,10 @@ compile_error!(
         not(any(
             portable_atomic_armv6m,
             all(
+                target_arch = "arm",
+                not(any(target_feature = "v6", portable_atomic_target_feature = "v6"))
+            ),
+            all(
                 any(target_arch = "riscv32", target_arch = "riscv64"),
                 portable_atomic_no_atomic_cas
             ),
@@ -260,6 +277,10 @@ compile_error!(
         target_has_atomic = "ptr",
         not(any(
             portable_atomic_armv6m,
+            all(
+                target_arch = "arm",
+                not(any(target_feature = "v6", portable_atomic_target_feature = "v6"))
+            ),
             all(
                 any(target_arch = "riscv32", target_arch = "riscv64"),
                 not(target_has_atomic = "ptr")

--- a/tests/gba/.cargo/config.toml
+++ b/tests/gba/.cargo/config.toml
@@ -1,0 +1,8 @@
+[build]
+target-dir = "../../target"
+
+[target.thumbv4t-none-eabi]
+runner = "mgba -l 4"
+
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+rustflags = ["-C", "link-arg=-Tlinker.ld"]

--- a/tests/gba/Cargo.toml
+++ b/tests/gba/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "gba-test"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[workspace]
+resolver = "2"
+
+[dependencies]
+portable-atomic = { path = "../.." }
+
+gba = "0.5"
+paste = "1"
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"

--- a/tests/gba/linker.ld
+++ b/tests/gba/linker.ld
@@ -1,0 +1,82 @@
+/* Device specific memory layout for GBA test
+ * Adapted from https://github.com/rust-console/gba.
+ */
+
+ENTRY(__start)
+
+MEMORY {
+    ewram (w!x) : ORIGIN = 0x2000000, LENGTH = 256K
+    iwram (w!x) : ORIGIN = 0x3000000, LENGTH = 32K
+    rom (rx)    : ORIGIN = 0x8000000, LENGTH = 32M
+}
+
+SECTIONS {
+    .text : {
+        KEEP(rsrt0.o(.text));
+        *(.text .text.*);
+        . = ALIGN(4);
+    } >rom = 0xff
+
+    .rodata : {
+        *(.rodata .rodata.*);
+        . = ALIGN(4);
+    } >rom = 0xff
+
+    __iwram_lma = .;
+    .iwram : {
+        __iwram_start = ABSOLUTE(.);
+
+        __data_start = ABSOLUTE(.);
+        *(.data .data.*);
+        . = ALIGN(4);
+        __data_end = ABSOLUTE(.);
+
+        __text_iwram_start = ABSOLUTE(.);
+        *(.text_iwram .text_iwram.*);
+        . = ALIGN(4);
+        __text_iwram_end = ABSOLUTE(.);
+
+        __iwram_end = ABSOLUTE(.);
+    } >iwram AT>rom = 0xff
+
+    .bss : {
+        *(.bss .bss.*);
+        . = ALIGN(4);
+        __bss_end = ABSOLUTE(.);
+    } >iwram
+
+    /* debugging sections */
+    /* Stabs */
+    .stab            0 : { *(.stab) }
+    .stabstr         0 : { *(.stabstr) }
+    .stab.excl       0 : { *(.stab.excl) }
+    .stab.exclstr    0 : { *(.stab.exclstr) }
+    .stab.index      0 : { *(.stab.index) }
+    .stab.indexstr   0 : { *(.stab.indexstr) }
+    .comment         0 : { *(.comment) }
+    /* DWARF 1 */
+    .debug           0 : { *(.debug) }
+    .line            0 : { *(.line) }
+    /* GNU DWARF 1 extensions */
+    .debug_srcinfo   0 : { *(.debug_srcinfo) }
+    .debug_sfnames   0 : { *(.debug_sfnames) }
+    /* DWARF 1.1 and DWARF 2 */
+    .debug_aranges   0 : { *(.debug_aranges) }
+    .debug_pubnames  0 : { *(.debug_pubnames) }
+    /* DWARF 2 */
+    .debug_info      0 : { *(.debug_info) }
+    .debug_abbrev    0 : { *(.debug_abbrev) }
+    .debug_line      0 : { *(.debug_line) }
+   	.debug_frame     0 : { *(.debug_frame) }
+    .debug_str       0 : { *(.debug_str) }
+    .debug_loc       0 : { *(.debug_loc) }
+    .debug_macinfo   0 : { *(.debug_macinfo) }
+    /* SGI/MIPS DWARF 2 extensions */
+    .debug_weaknames 0 : { *(.debug_weaknames) }
+    .debug_funcnames 0 : { *(.debug_funcnames) }
+    .debug_typenames 0 : { *(.debug_typenames) }
+    .debug_varnames  0 : { *(.debug_varnames) }
+
+    /* discard anything not already mentioned */
+    /DISCARD/ : { *(*) }
+}

--- a/tests/gba/src/main.rs
+++ b/tests/gba/src/main.rs
@@ -1,0 +1,122 @@
+#![no_main]
+#![no_std]
+#![warn(rust_2018_idioms, single_use_lifetimes, unsafe_op_in_unsafe_fn)]
+#![feature(linkage, core_intrinsics)]
+
+#[macro_use]
+#[path = "../../api-test/src/helper.rs"]
+mod helper;
+
+use core::{ptr, sync::atomic::Ordering};
+
+use gba::{fatal, warning};
+use portable_atomic::*;
+
+use core::{ffi::c_int, mem};
+
+// Refs: https://gcc.gnu.org/wiki/Atomic/GCCMM/LIbrary
+const MEMORY_ORDER_RELAXED: c_int = 0;
+const MEMORY_ORDER_CONSUME: c_int = 1;
+const MEMORY_ORDER_ACQUIRE: c_int = 2;
+// const MEMORY_ORDER_RELEASE: c_int = 3;
+// const MEMORY_ORDER_ACQ_REL: c_int = 4;
+// const MEMORY_ORDER_SEQ_CST: c_int = 5;
+
+#[inline]
+fn c_load_ordering(order: c_int) -> Ordering {
+    match order {
+        MEMORY_ORDER_RELAXED => Ordering::Relaxed,
+        MEMORY_ORDER_CONSUME | MEMORY_ORDER_ACQUIRE => Ordering::Acquire,
+        _ => Ordering::SeqCst,
+    }
+}
+
+struct FFIPanicGuard;
+impl Drop for FFIPanicGuard {
+    fn drop(&mut self) {
+        core::intrinsics::abort();
+    }
+}
+macro_rules! atomic_load {
+    ($name:ident, $int_ty:ty, $atomic_ty:ident) => {
+        #[no_mangle]
+        #[cfg_attr(all(not(windows), not(target_vendor = "apple")), linkage = "weak")]
+        pub unsafe extern "C" fn $name(dst: *mut $int_ty, ordering: c_int) -> $int_ty {
+            unsafe {
+                let guard = FFIPanicGuard;
+                let res = mem::transmute(
+                    (*dst.cast::<portable_atomic::$atomic_ty>()).load(c_load_ordering(ordering)),
+                );
+                mem::forget(guard);
+                res
+            }
+        }
+    };
+}
+atomic_load!(__atomic_load_1, u8, AtomicU8);
+atomic_load!(__atomic_load_2, u16, AtomicU16);
+atomic_load!(__atomic_load_4, u32, AtomicU32);
+
+#[no_mangle]
+fn main() -> ! {
+    macro_rules! test_atomic {
+        ($int_type:ident) => {
+            paste::paste! {
+                fn [<test_atomic_ $int_type>]() {
+                    __test_atomic_int!($int_type, [<Atomic $int_type:camel>]);
+                }
+                warning!("test test_atomic_{} ...", stringify!($int_type));
+                [<test_atomic_ $int_type>]();
+                warning!(" ok");
+            }
+        };
+    }
+    macro_rules! test_atomic_bool {
+        () => {
+            fn test_atomic_bool() {
+                __test_atomic_bool!(AtomicBool);
+            }
+            warning!("test test_atomic_bool ...");
+            test_atomic_bool();
+            warning!(" ok");
+        };
+    }
+    macro_rules! test_atomic_ptr {
+        () => {
+            fn test_atomic_ptr() {
+                __test_atomic_ptr!(AtomicPtr<u8>);
+            }
+            warning!("test test_atomic_ptr ...");
+            test_atomic_ptr();
+            warning!(" ok");
+        };
+    }
+    // TODO: AtomicF{32,64}
+
+    warning!("starting tests...");
+
+    test_atomic_bool!();
+    test_atomic_ptr!();
+    test_atomic!(isize);
+    test_atomic!(usize);
+    test_atomic!(i8);
+    test_atomic!(u8);
+    test_atomic!(i16);
+    test_atomic!(u16);
+    test_atomic!(i32);
+    test_atomic!(u32);
+    test_atomic!(i64);
+    test_atomic!(u64);
+    test_atomic!(i128);
+    test_atomic!(u128);
+
+    warning!("all tests passed");
+
+    loop {}
+}
+
+#[inline(never)]
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
+    fatal!("{}", info)
+}

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -166,7 +166,7 @@ build() {
                 RUSTFLAGS="${target_rustflags}" \
                     x cargo "${args[@]}" --manifest-path tests/api-test/Cargo.toml "$@"
                 ;;
-            bpf* | thumbv4t-*) ;; # TODO
+            bpf*) ;; # TODO
             *)
                 RUSTFLAGS="${target_rustflags} --cfg portable_atomic_unsafe_assume_single_core" \
                     x cargo "${args[@]}" --manifest-path tests/api-test/Cargo.toml "$@"
@@ -196,7 +196,7 @@ build() {
             if ! grep <<<"${cfgs}" -q "target_has_atomic=" && [[ -n "${has_asm}" ]]; then
                 case "${target}" in
                     avr-* | msp430-*) ;;  # always single-core
-                    bpf* | thumbv4t-*) ;; # TODO
+                    bpf*) ;; # TODO
                     *)
                         RUSTFLAGS="${target_rustflags} --cfg portable_atomic_unsafe_assume_single_core" \
                             x cargo "${args[@]}" --target-dir target/assume-single-core "$@"

--- a/tools/no-std.sh
+++ b/tools/no-std.sh
@@ -6,6 +6,9 @@ cd "$(dirname "$0")"/..
 trap -- 'exit 0' SIGINT
 
 default_targets=(
+    # TODO: find a way to exit from mGBA with exit code 0 (and disable video?).
+    # # armv4t
+    # thumbv4t-none-eabi
     # armv6-m
     thumbv6m-none-eabi
     # armv7-m
@@ -66,6 +69,15 @@ run() {
     args+=(--target "${target}")
 
     case "${target}" in
+        thumbv4t* | armv4t*)
+            (
+                cd tests/gba
+                RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-Tlinker.ld --cfg portable_atomic_unsafe_assume_single_core" \
+                    x cargo "${args[@]}" "$@"
+                RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-Tlinker.ld --cfg portable_atomic_unsafe_assume_single_core" \
+                    x cargo "${args[@]}" --release "$@"
+            )
+            ;;
         thumbv6m*)
             (
                 cd tests/cortex-m


### PR DESCRIPTION
Closes #26 

This currently disables only IRQs. This is explained in the document on safety requirements:

> - On pre-v6 ARM, this currently disables only IRQs.
>   Enabling this cfg in an environment where FIQs must also be disabled is also considered **unsound**.

I have a few questions:

- ~~Should we also disable FIQs? [The emulation of atomic operation on Linux seemed to disable only IRQs](https://github.com/torvalds/linux/blob/eb555cb5b794f4e12a9897f3d46d5a72104cd4a7/arch/arm/include/asm/atomic.h#L156-L170), but they may have disabled FIQs globally.~~ EDIT: see https://github.com/taiki-e/portable-atomic/pull/28#issuecomment-1214146912
- Is there a way to test this target on CI?