### PR TITLE
Add cfg to use `__atomic_*` builtins

### DIFF
--- a/src/imp/libcalls.rs
+++ b/src/imp/libcalls.rs
@@ -1,0 +1,987 @@
+// Refs:
+// - https://llvm.org/docs/Atomics.html
+// - https://gcc.gnu.org/wiki/Atomic/GCCMM/LIbrary
+
+use core::{cell::UnsafeCell, mem, ptr, sync::atomic::Ordering};
+
+#[allow(non_upper_case_globals, non_camel_case_types)]
+mod ffi {
+    pub(super) use core::ffi::c_void;
+
+    // core::ffi::c_* requires Rust 1.54: https://github.com/rust-lang/rust/issues/94501
+    // https://github.com/rust-lang/rust/blob/6d3f1beae1720055e5a30f4dbe7a9e7fb810c65e/library/core/src/ffi/mod.rs#L159-L173
+    #[cfg(any(target_arch = "avr", target_arch = "msp430"))]
+    pub(super) type c_int = i16;
+    #[cfg(not(any(target_arch = "avr", target_arch = "msp430")))]
+    pub(super) type c_int = i32;
+}
+use ffi::{c_int, c_void};
+
+// FFI-safe 128-bit value.
+#[allow(dead_code)]
+#[derive(Clone, Copy)]
+#[repr(C, align(16))]
+struct U128(u64, u64);
+
+// Refs: https://gcc.gnu.org/wiki/Atomic/GCCMM/LIbrary
+const MEMORY_ORDER_RELAXED: c_int = 0;
+// const MEMORY_ORDER_CONSUME: c_int = 1;
+const MEMORY_ORDER_ACQUIRE: c_int = 2;
+const MEMORY_ORDER_RELEASE: c_int = 3;
+const MEMORY_ORDER_ACQ_REL: c_int = 4;
+const MEMORY_ORDER_SEQ_CST: c_int = 5;
+
+#[inline]
+fn c_ordering(order: Ordering) -> c_int {
+    match order {
+        Ordering::Relaxed => MEMORY_ORDER_RELAXED,
+        Ordering::Acquire => MEMORY_ORDER_ACQUIRE,
+        Ordering::Release => MEMORY_ORDER_RELEASE,
+        Ordering::AcqRel => MEMORY_ORDER_ACQ_REL,
+        Ordering::SeqCst => MEMORY_ORDER_SEQ_CST,
+        _ => unreachable!("{:?}", order),
+    }
+}
+
+extern "C" {
+    fn __atomic_load_1(src: *mut u8, ordering: c_int) -> u8;
+    fn __atomic_load_2(src: *mut u16, ordering: c_int) -> u16;
+    fn __atomic_load_4(src: *mut u32, ordering: c_int) -> u32;
+    fn __atomic_load_8(src: *mut u64, ordering: c_int) -> u64;
+    fn __atomic_load_16(src: *mut U128, ordering: c_int) -> U128;
+
+    fn __atomic_store_1(dst: *mut u8, val: u8, ordering: c_int);
+    fn __atomic_store_2(dst: *mut u16, val: u16, ordering: c_int);
+    fn __atomic_store_4(dst: *mut u32, val: u32, ordering: c_int);
+    fn __atomic_store_8(dst: *mut u64, val: u64, ordering: c_int);
+    fn __atomic_store_16(dst: *mut U128, val: U128, ordering: c_int);
+
+    fn __atomic_exchange_1(dst: *mut u8, val: u8, ordering: c_int) -> u8;
+    fn __atomic_exchange_2(dst: *mut u16, val: u16, ordering: c_int) -> u16;
+    fn __atomic_exchange_4(dst: *mut u32, val: u32, ordering: c_int) -> u32;
+    fn __atomic_exchange_8(dst: *mut u64, val: u64, ordering: c_int) -> u64;
+    fn __atomic_exchange_16(dst: *mut U128, val: U128, ordering: c_int) -> U128;
+
+    fn __atomic_compare_exchange_1(
+        dst: *mut u8,
+        expected: *mut u8,
+        desired: u8,
+        success_order: c_int,
+        failure_order: c_int,
+    ) -> bool;
+    fn __atomic_compare_exchange_2(
+        dst: *mut u16,
+        expected: *mut u16,
+        desired: u16,
+        success_order: c_int,
+        failure_order: c_int,
+    ) -> bool;
+    fn __atomic_compare_exchange_4(
+        dst: *mut u32,
+        expected: *mut u32,
+        desired: u32,
+        success_order: c_int,
+        failure_order: c_int,
+    ) -> bool;
+    fn __atomic_compare_exchange_8(
+        dst: *mut u64,
+        expected: *mut u64,
+        desired: u64,
+        success_order: c_int,
+        failure_order: c_int,
+    ) -> bool;
+    fn __atomic_compare_exchange_16(
+        dst: *mut U128,
+        expected: *mut U128,
+        desired: U128,
+        success_order: c_int,
+        failure_order: c_int,
+    ) -> bool;
+
+    fn __atomic_fetch_add_1(dst: *mut u8, val: u8, ordering: c_int) -> u8;
+    fn __atomic_fetch_add_2(dst: *mut u16, val: u16, ordering: c_int) -> u16;
+    fn __atomic_fetch_add_4(dst: *mut u32, val: u32, ordering: c_int) -> u32;
+    fn __atomic_fetch_add_8(dst: *mut u64, val: u64, ordering: c_int) -> u64;
+    fn __atomic_fetch_add_16(dst: *mut U128, val: U128, ordering: c_int) -> U128;
+
+    fn __atomic_fetch_sub_1(dst: *mut u8, val: u8, ordering: c_int) -> u8;
+    fn __atomic_fetch_sub_2(dst: *mut u16, val: u16, ordering: c_int) -> u16;
+    fn __atomic_fetch_sub_4(dst: *mut u32, val: u32, ordering: c_int) -> u32;
+    fn __atomic_fetch_sub_8(dst: *mut u64, val: u64, ordering: c_int) -> u64;
+    fn __atomic_fetch_sub_16(dst: *mut U128, val: U128, ordering: c_int) -> U128;
+
+    fn __atomic_fetch_and_1(dst: *mut u8, val: u8, ordering: c_int) -> u8;
+    fn __atomic_fetch_and_2(dst: *mut u16, val: u16, ordering: c_int) -> u16;
+    fn __atomic_fetch_and_4(dst: *mut u32, val: u32, ordering: c_int) -> u32;
+    fn __atomic_fetch_and_8(dst: *mut u64, val: u64, ordering: c_int) -> u64;
+    fn __atomic_fetch_and_16(dst: *mut U128, val: U128, ordering: c_int) -> U128;
+
+    fn __atomic_fetch_or_1(dst: *mut u8, val: u8, ordering: c_int) -> u8;
+    fn __atomic_fetch_or_2(dst: *mut u16, val: u16, ordering: c_int) -> u16;
+    fn __atomic_fetch_or_4(dst: *mut u32, val: u32, ordering: c_int) -> u32;
+    fn __atomic_fetch_or_8(dst: *mut u64, val: u64, ordering: c_int) -> u64;
+    fn __atomic_fetch_or_16(dst: *mut U128, val: U128, ordering: c_int) -> U128;
+
+    fn __atomic_fetch_xor_1(dst: *mut u8, val: u8, ordering: c_int) -> u8;
+    fn __atomic_fetch_xor_2(dst: *mut u16, val: u16, ordering: c_int) -> u16;
+    fn __atomic_fetch_xor_4(dst: *mut u32, val: u32, ordering: c_int) -> u32;
+    fn __atomic_fetch_xor_8(dst: *mut u64, val: u64, ordering: c_int) -> u64;
+    fn __atomic_fetch_xor_16(dst: *mut U128, val: U128, ordering: c_int) -> U128;
+
+    fn __atomic_is_lock_free(object_size: usize, ptr: *const c_void) -> bool;
+}
+
+#[repr(C, align(1))]
+pub(crate) struct AtomicBool {
+    v: UnsafeCell<u8>,
+}
+
+// Send is implicitly implemented.
+// SAFETY: any data races are prevented by atomic builtins.
+unsafe impl Sync for AtomicBool {}
+
+impl AtomicBool {
+    #[inline]
+    pub(crate) const fn new(v: bool) -> Self {
+        Self { v: UnsafeCell::new(v as u8) }
+    }
+
+    #[inline]
+    pub(crate) fn is_lock_free() -> bool {
+        // SAFETY: calling __atomic_is_lock_free is safe.
+        // Pass null ptr to retrieve the lock-free property  for a properly aligned object.
+        unsafe { __atomic_is_lock_free(mem::size_of::<Self>(), ptr::null()) }
+    }
+    #[inline]
+    pub(crate) const fn is_always_lock_free() -> bool {
+        false
+    }
+
+    #[inline]
+    pub(crate) fn get_mut(&mut self) -> &mut bool {
+        // SAFETY: the mutable reference guarantees unique ownership.
+        unsafe { &mut *(self.v.get() as *mut bool) }
+    }
+
+    #[inline]
+    pub(crate) fn into_inner(self) -> bool {
+        self.v.into_inner() != 0
+    }
+
+    #[inline]
+    pub(crate) fn load(&self, order: Ordering) -> bool {
+        crate::utils::assert_load_ordering(order);
+        // SAFETY: any data races are prevented by atomic builtins and the raw
+        // pointer passed in is valid because we got it from a reference.
+        unsafe { __atomic_load_1(self.v.get(), c_ordering(order)) != 0 }
+    }
+
+    #[inline]
+    pub(crate) fn store(&self, val: bool, order: Ordering) {
+        crate::utils::assert_store_ordering(order);
+        // SAFETY: any data races are prevented by atomic builtins and the raw
+        // pointer passed in is valid because we got it from a reference.
+        unsafe { __atomic_store_1(self.v.get(), val as u8, c_ordering(order)) }
+    }
+
+    #[inline]
+    pub(crate) fn swap(&self, val: bool, order: Ordering) -> bool {
+        // SAFETY: any data races are prevented by atomic builtins and the raw
+        // pointer passed in is valid because we got it from a reference.
+        unsafe { __atomic_exchange_1(self.v.get(), val as u8, c_ordering(order)) != 0 }
+    }
+
+    #[inline]
+    pub(crate) fn compare_exchange(
+        &self,
+        current: bool,
+        new: bool,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<bool, bool> {
+        crate::utils::assert_compare_exchange_ordering(success, failure);
+        // SAFETY: any data races are prevented by atomic builtins and the raw
+        // pointer passed in is valid because we got it from a reference.
+        unsafe {
+            let success = crate::utils::upgrade_success_ordering(success, failure); // stronger failure ordering requires c++17
+            let mut expected = current as u8;
+            let res = __atomic_compare_exchange_1(
+                self.v.get(),
+                &mut expected,
+                new as u8,
+                c_ordering(success),
+                c_ordering(failure),
+            );
+            if res {
+                Ok(expected != 0)
+            } else {
+                Err(expected != 0)
+            }
+        }
+    }
+
+    #[inline]
+    pub(crate) fn compare_exchange_weak(
+        &self,
+        current: bool,
+        new: bool,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<bool, bool> {
+        self.compare_exchange(current, new, success, failure)
+    }
+
+    #[inline]
+    pub(crate) fn fetch_and(&self, val: bool, order: Ordering) -> bool {
+        // SAFETY: any data races are prevented by atomic builtins and the raw
+        // pointer passed in is valid because we got it from a reference.
+        unsafe { __atomic_fetch_and_1(self.v.get(), val as u8, c_ordering(order)) != 0 }
+    }
+
+    #[inline]
+    pub(crate) fn fetch_nand(&self, val: bool, order: Ordering) -> bool {
+        if val {
+            // !(x & true) == !x
+            // We must invert the bool.
+            self.fetch_xor(true, order)
+        } else {
+            // !(x & false) == true
+            // We must set the bool to true.
+            self.swap(true, order)
+        }
+    }
+
+    #[inline]
+    pub(crate) fn fetch_or(&self, val: bool, order: Ordering) -> bool {
+        // SAFETY: any data races are prevented by atomic builtins and the raw
+        // pointer passed in is valid because we got it from a reference.
+        unsafe { __atomic_fetch_or_1(self.v.get(), val as u8, c_ordering(order)) != 0 }
+    }
+
+    #[inline]
+    pub(crate) fn fetch_xor(&self, val: bool, order: Ordering) -> bool {
+        // SAFETY: any data races are prevented by atomic builtins and the raw
+        // pointer passed in is valid because we got it from a reference.
+        unsafe { __atomic_fetch_xor_1(self.v.get(), val as u8, c_ordering(order)) != 0 }
+    }
+}
+
+#[cfg_attr(target_pointer_width = "16", repr(C, align(2)))]
+#[cfg_attr(target_pointer_width = "32", repr(C, align(4)))]
+#[cfg_attr(target_pointer_width = "64", repr(C, align(8)))]
+pub(crate) struct AtomicPtr<T> {
+    p: UnsafeCell<*mut T>,
+}
+
+// SAFETY: any data races are prevented by atomic builtins.
+unsafe impl<T> Send for AtomicPtr<T> {}
+// SAFETY: any data races are prevented by atomic builtins.
+unsafe impl<T> Sync for AtomicPtr<T> {}
+
+impl<T> AtomicPtr<T> {
+    #[inline]
+    pub(crate) const fn new(p: *mut T) -> Self {
+        Self { p: UnsafeCell::new(p) }
+    }
+
+    #[inline]
+    pub(crate) fn is_lock_free() -> bool {
+        // SAFETY: calling __atomic_is_lock_free is safe.
+        // Pass null ptr to retrieve the lock-free property  for a properly aligned object.
+        unsafe { __atomic_is_lock_free(mem::size_of::<Self>(), ptr::null()) }
+    }
+    #[inline]
+    pub(crate) const fn is_always_lock_free() -> bool {
+        false
+    }
+
+    #[inline]
+    pub(crate) fn get_mut(&mut self) -> &mut *mut T {
+        self.p.get_mut()
+    }
+
+    #[inline]
+    pub(crate) fn into_inner(self) -> *mut T {
+        self.p.into_inner()
+    }
+
+    #[inline]
+    pub(crate) fn load(&self, order: Ordering) -> *mut T {
+        crate::utils::assert_load_ordering(order);
+        #[cfg(target_pointer_width = "16")]
+        // SAFETY: any data races are prevented by atomic builtins and the raw
+        // pointer passed in is valid because we got it from a reference.
+        unsafe {
+            __atomic_load_2(self.p.get() as *mut u16, c_ordering(order)) as *mut T
+        }
+        #[cfg(target_pointer_width = "32")]
+        // SAFETY: any data races are prevented by atomic builtins and the raw
+        // pointer passed in is valid because we got it from a reference.
+        unsafe {
+            __atomic_load_4(self.p.get() as *mut u32, c_ordering(order)) as *mut T
+        }
+        #[cfg(target_pointer_width = "64")]
+        // SAFETY: any data races are prevented by atomic builtins and the raw
+        // pointer passed in is valid because we got it from a reference.
+        unsafe {
+            __atomic_load_8(self.p.get() as *mut u64, c_ordering(order)) as *mut T
+        }
+    }
+
+    #[inline]
+    pub(crate) fn store(&self, ptr: *mut T, order: Ordering) {
+        crate::utils::assert_store_ordering(order);
+        #[cfg(target_pointer_width = "16")]
+        // SAFETY: any data races are prevented by atomic builtins and the raw
+        // pointer passed in is valid because we got it from a reference.
+        unsafe {
+            __atomic_store_2(self.p.get() as *mut u16, ptr as u16, c_ordering(order));
+        }
+        #[cfg(target_pointer_width = "32")]
+        // SAFETY: any data races are prevented by atomic builtins and the raw
+        // pointer passed in is valid because we got it from a reference.
+        unsafe {
+            __atomic_store_4(self.p.get() as *mut u32, ptr as u32, c_ordering(order));
+        }
+        #[cfg(target_pointer_width = "64")]
+        // SAFETY: any data races are prevented by atomic builtins and the raw
+        // pointer passed in is valid because we got it from a reference.
+        unsafe {
+            __atomic_store_8(self.p.get() as *mut u64, ptr as u64, c_ordering(order));
+        }
+    }
+
+    #[inline]
+    pub(crate) fn swap(&self, ptr: *mut T, order: Ordering) -> *mut T {
+        #[cfg(target_pointer_width = "16")]
+        // SAFETY: any data races are prevented by atomic builtins and the raw
+        // pointer passed in is valid because we got it from a reference.
+        unsafe {
+            __atomic_exchange_2(self.p.get() as *mut u16, ptr as u16, c_ordering(order)) as *mut T
+        }
+        #[cfg(target_pointer_width = "32")]
+        // SAFETY: any data races are prevented by atomic builtins and the raw
+        // pointer passed in is valid because we got it from a reference.
+        unsafe {
+            __atomic_exchange_4(self.p.get() as *mut u32, ptr as u32, c_ordering(order)) as *mut T
+        }
+        #[cfg(target_pointer_width = "64")]
+        // SAFETY: any data races are prevented by atomic builtins and the raw
+        // pointer passed in is valid because we got it from a reference.
+        unsafe {
+            __atomic_exchange_8(self.p.get() as *mut u64, ptr as u64, c_ordering(order)) as *mut T
+        }
+    }
+
+    #[inline]
+    pub(crate) fn compare_exchange(
+        &self,
+        current: *mut T,
+        new: *mut T,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<*mut T, *mut T> {
+        crate::utils::assert_compare_exchange_ordering(success, failure);
+        // SAFETY: any data races are prevented by atomic builtins and the raw
+        // pointer passed in is valid because we got it from a reference.
+        unsafe {
+            let success = crate::utils::upgrade_success_ordering(success, failure); // stronger failure ordering requires c++17
+            let mut expected = current as usize;
+            #[cfg(target_pointer_width = "16")]
+            let res = __atomic_compare_exchange_2(
+                self.p.get() as *mut u16,
+                &mut expected as *mut _ as *mut u16,
+                new as u16,
+                c_ordering(success),
+                c_ordering(failure),
+            );
+            #[cfg(target_pointer_width = "32")]
+            let res = __atomic_compare_exchange_4(
+                self.p.get() as *mut u32,
+                &mut expected as *mut _ as *mut u32,
+                new as u32,
+                c_ordering(success),
+                c_ordering(failure),
+            );
+            #[cfg(target_pointer_width = "64")]
+            let res = __atomic_compare_exchange_8(
+                self.p.get() as *mut u64,
+                &mut expected as *mut _ as *mut u64,
+                new as u64,
+                c_ordering(success),
+                c_ordering(failure),
+            );
+            if res {
+                Ok(expected as *mut T)
+            } else {
+                Err(expected as *mut T)
+            }
+        }
+    }
+
+    #[inline]
+    pub(crate) fn compare_exchange_weak(
+        &self,
+        current: *mut T,
+        new: *mut T,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<*mut T, *mut T> {
+        self.compare_exchange(current, new, success, failure)
+    }
+}
+
+macro_rules! atomic_int {
+    (
+        $atomic_type:ident,
+        $int_type:ident,
+        $align:expr,
+        $atomic_load:ident,
+        $atomic_store:ident,
+        $atomic_exchange:ident,
+        $atomic_compare_exchange:ident,
+        $atomic_fetch_add:ident,
+        $atomic_fetch_sub:ident,
+        $atomic_fetch_and:ident,
+        $atomic_fetch_or:ident,
+        $atomic_fetch_xor:ident,
+    ) => {
+        #[repr(C, align($align))]
+        pub(crate) struct $atomic_type {
+            v: UnsafeCell<$int_type>,
+        }
+
+        // Send is implicitly implemented.
+        // SAFETY: any data races are prevented by atomic builtins.
+        unsafe impl Sync for $atomic_type {}
+
+        #[allow(clippy::useless_transmute)]
+        impl $atomic_type {
+            #[inline]
+            pub(crate) const fn new(v: $int_type) -> Self {
+                Self { v: UnsafeCell::new(v) }
+            }
+
+            #[inline]
+            pub(crate) fn is_lock_free() -> bool {
+                // SAFETY: calling __atomic_is_lock_free is safe.
+                // Pass null ptr to retrieve the lock-free property  for a properly aligned object.
+                unsafe { __atomic_is_lock_free(mem::size_of::<Self>(), ptr::null()) }
+            }
+            #[inline]
+            pub(crate) const fn is_always_lock_free() -> bool {
+                false
+            }
+
+            #[inline]
+            pub(crate) fn get_mut(&mut self) -> &mut $int_type {
+                self.v.get_mut()
+            }
+
+            #[inline]
+            pub(crate) fn into_inner(self) -> $int_type {
+                self.v.into_inner()
+            }
+
+            #[inline]
+            pub(crate) fn load(&self, order: Ordering) -> $int_type {
+                crate::utils::assert_load_ordering(order);
+                // SAFETY: any data races are prevented by atomic builtins and the raw
+                // pointer passed in is valid because we got it from a reference.
+                unsafe { mem::transmute($atomic_load(self.v.get() as *mut _, c_ordering(order))) }
+            }
+
+            #[inline]
+            pub(crate) fn store(&self, val: $int_type, order: Ordering) {
+                crate::utils::assert_store_ordering(order);
+                // SAFETY: any data races are prevented by atomic builtins and the raw
+                // pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    $atomic_store(self.v.get() as *mut _, mem::transmute(val), c_ordering(order))
+                }
+            }
+
+            #[inline]
+            pub(crate) fn swap(&self, val: $int_type, order: Ordering) -> $int_type {
+                // SAFETY: any data races are prevented by atomic builtins and the raw
+                // pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    mem::transmute($atomic_exchange(
+                        self.v.get() as *mut _,
+                        mem::transmute(val),
+                        c_ordering(order),
+                    ))
+                }
+            }
+
+            #[inline]
+            pub(crate) fn compare_exchange(
+                &self,
+                current: $int_type,
+                new: $int_type,
+                success: Ordering,
+                failure: Ordering,
+            ) -> Result<$int_type, $int_type> {
+                crate::utils::assert_compare_exchange_ordering(success, failure);
+                let mut expected = current;
+                // SAFETY: any data races are prevented by atomic builtins and the raw
+                // pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    let success = crate::utils::upgrade_success_ordering(success, failure); // stronger failure ordering requires c++17
+                    let res = $atomic_compare_exchange(
+                        self.v.get() as *mut _,
+                        &mut expected as *mut _ as *mut _,
+                        mem::transmute(new),
+                        c_ordering(success),
+                        c_ordering(failure),
+                    );
+                    if res {
+                        Ok(expected as $int_type)
+                    } else {
+                        Err(expected as $int_type)
+                    }
+                }
+            }
+
+            #[inline]
+            pub(crate) fn compare_exchange_weak(
+                &self,
+                current: $int_type,
+                new: $int_type,
+                success: Ordering,
+                failure: Ordering,
+            ) -> Result<$int_type, $int_type> {
+                self.compare_exchange(current, new, success, failure)
+            }
+
+            #[inline]
+            pub(crate) fn fetch_add(&self, val: $int_type, order: Ordering) -> $int_type {
+                // SAFETY: any data races are prevented by atomic builtins and the raw
+                // pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    mem::transmute($atomic_fetch_add(
+                        self.v.get() as *mut _,
+                        mem::transmute(val),
+                        c_ordering(order),
+                    ))
+                }
+            }
+
+            #[inline]
+            pub(crate) fn fetch_sub(&self, val: $int_type, order: Ordering) -> $int_type {
+                // SAFETY: any data races are prevented by atomic builtins and the raw
+                // pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    mem::transmute($atomic_fetch_sub(
+                        self.v.get() as *mut _,
+                        mem::transmute(val),
+                        c_ordering(order),
+                    ))
+                }
+            }
+
+            #[inline]
+            pub(crate) fn fetch_and(&self, val: $int_type, order: Ordering) -> $int_type {
+                // SAFETY: any data races are prevented by atomic builtins and the raw
+                // pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    mem::transmute($atomic_fetch_and(
+                        self.v.get() as *mut _,
+                        mem::transmute(val),
+                        c_ordering(order),
+                    ))
+                }
+            }
+
+            #[inline]
+            pub(crate) fn fetch_nand(&self, val: $int_type, order: Ordering) -> $int_type {
+                self.fetch_update(order, crate::utils::strongest_failure_ordering(order), |x| {
+                    !(x & val)
+                })
+            }
+
+            #[inline]
+            pub(crate) fn fetch_or(&self, val: $int_type, order: Ordering) -> $int_type {
+                // SAFETY: any data races are prevented by atomic builtins and the raw
+                // pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    mem::transmute($atomic_fetch_or(
+                        self.v.get() as *mut _,
+                        mem::transmute(val),
+                        c_ordering(order),
+                    ))
+                }
+            }
+
+            #[inline]
+            pub(crate) fn fetch_xor(&self, val: $int_type, order: Ordering) -> $int_type {
+                // SAFETY: any data races are prevented by atomic builtins and the raw
+                // pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    mem::transmute($atomic_fetch_xor(
+                        self.v.get() as *mut _,
+                        mem::transmute(val),
+                        c_ordering(order),
+                    ))
+                }
+            }
+
+            #[inline]
+            pub(crate) fn fetch_max(&self, val: $int_type, order: Ordering) -> $int_type {
+                self.fetch_update(order, crate::utils::strongest_failure_ordering(order), |x| {
+                    core::cmp::max(x, val)
+                })
+            }
+
+            #[inline]
+            pub(crate) fn fetch_min(&self, val: $int_type, order: Ordering) -> $int_type {
+                self.fetch_update(order, crate::utils::strongest_failure_ordering(order), |x| {
+                    core::cmp::min(x, val)
+                })
+            }
+
+            #[inline]
+            fn fetch_update<F>(
+                &self,
+                set_order: Ordering,
+                fetch_order: Ordering,
+                mut f: F,
+            ) -> $int_type
+            where
+                F: FnMut($int_type) -> $int_type,
+            {
+                let mut prev = self.load(fetch_order);
+                loop {
+                    let next = f(prev);
+                    match self.compare_exchange_weak(prev, next, set_order, fetch_order) {
+                        Ok(x) => return x,
+                        Err(next_prev) => prev = next_prev,
+                    }
+                }
+            }
+        }
+    };
+}
+
+#[cfg(target_pointer_width = "16")]
+atomic_int!(
+    AtomicIsize,
+    isize,
+    2,
+    __atomic_load_2,
+    __atomic_store_2,
+    __atomic_exchange_2,
+    __atomic_compare_exchange_2,
+    __atomic_fetch_add_2,
+    __atomic_fetch_sub_2,
+    __atomic_fetch_and_2,
+    __atomic_fetch_or_2,
+    __atomic_fetch_xor_2,
+);
+#[cfg(target_pointer_width = "16")]
+atomic_int!(
+    AtomicUsize,
+    usize,
+    2,
+    __atomic_load_2,
+    __atomic_store_2,
+    __atomic_exchange_2,
+    __atomic_compare_exchange_2,
+    __atomic_fetch_add_2,
+    __atomic_fetch_sub_2,
+    __atomic_fetch_and_2,
+    __atomic_fetch_or_2,
+    __atomic_fetch_xor_2,
+);
+#[cfg(target_pointer_width = "32")]
+atomic_int!(
+    AtomicIsize,
+    isize,
+    4,
+    __atomic_load_4,
+    __atomic_store_4,
+    __atomic_exchange_4,
+    __atomic_compare_exchange_4,
+    __atomic_fetch_add_4,
+    __atomic_fetch_sub_4,
+    __atomic_fetch_and_4,
+    __atomic_fetch_or_4,
+    __atomic_fetch_xor_4,
+);
+#[cfg(target_pointer_width = "32")]
+atomic_int!(
+    AtomicUsize,
+    usize,
+    4,
+    __atomic_load_4,
+    __atomic_store_4,
+    __atomic_exchange_4,
+    __atomic_compare_exchange_4,
+    __atomic_fetch_add_4,
+    __atomic_fetch_sub_4,
+    __atomic_fetch_and_4,
+    __atomic_fetch_or_4,
+    __atomic_fetch_xor_4,
+);
+#[cfg(target_pointer_width = "64")]
+atomic_int!(
+    AtomicIsize,
+    isize,
+    8,
+    __atomic_load_8,
+    __atomic_store_8,
+    __atomic_exchange_8,
+    __atomic_compare_exchange_8,
+    __atomic_fetch_add_8,
+    __atomic_fetch_sub_8,
+    __atomic_fetch_and_8,
+    __atomic_fetch_or_8,
+    __atomic_fetch_xor_8,
+);
+#[cfg(target_pointer_width = "64")]
+atomic_int!(
+    AtomicUsize,
+    usize,
+    8,
+    __atomic_load_8,
+    __atomic_store_8,
+    __atomic_exchange_8,
+    __atomic_compare_exchange_8,
+    __atomic_fetch_add_8,
+    __atomic_fetch_sub_8,
+    __atomic_fetch_and_8,
+    __atomic_fetch_or_8,
+    __atomic_fetch_xor_8,
+);
+
+atomic_int!(
+    AtomicI8,
+    i8,
+    1,
+    __atomic_load_1,
+    __atomic_store_1,
+    __atomic_exchange_1,
+    __atomic_compare_exchange_1,
+    __atomic_fetch_add_1,
+    __atomic_fetch_sub_1,
+    __atomic_fetch_and_1,
+    __atomic_fetch_or_1,
+    __atomic_fetch_xor_1,
+);
+atomic_int!(
+    AtomicU8,
+    u8,
+    1,
+    __atomic_load_1,
+    __atomic_store_1,
+    __atomic_exchange_1,
+    __atomic_compare_exchange_1,
+    __atomic_fetch_add_1,
+    __atomic_fetch_sub_1,
+    __atomic_fetch_and_1,
+    __atomic_fetch_or_1,
+    __atomic_fetch_xor_1,
+);
+atomic_int!(
+    AtomicI16,
+    i16,
+    2,
+    __atomic_load_2,
+    __atomic_store_2,
+    __atomic_exchange_2,
+    __atomic_compare_exchange_2,
+    __atomic_fetch_add_2,
+    __atomic_fetch_sub_2,
+    __atomic_fetch_and_2,
+    __atomic_fetch_or_2,
+    __atomic_fetch_xor_2,
+);
+atomic_int!(
+    AtomicU16,
+    u16,
+    2,
+    __atomic_load_2,
+    __atomic_store_2,
+    __atomic_exchange_2,
+    __atomic_compare_exchange_2,
+    __atomic_fetch_add_2,
+    __atomic_fetch_sub_2,
+    __atomic_fetch_and_2,
+    __atomic_fetch_or_2,
+    __atomic_fetch_xor_2,
+);
+
+#[cfg(any(
+    portable_atomic_unsafe_atomic_builtins_4,
+    portable_atomic_unsafe_atomic_builtins_8,
+    portable_atomic_unsafe_atomic_builtins_16,
+    not(target_pointer_width = "16")
+))]
+atomic_int!(
+    AtomicI32,
+    i32,
+    4,
+    __atomic_load_4,
+    __atomic_store_4,
+    __atomic_exchange_4,
+    __atomic_compare_exchange_4,
+    __atomic_fetch_add_4,
+    __atomic_fetch_sub_4,
+    __atomic_fetch_and_4,
+    __atomic_fetch_or_4,
+    __atomic_fetch_xor_4,
+);
+#[cfg(any(
+    portable_atomic_unsafe_atomic_builtins_4,
+    portable_atomic_unsafe_atomic_builtins_8,
+    portable_atomic_unsafe_atomic_builtins_16,
+    not(target_pointer_width = "16")
+))]
+atomic_int!(
+    AtomicU32,
+    u32,
+    4,
+    __atomic_load_4,
+    __atomic_store_4,
+    __atomic_exchange_4,
+    __atomic_compare_exchange_4,
+    __atomic_fetch_add_4,
+    __atomic_fetch_sub_4,
+    __atomic_fetch_and_4,
+    __atomic_fetch_or_4,
+    __atomic_fetch_xor_4,
+);
+
+#[cfg(any(
+    portable_atomic_unsafe_atomic_builtins_8,
+    portable_atomic_unsafe_atomic_builtins_16,
+    not(any(target_pointer_width = "16", target_pointer_width = "32"))
+))]
+atomic_int!(
+    AtomicI64,
+    i64,
+    8,
+    __atomic_load_8,
+    __atomic_store_8,
+    __atomic_exchange_8,
+    __atomic_compare_exchange_8,
+    __atomic_fetch_add_8,
+    __atomic_fetch_sub_8,
+    __atomic_fetch_and_8,
+    __atomic_fetch_or_8,
+    __atomic_fetch_xor_8,
+);
+#[cfg(any(
+    portable_atomic_unsafe_atomic_builtins_8,
+    portable_atomic_unsafe_atomic_builtins_16,
+    not(any(target_pointer_width = "16", target_pointer_width = "32"))
+))]
+atomic_int!(
+    AtomicU64,
+    u64,
+    8,
+    __atomic_load_8,
+    __atomic_store_8,
+    __atomic_exchange_8,
+    __atomic_compare_exchange_8,
+    __atomic_fetch_add_8,
+    __atomic_fetch_sub_8,
+    __atomic_fetch_and_8,
+    __atomic_fetch_or_8,
+    __atomic_fetch_xor_8,
+);
+
+#[cfg(any(
+    portable_atomic_unsafe_atomic_builtins_16,
+    not(any(
+        target_pointer_width = "16",
+        target_pointer_width = "32",
+        target_pointer_width = "64"
+    ))
+))]
+atomic_int!(
+    AtomicI128,
+    i128,
+    16,
+    __atomic_load_16,
+    __atomic_store_16,
+    __atomic_exchange_16,
+    __atomic_compare_exchange_16,
+    __atomic_fetch_add_16,
+    __atomic_fetch_sub_16,
+    __atomic_fetch_and_16,
+    __atomic_fetch_or_16,
+    __atomic_fetch_xor_16,
+);
+#[cfg(any(
+    portable_atomic_unsafe_atomic_builtins_16,
+    not(any(
+        target_pointer_width = "16",
+        target_pointer_width = "32",
+        target_pointer_width = "64"
+    ))
+))]
+atomic_int!(
+    AtomicU128,
+    u128,
+    16,
+    __atomic_load_16,
+    __atomic_store_16,
+    __atomic_exchange_16,
+    __atomic_compare_exchange_16,
+    __atomic_fetch_add_16,
+    __atomic_fetch_sub_16,
+    __atomic_fetch_and_16,
+    __atomic_fetch_or_16,
+    __atomic_fetch_xor_16,
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_atomic_bool!();
+    test_atomic_ptr!();
+    test_atomic_int!(i8);
+    test_atomic_int!(u8);
+    test_atomic_int!(i16);
+    test_atomic_int!(u16);
+    test_atomic_int!(i32);
+    test_atomic_int!(u32);
+    #[cfg(any(
+        portable_atomic_unsafe_atomic_builtins_8,
+        portable_atomic_unsafe_atomic_builtins_16,
+        not(any(target_pointer_width = "16", target_pointer_width = "32"))
+    ))]
+    test_atomic_int!(i64);
+    #[cfg(any(
+        portable_atomic_unsafe_atomic_builtins_8,
+        portable_atomic_unsafe_atomic_builtins_16,
+        not(any(target_pointer_width = "16", target_pointer_width = "32"))
+    ))]
+    test_atomic_int!(u64);
+    #[cfg(any(
+        portable_atomic_unsafe_atomic_builtins_16,
+        not(any(
+            target_pointer_width = "16",
+            target_pointer_width = "32",
+            target_pointer_width = "64"
+        ))
+    ))]
+    test_atomic_int!(i128);
+    #[cfg(any(
+        portable_atomic_unsafe_atomic_builtins_16,
+        not(any(
+            target_pointer_width = "16",
+            target_pointer_width = "32",
+            target_pointer_width = "64"
+        ))
+    ))]
+    test_atomic_int!(u128);
+    test_atomic_int!(isize);
+    test_atomic_int!(usize);
+}
+
+/*
+RUSTFLAGS="--cfg portable_atomic_unsafe_atomic_builtins_16" ct -r --tests
+*/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ Portable atomic types including support for 128-bit atomics, atomic float, etc.
 - Provide `AtomicF32` and `AtomicF64`. (optional)
 <!-- - Provide generic `Atomic<T>` type. (optional) -->
 - Provide atomic load/store for targets where atomic is not available at all in the standard library. (RISC-V without A-extension, MSP430, AVR)
-- Provide atomic CAS for targets where atomic CAS is not available in the standard library. (thumbv6m, RISC-V without A-extension, MSP430, AVR) (optional, [single-core only](#optional-cfg))
+- Provide atomic CAS for targets where atomic CAS is not available in the standard library. (thumbv6m, RISC-V without A-extension, MSP430, AVR) ([optional](#optional-cfg))
 - Provide stable equivalents of the standard library atomic types' unstable APIs, such as [`AtomicPtr::fetch_*`](https://github.com/rust-lang/rust/issues/99108), [`AtomicBool::fetch_not`](https://github.com/rust-lang/rust/issues/98485).
 - Make features that require newer compilers, such as [fetch_max](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_max), [fetch_min](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_min), [fetch_update](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicPtr.html#method.fetch_update), and [stronger CAS failure ordering](https://github.com/rust-lang/rust/pull/98383) available on Rust 1.34+.
 
@@ -70,9 +70,37 @@ See [this list](https://github.com/taiki-e/portable-atomic/issues/10#issuecommen
 
   Enabling this cfg for targets that have atomic CAS will result in a compile error.
 
-  ARMv6-M (thumbv6m), RISC-V without A-extension, MSP430, and AVR are currently supported. See [#26] for support of no-std pre-v6 ARM and multi-core systems.
+  ARMv6-M (thumbv6m), RISC-V without A-extension, MSP430, and AVR are currently supported. See [#26] for support of no-std pre-v6 ARM.
+
+  For multi-core systems or unsupported targets, consider using `--cfg portable_atomic_unsafe_atomic_builtins` or `--cfg portable_atomic_unsafe_atomic_builtins_N`.
 
   Feel free to submit an issue if your target is not supported yet.
+
+- **`--cfg portable_atomic_unsafe_atomic_builtins`**<br>
+  Use [`__atomic_*` builtins](https://llvm.org/docs/Atomics.html#libcalls-atomic).
+
+  Combine this with custom atomic logic and you can support CAS on multi-core systems where atomic CAS is not available in the standard library.
+
+  Note: This cfg is `unsafe`.
+
+  This cfg enables pointer-width and smaller atomic types.
+
+  To enable atomic types grater than pointer-width, you need to enable `--cfg portable_atomic_unsafe_atomic_builtins_N` cfgs.
+
+- **`--cfg portable_atomic_unsafe_atomic_builtins_N`**<br>
+  Similar to `--cfg portable_atomic_unsafe_atomic_builtins`, but also enables the specified size and smaller atomic types if the pointer width is smaller than the specified size.
+
+  For example, when `--cfg portable_atomic_unsafe_atomic_builtins_4` is enabled:
+  - On 64-bit platform, `Atomic{I,U}{64,32,16,8}` will be enabled.
+  - On 32-bit and 16-bit platform, `Atomic{I,U}{32,16,8}` will be enabled.
+
+  `N` is in bytes and must be 4, 8, or 16. In other words, there are three valid patterns:
+
+  ```text
+  --cfg portable_atomic_unsafe_atomic_builtins_4
+  --cfg portable_atomic_unsafe_atomic_builtins_8
+  --cfg portable_atomic_unsafe_atomic_builtins_16
+  ```
 
 ## Related Projects
 
@@ -94,6 +122,8 @@ See [this list](https://github.com/taiki-e/portable-atomic/issues/10#issuecommen
     )
 ))]
 #![warn(
+    improper_ctypes_definitions,
+    improper_ctypes,
     missing_debug_implementations,
     missing_docs,
     rust_2018_idioms,
@@ -250,6 +280,18 @@ compile_error!(
      please submit an issue at <https://github.com/taiki-e/portable-atomic>"
 );
 
+#[cfg(miri)]
+#[cfg(any(
+    portable_atomic_unsafe_atomic_builtins,
+    portable_atomic_unsafe_atomic_builtins_4,
+    portable_atomic_unsafe_atomic_builtins_8,
+    portable_atomic_unsafe_atomic_builtins_16,
+))]
+compile_error!(
+    "cfg(portable_atomic_unsafe_atomic_builtins) and cfg(portable_atomic_unsafe_atomic_builtins_N) \
+     do not compatible with Miri"
+);
+
 #[cfg(any(test, feature = "std"))]
 extern crate std;
 
@@ -263,6 +305,21 @@ mod tests;
 #[doc(no_inline)]
 pub use core::sync::atomic::{compiler_fence, fence, Ordering};
 
+#[cfg(not(any(
+    portable_atomic_unsafe_atomic_builtins,
+    portable_atomic_unsafe_atomic_builtins_4,
+    portable_atomic_unsafe_atomic_builtins_8,
+    portable_atomic_unsafe_atomic_builtins_16,
+)))]
+mod imp;
+// *_atomic_builtins* cfg overwrites all existing implementations.
+#[cfg(any(
+    portable_atomic_unsafe_atomic_builtins,
+    portable_atomic_unsafe_atomic_builtins_4,
+    portable_atomic_unsafe_atomic_builtins_8,
+    portable_atomic_unsafe_atomic_builtins_16,
+))]
+#[path = "imp/libcalls.rs"]
 mod imp;
 
 pub mod hint {
@@ -530,11 +587,25 @@ impl AtomicBool {
     /// ```
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16,
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16,
+        ))
     )]
     #[inline]
     pub fn swap(&self, val: bool, order: Ordering) -> bool {
@@ -575,11 +646,25 @@ impl AtomicBool {
     /// ```
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16,
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16,
+        ))
     )]
     #[inline]
     #[cfg_attr(docsrs, doc(alias = "compare_and_swap"))]
@@ -626,11 +711,25 @@ impl AtomicBool {
     /// ```
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16,
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16,
+        ))
     )]
     #[inline]
     #[cfg_attr(docsrs, doc(alias = "compare_and_swap"))]
@@ -675,11 +774,25 @@ impl AtomicBool {
     /// ```
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16,
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[inline]
     pub fn fetch_and(&self, val: bool, order: Ordering) -> bool {
@@ -718,11 +831,25 @@ impl AtomicBool {
     /// ```
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[inline]
     pub fn fetch_nand(&self, val: bool, order: Ordering) -> bool {
@@ -760,11 +887,25 @@ impl AtomicBool {
     /// ```
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[inline]
     pub fn fetch_or(&self, val: bool, order: Ordering) -> bool {
@@ -802,11 +943,25 @@ impl AtomicBool {
     /// ```
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[inline]
     pub fn fetch_xor(&self, val: bool, order: Ordering) -> bool {
@@ -840,11 +995,25 @@ impl AtomicBool {
     /// ```
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[inline]
     pub fn fetch_not(&self, order: Ordering) -> bool {
@@ -887,11 +1056,25 @@ impl AtomicBool {
     /// ```
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[inline]
     pub fn fetch_update<F>(
@@ -1146,11 +1329,25 @@ impl<T> AtomicPtr<T> {
     /// ```
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[inline]
     pub fn swap(&self, ptr: *mut T, order: Ordering) -> *mut T {
@@ -1184,11 +1381,25 @@ impl<T> AtomicPtr<T> {
     /// ```
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[inline]
     #[cfg_attr(docsrs, doc(alias = "compare_and_swap"))]
@@ -1235,11 +1446,25 @@ impl<T> AtomicPtr<T> {
     /// ```
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[inline]
     #[cfg_attr(docsrs, doc(alias = "compare_and_swap"))]
@@ -1295,11 +1520,25 @@ impl<T> AtomicPtr<T> {
     /// ```
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[inline]
     pub fn fetch_update<F>(
@@ -1355,11 +1594,25 @@ impl<T> AtomicPtr<T> {
     #[inline]
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     pub fn fetch_ptr_add(&self, val: usize, order: Ordering) -> *mut T {
         self.fetch_byte_add(val.wrapping_mul(core::mem::size_of::<T>()), order)
@@ -1398,11 +1651,25 @@ impl<T> AtomicPtr<T> {
     #[inline]
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     pub fn fetch_ptr_sub(&self, val: usize, order: Ordering) -> *mut T {
         self.fetch_byte_sub(val.wrapping_mul(core::mem::size_of::<T>()), order)
@@ -1437,11 +1704,25 @@ impl<T> AtomicPtr<T> {
     #[inline]
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     pub fn fetch_byte_add(&self, val: usize, order: Ordering) -> *mut T {
         // Ideally, we would always use AtomicPtr::fetch_* since it is strict-provenance
@@ -1488,11 +1769,25 @@ impl<T> AtomicPtr<T> {
     #[inline]
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     pub fn fetch_byte_sub(&self, val: usize, order: Ordering) -> *mut T {
         // Ideally, we would always use AtomicPtr::fetch_* since it is strict-provenance
@@ -1554,11 +1849,25 @@ impl<T> AtomicPtr<T> {
     #[inline]
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     pub fn fetch_or(&self, val: usize, order: Ordering) -> *mut T {
         // Ideally, we would always use AtomicPtr::fetch_* since it is strict-provenance
@@ -1618,11 +1927,25 @@ impl<T> AtomicPtr<T> {
     #[inline]
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     pub fn fetch_and(&self, val: usize, order: Ordering) -> *mut T {
         // Ideally, we would always use AtomicPtr::fetch_* since it is strict-provenance
@@ -1681,11 +2004,25 @@ impl<T> AtomicPtr<T> {
     #[inline]
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     pub fn fetch_xor(&self, val: usize, order: Ordering) -> *mut T {
         // Ideally, we would always use AtomicPtr::fetch_* since it is strict-provenance
@@ -1708,11 +2045,25 @@ impl<T> AtomicPtr<T> {
     #[inline]
     #[cfg_attr(
         portable_atomic_no_cfg_target_has_atomic,
-        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     #[cfg_attr(
         not(portable_atomic_no_cfg_target_has_atomic),
-        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            portable_atomic_unsafe_atomic_builtins,
+            portable_atomic_unsafe_atomic_builtins_4,
+            portable_atomic_unsafe_atomic_builtins_8,
+            portable_atomic_unsafe_atomic_builtins_16
+        ))
     )]
     fn as_atomic_usize(&self) -> &AtomicUsize {
         let [] = [(); core::mem::size_of::<AtomicPtr<()>>() - core::mem::size_of::<AtomicUsize>()];
@@ -1761,9 +2112,9 @@ atomic instructions or locks will be used.
             // will show clearer docs.
             #[repr(C, align($align))]
             pub struct $atomic_type {
-                inner: imp::$atomic_type,
+                inner: crate::imp::$atomic_type,
                 // Prevent RefUnwindSafe from being propagated from the std atomic type.
-                _marker: PhantomData<NoRefUnwindSafe>,
+                _marker: core::marker::PhantomData<crate::utils::NoRefUnwindSafe>,
             }
         }
 
@@ -1783,11 +2134,11 @@ atomic instructions or locks will be used.
             }
         }
 
-        impl fmt::Debug for $atomic_type {
+        impl core::fmt::Debug for $atomic_type {
             #[allow(clippy::missing_inline_in_public_items)] // fmt is not hot path
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 // std atomic types use Relaxed in Debug::fmt: https://github.com/rust-lang/rust/blob/b2c9872c6c2c60c905e16bce0801934b86d15f95/library/core/src/sync/atomic.rs#L1520
-                fmt::Debug::fmt(&self.load(Ordering::Relaxed), f)
+                core::fmt::Debug::fmt(&self.load(Ordering::Relaxed), f)
             }
         }
 
@@ -1815,7 +2166,10 @@ let atomic_forty_two = ", stringify!($atomic_type), "::new(42);
                 #[inline]
                 #[must_use]
                 pub const fn new(v: $int_type) -> Self {
-                    Self { inner: imp::$atomic_type::new(v), _marker: PhantomData }
+                    Self {
+                        inner: crate::imp::$atomic_type::new(v),
+                        _marker: core::marker::PhantomData,
+                    }
                 }
             }
 
@@ -1836,7 +2190,7 @@ let is_lock_free = ", stringify!($atomic_type), "::is_lock_free();
                 #[inline]
                 #[must_use]
                 pub fn is_lock_free() -> bool {
-                    <imp::$atomic_type>::is_lock_free()
+                    <crate::imp::$atomic_type>::is_lock_free()
                 }
             }
 
@@ -1860,7 +2214,7 @@ const IS_ALWAYS_LOCK_FREE: bool = ", stringify!($atomic_type), "::is_always_lock
                 #[inline]
                 #[must_use]
                 pub const fn is_always_lock_free() -> bool {
-                    <imp::$atomic_type>::is_always_lock_free()
+                    <crate::imp::$atomic_type>::is_always_lock_free()
                 }
             }
 
@@ -1980,12 +2334,23 @@ assert_eq!(some_var.swap(10, Ordering::Relaxed), 5);
                     portable_atomic_no_cfg_target_has_atomic,
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
-                        portable_atomic_unsafe_assume_single_core
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
                     ))
                 )]
                 #[cfg_attr(
                     not(portable_atomic_no_cfg_target_has_atomic),
-                    cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                    cfg(any(
+                        target_has_atomic = "ptr",
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
+                    ))
                 )]
                 #[inline]
                 pub fn swap(&self, val: $int_type, order: Ordering) -> $int_type {
@@ -2032,12 +2397,23 @@ assert_eq!(some_var.load(Ordering::Relaxed), 10);
                     portable_atomic_no_cfg_target_has_atomic,
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
-                        portable_atomic_unsafe_assume_single_core
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
                     ))
                 )]
                 #[cfg_attr(
                     not(portable_atomic_no_cfg_target_has_atomic),
-                    cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                    cfg(any(
+                        target_has_atomic = "ptr",
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
+                    ))
                 )]
                 #[inline]
                 #[cfg_attr(docsrs, doc(alias = "compare_and_swap"))]
@@ -2089,12 +2465,23 @@ loop {
                     portable_atomic_no_cfg_target_has_atomic,
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
-                        portable_atomic_unsafe_assume_single_core
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
                     ))
                 )]
                 #[cfg_attr(
                     not(portable_atomic_no_cfg_target_has_atomic),
-                    cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                    cfg(any(
+                        target_has_atomic = "ptr",
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
+                    ))
                 )]
                 #[inline]
                 #[cfg_attr(docsrs, doc(alias = "compare_and_swap"))]
@@ -2132,12 +2519,23 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
                     portable_atomic_no_cfg_target_has_atomic,
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
-                        portable_atomic_unsafe_assume_single_core
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
                     ))
                 )]
                 #[cfg_attr(
                     not(portable_atomic_no_cfg_target_has_atomic),
-                    cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                    cfg(any(
+                        target_has_atomic = "ptr",
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
+                    ))
                 )]
                 #[inline]
                 pub fn fetch_add(&self, val: $int_type, order: Ordering) -> $int_type {
@@ -2168,12 +2566,23 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
                     portable_atomic_no_cfg_target_has_atomic,
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
-                        portable_atomic_unsafe_assume_single_core
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
                     ))
                 )]
                 #[cfg_attr(
                     not(portable_atomic_no_cfg_target_has_atomic),
-                    cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                    cfg(any(
+                        target_has_atomic = "ptr",
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
+                    ))
                 )]
                 #[inline]
                 pub fn fetch_sub(&self, val: $int_type, order: Ordering) -> $int_type {
@@ -2207,12 +2616,23 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b100001);
                     portable_atomic_no_cfg_target_has_atomic,
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
-                        portable_atomic_unsafe_assume_single_core
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
                     ))
                 )]
                 #[cfg_attr(
                     not(portable_atomic_no_cfg_target_has_atomic),
-                    cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                    cfg(any(
+                        target_has_atomic = "ptr",
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
+                    ))
                 )]
                 #[inline]
                 pub fn fetch_and(&self, val: $int_type, order: Ordering) -> $int_type {
@@ -2246,12 +2666,23 @@ assert_eq!(foo.load(Ordering::SeqCst), !(0x13 & 0x31));
                     portable_atomic_no_cfg_target_has_atomic,
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
-                        portable_atomic_unsafe_assume_single_core
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
                     ))
                 )]
                 #[cfg_attr(
                     not(portable_atomic_no_cfg_target_has_atomic),
-                    cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                    cfg(any(
+                        target_has_atomic = "ptr",
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
+                    ))
                 )]
                 #[inline]
                 pub fn fetch_nand(&self, val: $int_type, order: Ordering) -> $int_type {
@@ -2285,12 +2716,23 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b111111);
                     portable_atomic_no_cfg_target_has_atomic,
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
-                        portable_atomic_unsafe_assume_single_core
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
                     ))
                 )]
                 #[cfg_attr(
                     not(portable_atomic_no_cfg_target_has_atomic),
-                    cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                    cfg(any(
+                        target_has_atomic = "ptr",
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
+                    ))
                 )]
                 #[inline]
                 pub fn fetch_or(&self, val: $int_type, order: Ordering) -> $int_type {
@@ -2324,12 +2766,23 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b011110);
                     portable_atomic_no_cfg_target_has_atomic,
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
-                        portable_atomic_unsafe_assume_single_core
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
                     ))
                 )]
                 #[cfg_attr(
                     not(portable_atomic_no_cfg_target_has_atomic),
-                    cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                    cfg(any(
+                        target_has_atomic = "ptr",
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
+                    ))
                 )]
                 #[inline]
                 pub fn fetch_xor(&self, val: $int_type, order: Ordering) -> $int_type {
@@ -2370,12 +2823,23 @@ assert_eq!(x.load(Ordering::SeqCst), 9);
                     portable_atomic_no_cfg_target_has_atomic,
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
-                        portable_atomic_unsafe_assume_single_core
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
                     ))
                 )]
                 #[cfg_attr(
                     not(portable_atomic_no_cfg_target_has_atomic),
-                    cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                    cfg(any(
+                        target_has_atomic = "ptr",
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
+                    ))
                 )]
                 #[inline]
                 pub fn fetch_update<F>(
@@ -2435,12 +2899,23 @@ assert!(max_foo == 42);
                     portable_atomic_no_cfg_target_has_atomic,
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
-                        portable_atomic_unsafe_assume_single_core
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
                     ))
                 )]
                 #[cfg_attr(
                     not(portable_atomic_no_cfg_target_has_atomic),
-                    cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                    cfg(any(
+                        target_has_atomic = "ptr",
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
+                    ))
                 )]
                 #[inline]
                 pub fn fetch_max(&self, val: $int_type, order: Ordering) -> $int_type {
@@ -2487,12 +2962,23 @@ assert_eq!(min_foo, 12);
                     portable_atomic_no_cfg_target_has_atomic,
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
-                        portable_atomic_unsafe_assume_single_core
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
                     ))
                 )]
                 #[cfg_attr(
                     not(portable_atomic_no_cfg_target_has_atomic),
-                    cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                    cfg(any(
+                        target_has_atomic = "ptr",
+                        portable_atomic_unsafe_assume_single_core,
+                        portable_atomic_unsafe_atomic_builtins,
+                        portable_atomic_unsafe_atomic_builtins_4,
+                        portable_atomic_unsafe_atomic_builtins_8,
+                        portable_atomic_unsafe_atomic_builtins_16
+                    ))
                 )]
                 #[inline]
                 pub fn fetch_min(&self, val: $int_type, order: Ordering) -> $int_type {
@@ -2539,11 +3025,11 @@ This type has the same in-memory representation as the underlying floating point
             }
         }
 
-        impl fmt::Debug for $atomic_type {
+        impl core::fmt::Debug for $atomic_type {
             #[allow(clippy::missing_inline_in_public_items)] // fmt is not hot path
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 // std atomic types use Relaxed in Debug::fmt: https://github.com/rust-lang/rust/blob/b2c9872c6c2c60c905e16bce0801934b86d15f95/library/core/src/sync/atomic.rs#L1520
-                fmt::Debug::fmt(&self.load(Ordering::Relaxed), f)
+                core::fmt::Debug::fmt(&self.load(Ordering::Relaxed), f)
             }
         }
 
@@ -2651,12 +3137,23 @@ This type has the same in-memory representation as the underlying floating point
                 portable_atomic_no_cfg_target_has_atomic,
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
-                    portable_atomic_unsafe_assume_single_core
+                    portable_atomic_unsafe_assume_single_core,
+                    portable_atomic_unsafe_atomic_builtins,
+                    portable_atomic_unsafe_atomic_builtins_4,
+                    portable_atomic_unsafe_atomic_builtins_8,
+                    portable_atomic_unsafe_atomic_builtins_16
                 ))
             )]
             #[cfg_attr(
                 not(portable_atomic_no_cfg_target_has_atomic),
-                cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                cfg(any(
+                    target_has_atomic = "ptr",
+                    portable_atomic_unsafe_assume_single_core,
+                    portable_atomic_unsafe_atomic_builtins,
+                    portable_atomic_unsafe_atomic_builtins_4,
+                    portable_atomic_unsafe_atomic_builtins_8,
+                    portable_atomic_unsafe_atomic_builtins_16
+                ))
             )]
             #[inline]
             pub fn swap(&self, val: $float_type, order: Ordering) -> $float_type {
@@ -2681,12 +3178,23 @@ This type has the same in-memory representation as the underlying floating point
                 portable_atomic_no_cfg_target_has_atomic,
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
-                    portable_atomic_unsafe_assume_single_core
+                    portable_atomic_unsafe_assume_single_core,
+                    portable_atomic_unsafe_atomic_builtins,
+                    portable_atomic_unsafe_atomic_builtins_4,
+                    portable_atomic_unsafe_atomic_builtins_8,
+                    portable_atomic_unsafe_atomic_builtins_16
                 ))
             )]
             #[cfg_attr(
                 not(portable_atomic_no_cfg_target_has_atomic),
-                cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                cfg(any(
+                    target_has_atomic = "ptr",
+                    portable_atomic_unsafe_assume_single_core,
+                    portable_atomic_unsafe_atomic_builtins,
+                    portable_atomic_unsafe_atomic_builtins_4,
+                    portable_atomic_unsafe_atomic_builtins_8,
+                    portable_atomic_unsafe_atomic_builtins_16
+                ))
             )]
             #[inline]
             #[cfg_attr(docsrs, doc(alias = "compare_and_swap"))]
@@ -2727,12 +3235,23 @@ This type has the same in-memory representation as the underlying floating point
                 portable_atomic_no_cfg_target_has_atomic,
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
-                    portable_atomic_unsafe_assume_single_core
+                    portable_atomic_unsafe_assume_single_core,
+                    portable_atomic_unsafe_atomic_builtins,
+                    portable_atomic_unsafe_atomic_builtins_4,
+                    portable_atomic_unsafe_atomic_builtins_8,
+                    portable_atomic_unsafe_atomic_builtins_16
                 ))
             )]
             #[cfg_attr(
                 not(portable_atomic_no_cfg_target_has_atomic),
-                cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                cfg(any(
+                    target_has_atomic = "ptr",
+                    portable_atomic_unsafe_assume_single_core,
+                    portable_atomic_unsafe_atomic_builtins,
+                    portable_atomic_unsafe_atomic_builtins_4,
+                    portable_atomic_unsafe_atomic_builtins_8,
+                    portable_atomic_unsafe_atomic_builtins_16
+                ))
             )]
             #[inline]
             #[cfg_attr(docsrs, doc(alias = "compare_and_swap"))]
@@ -2766,12 +3285,23 @@ This type has the same in-memory representation as the underlying floating point
                 portable_atomic_no_cfg_target_has_atomic,
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
-                    portable_atomic_unsafe_assume_single_core
+                    portable_atomic_unsafe_assume_single_core,
+                    portable_atomic_unsafe_atomic_builtins,
+                    portable_atomic_unsafe_atomic_builtins_4,
+                    portable_atomic_unsafe_atomic_builtins_8,
+                    portable_atomic_unsafe_atomic_builtins_16
                 ))
             )]
             #[cfg_attr(
                 not(portable_atomic_no_cfg_target_has_atomic),
-                cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                cfg(any(
+                    target_has_atomic = "ptr",
+                    portable_atomic_unsafe_assume_single_core,
+                    portable_atomic_unsafe_atomic_builtins,
+                    portable_atomic_unsafe_atomic_builtins_4,
+                    portable_atomic_unsafe_atomic_builtins_8,
+                    portable_atomic_unsafe_atomic_builtins_16
+                ))
             )]
             #[inline]
             pub fn fetch_add(&self, val: $float_type, order: Ordering) -> $float_type {
@@ -2793,12 +3323,23 @@ This type has the same in-memory representation as the underlying floating point
                 portable_atomic_no_cfg_target_has_atomic,
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
-                    portable_atomic_unsafe_assume_single_core
+                    portable_atomic_unsafe_assume_single_core,
+                    portable_atomic_unsafe_atomic_builtins,
+                    portable_atomic_unsafe_atomic_builtins_4,
+                    portable_atomic_unsafe_atomic_builtins_8,
+                    portable_atomic_unsafe_atomic_builtins_16
                 ))
             )]
             #[cfg_attr(
                 not(portable_atomic_no_cfg_target_has_atomic),
-                cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                cfg(any(
+                    target_has_atomic = "ptr",
+                    portable_atomic_unsafe_assume_single_core,
+                    portable_atomic_unsafe_atomic_builtins,
+                    portable_atomic_unsafe_atomic_builtins_4,
+                    portable_atomic_unsafe_atomic_builtins_8,
+                    portable_atomic_unsafe_atomic_builtins_16
+                ))
             )]
             #[inline]
             pub fn fetch_sub(&self, val: $float_type, order: Ordering) -> $float_type {
@@ -2828,12 +3369,23 @@ This type has the same in-memory representation as the underlying floating point
                 portable_atomic_no_cfg_target_has_atomic,
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
-                    portable_atomic_unsafe_assume_single_core
+                    portable_atomic_unsafe_assume_single_core,
+                    portable_atomic_unsafe_atomic_builtins,
+                    portable_atomic_unsafe_atomic_builtins_4,
+                    portable_atomic_unsafe_atomic_builtins_8,
+                    portable_atomic_unsafe_atomic_builtins_16
                 ))
             )]
             #[cfg_attr(
                 not(portable_atomic_no_cfg_target_has_atomic),
-                cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                cfg(any(
+                    target_has_atomic = "ptr",
+                    portable_atomic_unsafe_assume_single_core,
+                    portable_atomic_unsafe_atomic_builtins,
+                    portable_atomic_unsafe_atomic_builtins_4,
+                    portable_atomic_unsafe_atomic_builtins_8,
+                    portable_atomic_unsafe_atomic_builtins_16
+                ))
             )]
             #[inline]
             pub fn fetch_update<F>(
@@ -2870,12 +3422,23 @@ This type has the same in-memory representation as the underlying floating point
                 portable_atomic_no_cfg_target_has_atomic,
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
-                    portable_atomic_unsafe_assume_single_core
+                    portable_atomic_unsafe_assume_single_core,
+                    portable_atomic_unsafe_atomic_builtins,
+                    portable_atomic_unsafe_atomic_builtins_4,
+                    portable_atomic_unsafe_atomic_builtins_8,
+                    portable_atomic_unsafe_atomic_builtins_16
                 ))
             )]
             #[cfg_attr(
                 not(portable_atomic_no_cfg_target_has_atomic),
-                cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                cfg(any(
+                    target_has_atomic = "ptr",
+                    portable_atomic_unsafe_assume_single_core,
+                    portable_atomic_unsafe_atomic_builtins,
+                    portable_atomic_unsafe_atomic_builtins_4,
+                    portable_atomic_unsafe_atomic_builtins_8,
+                    portable_atomic_unsafe_atomic_builtins_16
+                ))
             )]
             #[inline]
             pub fn fetch_max(&self, val: $float_type, order: Ordering) -> $float_type {
@@ -2900,12 +3463,23 @@ This type has the same in-memory representation as the underlying floating point
                 portable_atomic_no_cfg_target_has_atomic,
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
-                    portable_atomic_unsafe_assume_single_core
+                    portable_atomic_unsafe_assume_single_core,
+                    portable_atomic_unsafe_atomic_builtins,
+                    portable_atomic_unsafe_atomic_builtins_4,
+                    portable_atomic_unsafe_atomic_builtins_8,
+                    portable_atomic_unsafe_atomic_builtins_16
                 ))
             )]
             #[cfg_attr(
                 not(portable_atomic_no_cfg_target_has_atomic),
-                cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                cfg(any(
+                    target_has_atomic = "ptr",
+                    portable_atomic_unsafe_assume_single_core,
+                    portable_atomic_unsafe_atomic_builtins,
+                    portable_atomic_unsafe_atomic_builtins_4,
+                    portable_atomic_unsafe_atomic_builtins_8,
+                    portable_atomic_unsafe_atomic_builtins_16
+                ))
             )]
             #[inline]
             pub fn fetch_min(&self, val: $float_type, order: Ordering) -> $float_type {
@@ -2928,12 +3502,23 @@ This type has the same in-memory representation as the underlying floating point
                 portable_atomic_no_cfg_target_has_atomic,
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
-                    portable_atomic_unsafe_assume_single_core
+                    portable_atomic_unsafe_assume_single_core,
+                    portable_atomic_unsafe_atomic_builtins,
+                    portable_atomic_unsafe_atomic_builtins_4,
+                    portable_atomic_unsafe_atomic_builtins_8,
+                    portable_atomic_unsafe_atomic_builtins_16
                 ))
             )]
             #[cfg_attr(
                 not(portable_atomic_no_cfg_target_has_atomic),
-                cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+                cfg(any(
+                    target_has_atomic = "ptr",
+                    portable_atomic_unsafe_assume_single_core,
+                    portable_atomic_unsafe_atomic_builtins,
+                    portable_atomic_unsafe_atomic_builtins_4,
+                    portable_atomic_unsafe_atomic_builtins_8,
+                    portable_atomic_unsafe_atomic_builtins_16
+                ))
             )]
             #[inline]
             pub fn fetch_abs(&self, order: Ordering) -> $float_type {
@@ -2982,123 +3567,200 @@ atomic_int!(AtomicU8, u8, 1);
 atomic_int!(AtomicI16, i16, 2);
 atomic_int!(AtomicU16, u16, 2);
 
-// cfg(any(target_has_atomic_load_store = "32", target_arch = "riscv32", target_arch = "riscv64", all(feature = "fallback", portable_atomic_unsafe_assume_single_core)))
-#[cfg(any(
-    not(target_pointer_width = "16"),
-    all(feature = "fallback", portable_atomic_unsafe_assume_single_core)
-))]
-atomic_int!(AtomicI32, i32, 4);
-#[cfg(any(
-    not(target_pointer_width = "16"),
-    all(feature = "fallback", portable_atomic_unsafe_assume_single_core)
-))]
-atomic_int!(AtomicU32, u32, 4);
+pub use imp_::*;
+#[cfg(not(any(
+    portable_atomic_unsafe_atomic_builtins,
+    portable_atomic_unsafe_atomic_builtins_4,
+    portable_atomic_unsafe_atomic_builtins_8,
+    portable_atomic_unsafe_atomic_builtins_16,
+)))]
+mod imp_ {
+    use core::sync::atomic::Ordering;
+    #[cfg(doc)]
+    use core::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release, SeqCst};
 
-// cfg(any(target_has_atomic = "ptr", target_has_atomic_load_store = "64", all(feature = "fallback", portable_atomic_unsafe_assume_single_core)))
-#[cfg_attr(
-    portable_atomic_no_cfg_target_has_atomic,
-    cfg(any(
-        all(feature = "fallback", not(portable_atomic_no_atomic_cas)),
-        not(portable_atomic_no_atomic_64),
-        not(any(target_pointer_width = "16", target_pointer_width = "32")),
+    // cfg(any(target_has_atomic_load_store = "32", target_arch = "riscv32", target_arch = "riscv64", all(feature = "fallback", portable_atomic_unsafe_assume_single_core)))
+    #[cfg(any(
+        not(target_pointer_width = "16"),
         all(feature = "fallback", portable_atomic_unsafe_assume_single_core)
-    ))
-)]
-#[cfg_attr(
-    not(portable_atomic_no_cfg_target_has_atomic),
-    cfg(any(
-        all(feature = "fallback", target_has_atomic = "ptr"),
-        target_has_atomic = "64",
-        not(any(target_pointer_width = "16", target_pointer_width = "32")),
+    ))]
+    atomic_int!(AtomicI32, i32, 4);
+    #[cfg(any(
+        not(target_pointer_width = "16"),
         all(feature = "fallback", portable_atomic_unsafe_assume_single_core)
-    ))
-)]
-atomic_int!(AtomicI64, i64, 8);
-#[cfg_attr(
-    portable_atomic_no_cfg_target_has_atomic,
-    cfg(any(
-        all(feature = "fallback", not(portable_atomic_no_atomic_cas)),
-        not(portable_atomic_no_atomic_64),
-        not(any(target_pointer_width = "16", target_pointer_width = "32")),
-        all(feature = "fallback", portable_atomic_unsafe_assume_single_core)
-    ))
-)]
-#[cfg_attr(
-    not(portable_atomic_no_cfg_target_has_atomic),
-    cfg(any(
-        all(feature = "fallback", target_has_atomic = "ptr"),
-        target_has_atomic = "64",
-        not(any(target_pointer_width = "16", target_pointer_width = "32")),
-        all(feature = "fallback", portable_atomic_unsafe_assume_single_core)
-    ))
-)]
-atomic_int!(AtomicU64, u64, 8);
+    ))]
+    atomic_int!(AtomicU32, u32, 4);
 
-#[cfg_attr(
-    not(feature = "fallback"),
-    cfg(any(
-        all(any(not(portable_atomic_no_asm), portable_atomic_nightly), target_arch = "aarch64"),
-        all(
-            any(not(portable_atomic_no_asm), portable_atomic_nightly),
-            any(
-                target_feature = "cmpxchg16b",
-                portable_atomic_target_feature = "cmpxchg16b",
-                portable_atomic_cmpxchg16b_dynamic
+    // cfg(any(target_has_atomic = "ptr", target_has_atomic_load_store = "64", all(feature = "fallback", portable_atomic_unsafe_assume_single_core)))
+    #[cfg_attr(
+        portable_atomic_no_cfg_target_has_atomic,
+        cfg(any(
+            all(feature = "fallback", not(portable_atomic_no_atomic_cas)),
+            not(portable_atomic_no_atomic_64),
+            not(any(target_pointer_width = "16", target_pointer_width = "32")),
+            all(feature = "fallback", portable_atomic_unsafe_assume_single_core)
+        ))
+    )]
+    #[cfg_attr(
+        not(portable_atomic_no_cfg_target_has_atomic),
+        cfg(any(
+            all(feature = "fallback", target_has_atomic = "ptr"),
+            target_has_atomic = "64",
+            not(any(target_pointer_width = "16", target_pointer_width = "32")),
+            all(feature = "fallback", portable_atomic_unsafe_assume_single_core)
+        ))
+    )]
+    atomic_int!(AtomicI64, i64, 8);
+    #[cfg_attr(
+        portable_atomic_no_cfg_target_has_atomic,
+        cfg(any(
+            all(feature = "fallback", not(portable_atomic_no_atomic_cas)),
+            not(portable_atomic_no_atomic_64),
+            not(any(target_pointer_width = "16", target_pointer_width = "32")),
+            all(feature = "fallback", portable_atomic_unsafe_assume_single_core)
+        ))
+    )]
+    #[cfg_attr(
+        not(portable_atomic_no_cfg_target_has_atomic),
+        cfg(any(
+            all(feature = "fallback", target_has_atomic = "ptr"),
+            target_has_atomic = "64",
+            not(any(target_pointer_width = "16", target_pointer_width = "32")),
+            all(feature = "fallback", portable_atomic_unsafe_assume_single_core)
+        ))
+    )]
+    atomic_int!(AtomicU64, u64, 8);
+
+    #[cfg_attr(
+        not(feature = "fallback"),
+        cfg(any(
+            all(
+                any(not(portable_atomic_no_asm), portable_atomic_nightly),
+                target_arch = "aarch64"
             ),
-            target_arch = "x86_64",
-        ),
-        all(
-            all(not(portable_atomic_no_asm), portable_atomic_nightly),
-            any(
-                target_endian = "little",
-                target_feature = "quadword-atomics",
-                portable_atomic_target_feature = "quadword-atomics"
+            all(
+                any(not(portable_atomic_no_asm), portable_atomic_nightly),
+                any(
+                    target_feature = "cmpxchg16b",
+                    portable_atomic_target_feature = "cmpxchg16b",
+                    portable_atomic_cmpxchg16b_dynamic
+                ),
+                target_arch = "x86_64",
             ),
-            target_arch = "powerpc64"
-        ),
-        all(all(not(portable_atomic_no_asm), portable_atomic_nightly), target_arch = "s390x"),
-    ))
-)]
-#[cfg_attr(
-    all(feature = "fallback", portable_atomic_no_cfg_target_has_atomic),
-    cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
-)]
-#[cfg_attr(
-    all(feature = "fallback", not(portable_atomic_no_cfg_target_has_atomic)),
-    cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
-)]
-atomic_int!(AtomicI128, i128, 16);
-#[cfg_attr(
-    not(feature = "fallback"),
-    cfg(any(
-        all(any(not(portable_atomic_no_asm), portable_atomic_nightly), target_arch = "aarch64"),
-        all(
-            any(not(portable_atomic_no_asm), portable_atomic_nightly),
-            any(
-                target_feature = "cmpxchg16b",
-                portable_atomic_target_feature = "cmpxchg16b",
-                portable_atomic_cmpxchg16b_dynamic
+            all(
+                all(not(portable_atomic_no_asm), portable_atomic_nightly),
+                any(
+                    target_endian = "little",
+                    target_feature = "quadword-atomics",
+                    portable_atomic_target_feature = "quadword-atomics"
+                ),
+                target_arch = "powerpc64"
             ),
-            target_arch = "x86_64",
-        ),
-        all(
-            all(not(portable_atomic_no_asm), portable_atomic_nightly),
-            any(
-                target_endian = "little",
-                target_feature = "quadword-atomics",
-                portable_atomic_target_feature = "quadword-atomics"
+            all(all(not(portable_atomic_no_asm), portable_atomic_nightly), target_arch = "s390x"),
+        ))
+    )]
+    #[cfg_attr(
+        all(feature = "fallback", portable_atomic_no_cfg_target_has_atomic),
+        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+    )]
+    #[cfg_attr(
+        all(feature = "fallback", not(portable_atomic_no_cfg_target_has_atomic)),
+        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+    )]
+    atomic_int!(AtomicI128, i128, 16);
+    #[cfg_attr(
+        not(feature = "fallback"),
+        cfg(any(
+            all(
+                any(not(portable_atomic_no_asm), portable_atomic_nightly),
+                target_arch = "aarch64"
             ),
-            target_arch = "powerpc64"
-        ),
-        all(all(not(portable_atomic_no_asm), portable_atomic_nightly), target_arch = "s390x"),
-    ))
-)]
-#[cfg_attr(
-    all(feature = "fallback", portable_atomic_no_cfg_target_has_atomic),
-    cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
-)]
-#[cfg_attr(
-    all(feature = "fallback", not(portable_atomic_no_cfg_target_has_atomic)),
-    cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
-)]
-atomic_int!(AtomicU128, u128, 16);
+            all(
+                any(not(portable_atomic_no_asm), portable_atomic_nightly),
+                any(
+                    target_feature = "cmpxchg16b",
+                    portable_atomic_target_feature = "cmpxchg16b",
+                    portable_atomic_cmpxchg16b_dynamic
+                ),
+                target_arch = "x86_64",
+            ),
+            all(
+                all(not(portable_atomic_no_asm), portable_atomic_nightly),
+                any(
+                    target_endian = "little",
+                    target_feature = "quadword-atomics",
+                    portable_atomic_target_feature = "quadword-atomics"
+                ),
+                target_arch = "powerpc64"
+            ),
+            all(all(not(portable_atomic_no_asm), portable_atomic_nightly), target_arch = "s390x"),
+        ))
+    )]
+    #[cfg_attr(
+        all(feature = "fallback", portable_atomic_no_cfg_target_has_atomic),
+        cfg(any(not(portable_atomic_no_atomic_cas), portable_atomic_unsafe_assume_single_core))
+    )]
+    #[cfg_attr(
+        all(feature = "fallback", not(portable_atomic_no_cfg_target_has_atomic)),
+        cfg(any(target_has_atomic = "ptr", portable_atomic_unsafe_assume_single_core))
+    )]
+    atomic_int!(AtomicU128, u128, 16);
+}
+#[cfg(any(
+    portable_atomic_unsafe_atomic_builtins,
+    portable_atomic_unsafe_atomic_builtins_4,
+    portable_atomic_unsafe_atomic_builtins_8,
+    portable_atomic_unsafe_atomic_builtins_16,
+))]
+mod imp_ {
+    use core::sync::atomic::Ordering;
+    #[cfg(doc)]
+    use core::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release, SeqCst};
+
+    #[cfg(any(
+        portable_atomic_unsafe_atomic_builtins_4,
+        portable_atomic_unsafe_atomic_builtins_8,
+        portable_atomic_unsafe_atomic_builtins_16,
+        not(target_pointer_width = "16")
+    ))]
+    atomic_int!(AtomicI32, i32, 4);
+    #[cfg(any(
+        portable_atomic_unsafe_atomic_builtins_4,
+        portable_atomic_unsafe_atomic_builtins_8,
+        portable_atomic_unsafe_atomic_builtins_16,
+        not(target_pointer_width = "16")
+    ))]
+    atomic_int!(AtomicU32, u32, 4);
+
+    #[cfg(any(
+        portable_atomic_unsafe_atomic_builtins_8,
+        portable_atomic_unsafe_atomic_builtins_16,
+        not(any(target_pointer_width = "16", target_pointer_width = "32"))
+    ))]
+    atomic_int!(AtomicI64, i64, 8);
+    #[cfg(any(
+        portable_atomic_unsafe_atomic_builtins_8,
+        portable_atomic_unsafe_atomic_builtins_16,
+        not(any(target_pointer_width = "16", target_pointer_width = "32"))
+    ))]
+    atomic_int!(AtomicU64, u64, 8);
+
+    #[cfg(any(
+        portable_atomic_unsafe_atomic_builtins_16,
+        not(any(
+            target_pointer_width = "16",
+            target_pointer_width = "32",
+            target_pointer_width = "64"
+        ))
+    ))]
+    atomic_int!(AtomicI128, i128, 16);
+    #[cfg(any(
+        portable_atomic_unsafe_atomic_builtins_16,
+        not(any(
+            target_pointer_width = "16",
+            target_pointer_width = "32",
+            target_pointer_width = "64"
+        ))
+    ))]
+    atomic_int!(AtomicU128, u128, 16);
+}

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -102,7 +102,7 @@ if [[ "${rustc_version}" == *"nightly"* ]] || [[ "${rustc_version}" == *"dev"* ]
             # TODO: handle key-value cfg from build script as --check-cfg=values(name, "value1", "value2", ... "valueN")
             # shellcheck disable=SC2207
             build_script_cfg=($(grep -E 'cargo:rustc-cfg=' build.rs | sed -E 's/^.*cargo:rustc-cfg=//' | sed -E 's/(=\\)?".*$//' | LC_ALL=C sort | uniq))
-            check_cfg="-Z unstable-options --check-cfg=names(docsrs,portable_atomic_unsafe_assume_single_core,$(IFS=',' && echo "${build_script_cfg[*]}")) --check-cfg=values(target_pointer_width,\"128\")"
+            check_cfg="-Z unstable-options --check-cfg=names(docsrs,portable_atomic_unsafe_assume_single_core,portable_atomic_unsafe_atomic_builtins,portable_atomic_unsafe_atomic_builtins_4,portable_atomic_unsafe_atomic_builtins_8,portable_atomic_unsafe_atomic_builtins_16,$(IFS=',' && echo "${build_script_cfg[*]}")) --check-cfg=values(target_pointer_width,\"128\")"
             rustup ${pre_args[@]+"${pre_args[@]}"} component add clippy &>/dev/null
             base_args=(${pre_args[@]+"${pre_args[@]}"} hack clippy -Z check-cfg="names,values,output,features")
             ;;


### PR DESCRIPTION
- **`--cfg portable_atomic_unsafe_atomic_builtins`**<br>
  Use [`__atomic_*` builtins](https://llvm.org/docs/Atomics.html#libcalls-atomic).

  Combine this with custom atomic logic and you can support CAS on multi-core systems where atomic CAS is not available in the standard library.

  Note: This cfg is `unsafe`.

  This cfg enables pointer-width and smaller atomic types.

  To enable atomic types grater than pointer-width, you need to enable `--cfg portable_atomic_unsafe_atomic_builtins_N` cfgs.

- **`--cfg portable_atomic_unsafe_atomic_builtins_N`**<br>
  Similar to `--cfg portable_atomic_unsafe_atomic_builtins`, but also enables the specified size and smaller atomic types if the pointer width is smaller than the specified size.

  For example, when `--cfg portable_atomic_unsafe_atomic_builtins_4` is enabled:
  - On 64-bit platform, `Atomic{I,U}{64,32,16,8}` will be enabled.
  - On 32-bit and 16-bit platform, `Atomic{I,U}{32,16,8}` will be enabled.

  `N` is in bytes and must be 4, 8, or 16. In other words, there are three valid patterns:

  ```text
  --cfg portable_atomic_unsafe_atomic_builtins_4
  --cfg portable_atomic_unsafe_atomic_builtins_8
  --cfg portable_atomic_unsafe_atomic_builtins_16
  ```

cc #26, #33