### PR TITLE
Add empty portable-atomic-util crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [workspace]
 members = [
     "bench",
+    "portable-atomic-util",
     "tests/api-test",
 ]
 

--- a/bench/version.rs
+++ b/bench/version.rs
@@ -1,0 +1,1 @@
+../version.rs

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,10 @@
 
 #![warn(rust_2018_idioms, single_use_lifetimes)]
 
+#[path = "version.rs"]
+mod version;
+use version::{rustc_version, Version};
+
 use std::{env, str};
 
 include!("no_atomic.rs");
@@ -337,98 +341,3 @@ fn is_allowed_feature(name: &str) -> bool {
     // allowed by default
     true
 }
-
-mod version {
-    use std::{env, process::Command, str};
-
-    pub(crate) struct Version {
-        pub(crate) minor: u32,
-        pub(crate) nightly: bool,
-        commit_date: Date,
-        pub(crate) llvm: u32,
-    }
-
-    impl Version {
-        pub(crate) const LATEST: Self = Self::stable(63);
-
-        const fn stable(minor: u32) -> Self {
-            Self { minor, nightly: false, commit_date: Date::new(0, 0, 0), llvm: 0 }
-        }
-
-        pub(crate) fn probe(&self, minor: u32, year: u16, month: u8, day: u8) -> bool {
-            self.minor >= minor
-                && (!self.nightly || self.commit_date >= Date::new(year, month, day))
-        }
-    }
-
-    #[derive(PartialEq, Eq, PartialOrd, Ord)]
-    struct Date {
-        year: u16,
-        month: u8,
-        day: u8,
-    }
-
-    impl Date {
-        const fn new(year: u16, month: u8, day: u8) -> Self {
-            Self { year, month, day }
-        }
-    }
-
-    pub(crate) fn rustc_version() -> Option<Version> {
-        let rustc = env::var_os("RUSTC")?;
-        // Use verbose version output because the packagers add extra strings to the normal version output.
-        let output = Command::new(rustc).args(&["--version", "--verbose"]).output().ok()?;
-        let output = str::from_utf8(&output.stdout).ok()?;
-
-        let mut release = output
-            .lines()
-            .find(|line| line.starts_with("release: "))
-            .map(|line| &line["release: ".len()..])?
-            .splitn(2, '-');
-        let version = release.next().unwrap();
-        let channel = release.next().unwrap_or_default();
-        let mut digits = version.splitn(3, '.');
-        let major = digits.next()?.parse::<u32>().ok()?;
-        if major != 1 {
-            return None;
-        }
-        let minor = digits.next()?.parse::<u32>().ok()?;
-        let _patch = digits.next().unwrap_or("0").parse::<u32>().ok()?;
-        let nightly = channel == "nightly" || channel == "dev";
-
-        if nightly {
-            let llvm_major = (|| {
-                let version = output
-                    .lines()
-                    .find(|line| line.starts_with("LLVM version: "))
-                    .map(|line| &line["LLVM version: ".len()..])?;
-                let mut digits = version.splitn(3, '.');
-                let major = digits.next()?.parse::<u32>().ok()?;
-                let _minor = digits.next()?.parse::<u32>().ok()?;
-                let _patch = digits.next().unwrap_or("0").parse::<u32>().ok()?;
-                Some(major)
-            })();
-
-            let mut commit_date = output
-                .lines()
-                .find(|line| line.starts_with("commit-date: "))
-                .map(|line| &line["commit-date: ".len()..])?
-                .splitn(3, '-');
-            let year = commit_date.next()?.parse::<u16>().ok()?;
-            let month = commit_date.next()?.parse::<u8>().ok()?;
-            let day = commit_date.next()?.parse::<u8>().ok()?;
-            if month > 12 || day > 31 {
-                return None;
-            }
-            Some(Version {
-                minor,
-                nightly,
-                commit_date: Date::new(year, month, day),
-                llvm: llvm_major.unwrap_or(0),
-            })
-        } else {
-            Some(Version::stable(minor))
-        }
-    }
-}
-use version::{rustc_version, Version};

--- a/portable-atomic-util/Cargo.toml
+++ b/portable-atomic-util/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "portable-atomic-util"
+version = "0.3.15"
+edition = "2018"
+rust-version = "1.34"
+license = "Apache-2.0 OR MIT"
+repository = "https://github.com/taiki-e/portable-atomic"
+keywords = ["atomic"]
+categories = ["concurrency", "data-structures", "embedded", "hardware-support", "no-std"]
+description = """
+Synchronization primitives built with portable-atomic.
+"""
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+default = ["std"]
+std = ["alloc"]
+alloc = []
+
+[dependencies]
+portable-atomic = { version = "=0.3.15", default-features = false }

--- a/portable-atomic-util/LICENSE-APACHE
+++ b/portable-atomic-util/LICENSE-APACHE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/portable-atomic-util/LICENSE-MIT
+++ b/portable-atomic-util/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/portable-atomic-util/README.md
+++ b/portable-atomic-util/README.md
@@ -1,0 +1,3 @@
+# portable-atomic-util
+
+Synchronization primitives built with portable-atomic.

--- a/portable-atomic-util/build.rs
+++ b/portable-atomic-util/build.rs
@@ -1,0 +1,49 @@
+// The rustc-cfg emitted by the build script are *not* public API.
+
+#![warn(rust_2018_idioms, single_use_lifetimes)]
+
+#[allow(dead_code)]
+#[path = "version.rs"]
+mod version;
+use version::{rustc_version, Version};
+
+use std::env;
+
+fn main() {
+    println!("cargo:rerun-if-changed=no_atomic.rs");
+
+    let version = match rustc_version() {
+        Some(version) => version,
+        None => {
+            println!(
+                "cargo:warning={}: unable to determine rustc version; assuming latest stable rustc (1.{})",
+                env!("CARGO_PKG_NAME"),
+                Version::LATEST.minor
+            );
+            Version::LATEST
+        }
+    };
+
+    // Note that this is `no_`*, not `has_*`. This allows treating as the latest
+    // stable rustc is used when the build script doesn't run. This is useful
+    // for non-cargo build systems that don't run the build script.
+    if version.minor < 36 {
+        println!("cargo:rustc-cfg=portable_atomic_no_alloc");
+    }
+    // raw_ref_macros stabilized in Rust 1.51 (nightly-2021-01-31) https://github.com/rust-lang/rust/pull/80886
+    if !version.probe(51, 2021, 1, 30) {
+        println!("cargo:rustc-cfg=portable_atomic_no_raw_ref_macros");
+    }
+    // unsafe_op_in_unsafe_fn stabilized in Rust 1.52 (nightly-2021-03-11): https://github.com/rust-lang/rust/pull/79208
+    if !version.probe(52, 2021, 3, 10) {
+        println!("cargo:rustc-cfg=portable_atomic_no_unsafe_op_in_unsafe_fn");
+    }
+
+    if version.nightly {
+        // `cfg(sanitize = "..")` is not stabilized.
+        let sanitize = env::var("CARGO_CFG_SANITIZE").unwrap_or_default();
+        if sanitize.contains("thread") {
+            println!("cargo:rustc-cfg=portable_atomic_sanitize_thread");
+        }
+    }
+}

--- a/portable-atomic-util/src/lib.rs
+++ b/portable-atomic-util/src/lib.rs
@@ -1,0 +1,49 @@
+/*!
+Synchronization primitives built with portable-atomic.
+
+*/
+
+#![no_std]
+#![doc(test(
+    no_crate_inject,
+    attr(
+        deny(warnings, rust_2018_idioms, single_use_lifetimes),
+        allow(dead_code, unused_variables)
+    )
+))]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    single_use_lifetimes,
+    unreachable_pub
+)]
+#![cfg_attr(not(portable_atomic_no_unsafe_op_in_unsafe_fn), warn(unsafe_op_in_unsafe_fn))] // unsafe_op_in_unsafe_fn requires Rust 1.52
+#![cfg_attr(portable_atomic_no_unsafe_op_in_unsafe_fn, allow(unused_unsafe))]
+#![warn(
+    clippy::pedantic,
+    // lints for public library
+    clippy::alloc_instead_of_core,
+    clippy::exhaustive_enums,
+    clippy::exhaustive_structs,
+    clippy::std_instead_of_alloc,
+    clippy::std_instead_of_core,
+    // lints that help writing unsafe code
+    clippy::default_union_representation,
+    clippy::trailing_empty_array,
+    clippy::transmute_undefined_repr,
+    clippy::undocumented_unsafe_blocks,
+    // misc
+    clippy::inline_asm_x86_att_syntax,
+)]
+#![allow(
+    clippy::cast_lossless,
+    clippy::doc_markdown,
+    clippy::float_cmp,
+    clippy::inline_always,
+    clippy::missing_errors_doc,
+    clippy::module_inception,
+    clippy::similar_names,
+    clippy::single_match,
+    clippy::type_complexity
+)]

--- a/portable-atomic-util/version.rs
+++ b/portable-atomic-util/version.rs
@@ -1,0 +1,1 @@
+../version.rs

--- a/version.rs
+++ b/version.rs
@@ -1,0 +1,90 @@
+use std::{env, process::Command, str};
+
+pub(crate) struct Version {
+    pub(crate) minor: u32,
+    pub(crate) nightly: bool,
+    commit_date: Date,
+    pub(crate) llvm: u32,
+}
+
+impl Version {
+    pub(crate) const LATEST: Self = Self::stable(63);
+
+    const fn stable(minor: u32) -> Self {
+        Self { minor, nightly: false, commit_date: Date::new(0, 0, 0), llvm: 0 }
+    }
+
+    pub(crate) fn probe(&self, minor: u32, year: u16, month: u8, day: u8) -> bool {
+        self.minor >= minor && (!self.nightly || self.commit_date >= Date::new(year, month, day))
+    }
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct Date {
+    year: u16,
+    month: u8,
+    day: u8,
+}
+
+impl Date {
+    const fn new(year: u16, month: u8, day: u8) -> Self {
+        Self { year, month, day }
+    }
+}
+
+pub(crate) fn rustc_version() -> Option<Version> {
+    let rustc = env::var_os("RUSTC")?;
+    // Use verbose version output because the packagers add extra strings to the normal version output.
+    let output = Command::new(rustc).args(&["--version", "--verbose"]).output().ok()?;
+    let output = str::from_utf8(&output.stdout).ok()?;
+
+    let mut release = output
+        .lines()
+        .find(|line| line.starts_with("release: "))
+        .map(|line| &line["release: ".len()..])?
+        .splitn(2, '-');
+    let version = release.next().unwrap();
+    let channel = release.next().unwrap_or_default();
+    let mut digits = version.splitn(3, '.');
+    let major = digits.next()?.parse::<u32>().ok()?;
+    if major != 1 {
+        return None;
+    }
+    let minor = digits.next()?.parse::<u32>().ok()?;
+    let _patch = digits.next().unwrap_or("0").parse::<u32>().ok()?;
+    let nightly = channel == "nightly" || channel == "dev";
+
+    if nightly {
+        let llvm_major = (|| {
+            let version = output
+                .lines()
+                .find(|line| line.starts_with("LLVM version: "))
+                .map(|line| &line["LLVM version: ".len()..])?;
+            let mut digits = version.splitn(3, '.');
+            let major = digits.next()?.parse::<u32>().ok()?;
+            let _minor = digits.next()?.parse::<u32>().ok()?;
+            let _patch = digits.next().unwrap_or("0").parse::<u32>().ok()?;
+            Some(major)
+        })();
+
+        let mut commit_date = output
+            .lines()
+            .find(|line| line.starts_with("commit-date: "))
+            .map(|line| &line["commit-date: ".len()..])?
+            .splitn(3, '-');
+        let year = commit_date.next()?.parse::<u16>().ok()?;
+        let month = commit_date.next()?.parse::<u8>().ok()?;
+        let day = commit_date.next()?.parse::<u8>().ok()?;
+        if month > 12 || day > 31 {
+            return None;
+        }
+        Some(Version {
+            minor,
+            nightly,
+            commit_date: Date::new(year, month, day),
+            llvm: llvm_major.unwrap_or(0),
+        })
+    } else {
+        Some(Version::stable(minor))
+    }
+}


### PR DESCRIPTION
This adds an empty crate named `portable-atomic-util`.

For now, I'm considering putting the features proposed in #1 (#8) and #37 into this crate, but they may be merged into the main `portable-atomic` crate in the future.
