### PR TITLE
Add add/sub/and/or/xor methods that do not return previous value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Add `Atomic{I,U}*::{add,sub,and,or,xor}` and `AtomicBool::{and,or,xor}` methods.
+
+  They are equivalent to the corresponding `fetch_*` methods, but do not return the previous value. They are intended for optimization on platforms that implement atomics using inline assembly, such as the MSP430.
+
 - Various improvements to `portable_atomic_unsafe_assume_single_core` cfg. ([#44](https://github.com/taiki-e/portable-atomic/pull/44))
 
   - Support disabling FIQs on pre-v6 ARM under `portable_atomic_disable_fiq` cfg.

--- a/src/imp/atomic128/intrinsics.rs
+++ b/src/imp/atomic128/intrinsics.rs
@@ -415,6 +415,7 @@ macro_rules! atomic128 {
         // SAFETY: any data races are prevented by atomic intrinsics.
         unsafe impl Sync for $atomic_type {}
 
+        no_fetch_ops_impl!($atomic_type, $int_type);
         impl $atomic_type {
             #[inline]
             pub(crate) const fn new(v: $int_type) -> Self {

--- a/src/imp/atomic128/macros.rs
+++ b/src/imp/atomic128/macros.rs
@@ -10,6 +10,7 @@ macro_rules! atomic128 {
         // SAFETY: any data races are prevented by atomic intrinsics.
         unsafe impl Sync for $atomic_type {}
 
+        no_fetch_ops_impl!($atomic_type, $int_type);
         impl $atomic_type {
             #[inline]
             pub(crate) const fn new(v: $int_type) -> Self {
@@ -216,6 +217,7 @@ macro_rules! atomic128 {
         // SAFETY: any data races are prevented by atomic intrinsics.
         unsafe impl Sync for $atomic_type {}
 
+        no_fetch_ops_impl!($atomic_type, $int_type);
         impl $atomic_type {
             #[inline]
             pub(crate) const fn new(v: $int_type) -> Self {

--- a/src/imp/core_atomic.rs
+++ b/src/imp/core_atomic.rs
@@ -41,6 +41,9 @@ impl AtomicBool {
 }
 #[cfg_attr(portable_atomic_no_cfg_target_has_atomic, cfg(not(portable_atomic_no_atomic_cas)))]
 #[cfg_attr(not(portable_atomic_no_cfg_target_has_atomic), cfg(target_has_atomic = "ptr"))]
+no_fetch_ops_impl!(AtomicBool, bool);
+#[cfg_attr(portable_atomic_no_cfg_target_has_atomic, cfg(not(portable_atomic_no_atomic_cas)))]
+#[cfg_attr(not(portable_atomic_no_cfg_target_has_atomic), cfg(target_has_atomic = "ptr"))]
 impl AtomicBool {
     #[inline]
     #[cfg_attr(all(debug_assertions, not(portable_atomic_no_track_caller)), track_caller)]
@@ -171,6 +174,15 @@ macro_rules! atomic_int {
         pub(crate) struct $atomic_type {
             inner: core::sync::atomic::$atomic_type,
         }
+        #[cfg_attr(
+            portable_atomic_no_cfg_target_has_atomic,
+            cfg(not(portable_atomic_no_atomic_cas))
+        )]
+        #[cfg_attr(
+            not(portable_atomic_no_cfg_target_has_atomic),
+            cfg(target_has_atomic = "ptr")
+        )]
+        no_fetch_ops_impl!($atomic_type, $int_type);
         impl $atomic_type {
             #[inline]
             pub(crate) const fn new(v: $int_type) -> Self {

--- a/src/imp/fallback/imp.rs
+++ b/src/imp/fallback/imp.rs
@@ -130,6 +130,8 @@ macro_rules! atomic {
         // SAFETY: any data races are prevented by the lock and atomic operation.
         unsafe impl Sync for $atomic_type {}
 
+        #[cfg(any(test, not(portable_atomic_cmpxchg16b_dynamic)))]
+        no_fetch_ops_impl!($atomic_type, $int_type);
         impl $atomic_type {
             #[cfg(any(test, not(portable_atomic_cmpxchg16b_dynamic)))]
             #[inline]

--- a/src/imp/interrupt/msp430.rs
+++ b/src/imp/interrupt/msp430.rs
@@ -1,4 +1,6 @@
 // Adapted from https://github.com/rust-embedded/msp430.
+//
+// See also src/imp/msp430.rs.
 
 #[cfg(not(portable_atomic_no_asm))]
 use core::arch::asm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -818,6 +818,67 @@ impl AtomicBool {
         self.inner.fetch_and(val, order)
     }
 
+    /// Logical "and" with a boolean value.
+    ///
+    /// Performs a logical "and" operation on the current value and the argument `val`, and sets
+    /// the new value to the result.
+    ///
+    /// Unlike `fetch_and`, this does not return the previous value.
+    ///
+    /// `and` takes an [`Ordering`] argument which describes the memory ordering
+    /// of this operation. All ordering modes are possible. Note that using
+    /// [`Acquire`] makes the store part of this operation [`Relaxed`], and
+    /// using [`Release`] makes the load part [`Relaxed`].
+    ///
+    /// This function may generate more efficient code than `fetch_and` on some platforms.
+    ///
+    /// - x86: `lock and` instead of `cmpxchg` loop
+    /// - MSP430: `and` instead of disabling interrupts
+    ///
+    /// Note: On x86, the use of either function should not usually
+    /// affect the generated code, because LLVM can properly optimize the case
+    /// where the result is unused.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use portable_atomic::{AtomicBool, Ordering};
+    ///
+    /// let foo = AtomicBool::new(true);
+    /// foo.and(false, Ordering::SeqCst);
+    /// assert_eq!(foo.load(Ordering::SeqCst), false);
+    ///
+    /// let foo = AtomicBool::new(true);
+    /// foo.and(true, Ordering::SeqCst);
+    /// assert_eq!(foo.load(Ordering::SeqCst), true);
+    ///
+    /// let foo = AtomicBool::new(false);
+    /// foo.and(false, Ordering::SeqCst);
+    /// assert_eq!(foo.load(Ordering::SeqCst), false);
+    /// ```
+    #[cfg_attr(
+        portable_atomic_no_cfg_target_has_atomic,
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            target_arch = "avr",
+            target_arch = "msp430"
+        ))
+    )]
+    #[cfg_attr(
+        not(portable_atomic_no_cfg_target_has_atomic),
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            target_arch = "avr",
+            target_arch = "msp430"
+        ))
+    )]
+    #[inline]
+    pub fn and(&self, val: bool, order: Ordering) {
+        self.inner.and(val, order);
+    }
+
     /// Logical "nand" with a boolean value.
     ///
     /// Performs a logical "nand" operation on the current value and the argument `val`, and sets
@@ -923,6 +984,67 @@ impl AtomicBool {
         self.inner.fetch_or(val, order)
     }
 
+    /// Logical "or" with a boolean value.
+    ///
+    /// Performs a logical "or" operation on the current value and the argument `val`, and sets the
+    /// new value to the result.
+    ///
+    /// Unlike `fetch_or`, this does not return the previous value.
+    ///
+    /// `or` takes an [`Ordering`] argument which describes the memory ordering
+    /// of this operation. All ordering modes are possible. Note that using
+    /// [`Acquire`] makes the store part of this operation [`Relaxed`], and
+    /// using [`Release`] makes the load part [`Relaxed`].
+    ///
+    /// This function may generate more efficient code than `fetch_or` on some platforms.
+    ///
+    /// - x86: `lock or` instead of `cmpxchg` loop
+    /// - MSP430: `bis` instead of disabling interrupts
+    ///
+    /// Note: On x86, the use of either function should not usually
+    /// affect the generated code, because LLVM can properly optimize the case
+    /// where the result is unused.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use portable_atomic::{AtomicBool, Ordering};
+    ///
+    /// let foo = AtomicBool::new(true);
+    /// foo.or(false, Ordering::SeqCst);
+    /// assert_eq!(foo.load(Ordering::SeqCst), true);
+    ///
+    /// let foo = AtomicBool::new(true);
+    /// foo.or(true, Ordering::SeqCst);
+    /// assert_eq!(foo.load(Ordering::SeqCst), true);
+    ///
+    /// let foo = AtomicBool::new(false);
+    /// foo.or(false, Ordering::SeqCst);
+    /// assert_eq!(foo.load(Ordering::SeqCst), false);
+    /// ```
+    #[cfg_attr(
+        portable_atomic_no_cfg_target_has_atomic,
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            target_arch = "avr",
+            target_arch = "msp430"
+        ))
+    )]
+    #[cfg_attr(
+        not(portable_atomic_no_cfg_target_has_atomic),
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            target_arch = "avr",
+            target_arch = "msp430"
+        ))
+    )]
+    #[inline]
+    pub fn or(&self, val: bool, order: Ordering) {
+        self.inner.or(val, order);
+    }
+
     /// Logical "xor" with a boolean value.
     ///
     /// Performs a logical "xor" operation on the current value and the argument `val`, and sets
@@ -975,6 +1097,67 @@ impl AtomicBool {
         self.inner.fetch_xor(val, order)
     }
 
+    /// Logical "xor" with a boolean value.
+    ///
+    /// Performs a logical "xor" operation on the current value and the argument `val`, and sets
+    /// the new value to the result.
+    ///
+    /// Unlike `fetch_xor`, this does not return the previous value.
+    ///
+    /// `xor` takes an [`Ordering`] argument which describes the memory ordering
+    /// of this operation. All ordering modes are possible. Note that using
+    /// [`Acquire`] makes the store part of this operation [`Relaxed`], and
+    /// using [`Release`] makes the load part [`Relaxed`].
+    ///
+    /// This function may generate more efficient code than `fetch_xor` on some platforms.
+    ///
+    /// - x86: `lock xor` instead of `cmpxchg` loop
+    /// - MSP430: `xor` instead of disabling interrupts
+    ///
+    /// Note: On x86, the use of either function should not usually
+    /// affect the generated code, because LLVM can properly optimize the case
+    /// where the result is unused.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use portable_atomic::{AtomicBool, Ordering};
+    ///
+    /// let foo = AtomicBool::new(true);
+    /// foo.xor(false, Ordering::SeqCst);
+    /// assert_eq!(foo.load(Ordering::SeqCst), true);
+    ///
+    /// let foo = AtomicBool::new(true);
+    /// foo.xor(true, Ordering::SeqCst);
+    /// assert_eq!(foo.load(Ordering::SeqCst), false);
+    ///
+    /// let foo = AtomicBool::new(false);
+    /// foo.xor(false, Ordering::SeqCst);
+    /// assert_eq!(foo.load(Ordering::SeqCst), false);
+    /// ```
+    #[cfg_attr(
+        portable_atomic_no_cfg_target_has_atomic,
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            target_arch = "avr",
+            target_arch = "msp430"
+        ))
+    )]
+    #[cfg_attr(
+        not(portable_atomic_no_cfg_target_has_atomic),
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            target_arch = "avr",
+            target_arch = "msp430"
+        ))
+    )]
+    #[inline]
+    pub fn xor(&self, val: bool, order: Ordering) {
+        self.inner.xor(val, order);
+    }
+
     /// Logical "not" with a boolean value.
     ///
     /// Performs a logical "not" operation on the current value, and sets
@@ -1021,6 +1204,63 @@ impl AtomicBool {
     #[inline]
     pub fn fetch_not(&self, order: Ordering) -> bool {
         self.fetch_xor(true, order)
+    }
+
+    /// Logical "not" with a boolean value.
+    ///
+    /// Performs a logical "not" operation on the current value, and sets
+    /// the new value to the result.
+    ///
+    /// Unlike `fetch_not`, this does not return the previous value.
+    ///
+    /// `not` takes an [`Ordering`] argument which describes the memory ordering
+    /// of this operation. All ordering modes are possible. Note that using
+    /// [`Acquire`] makes the store part of this operation [`Relaxed`], and
+    /// using [`Release`] makes the load part [`Relaxed`].
+    ///
+    /// This function may generate more efficient code than `fetch_not` on some platforms.
+    ///
+    /// - x86: `lock xor` instead of `cmpxchg` loop
+    /// - MSP430: `xor` instead of disabling interrupts
+    ///
+    /// Note: On x86, the use of either function should not usually
+    /// affect the generated code, because LLVM can properly optimize the case
+    /// where the result is unused.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use portable_atomic::{AtomicBool, Ordering};
+    ///
+    /// let foo = AtomicBool::new(true);
+    /// assert_eq!(foo.fetch_not(Ordering::SeqCst), true);
+    /// assert_eq!(foo.load(Ordering::SeqCst), false);
+    ///
+    /// let foo = AtomicBool::new(false);
+    /// assert_eq!(foo.fetch_not(Ordering::SeqCst), false);
+    /// assert_eq!(foo.load(Ordering::SeqCst), true);
+    /// ```
+    #[cfg_attr(
+        portable_atomic_no_cfg_target_has_atomic,
+        cfg(any(
+            not(portable_atomic_no_atomic_cas),
+            portable_atomic_unsafe_assume_single_core,
+            target_arch = "avr",
+            target_arch = "msp430"
+        ))
+    )]
+    #[cfg_attr(
+        not(portable_atomic_no_cfg_target_has_atomic),
+        cfg(any(
+            target_has_atomic = "ptr",
+            portable_atomic_unsafe_assume_single_core,
+            target_arch = "avr",
+            target_arch = "msp430"
+        ))
+    )]
+    #[inline]
+    pub fn not(&self, order: Ordering) {
+        self.xor(true, order);
     }
 
     // TODO: Add as_mut_ptr once it is stable on std atomic types.
@@ -2540,6 +2780,55 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
             }
 
             doc_comment! {
+                concat!("Adds to the current value.
+
+This operation wraps around on overflow.
+
+Unlike `fetch_add`, this does not return the previous value.
+
+`add` takes an [`Ordering`] argument which describes the memory ordering
+of this operation. All ordering modes are possible. Note that using
+[`Acquire`] makes the store part of this operation [`Relaxed`], and
+using [`Release`] makes the load part [`Relaxed`].
+
+This function may generate more efficient code than `fetch_add` on some platforms.
+
+- MSP430: `add` instead of disabling interrupts
+
+# Examples
+
+```
+use portable_atomic::{", stringify!($atomic_type), ", Ordering};
+
+let foo = ", stringify!($atomic_type), "::new(0);
+foo.add(10, Ordering::SeqCst);
+assert_eq!(foo.load(Ordering::SeqCst), 10);
+```"),
+                #[cfg_attr(
+                    portable_atomic_no_cfg_target_has_atomic,
+                    cfg(any(
+                        not(portable_atomic_no_atomic_cas),
+                        portable_atomic_unsafe_assume_single_core,
+                        target_arch = "avr",
+                        target_arch = "msp430"
+                    ))
+                )]
+                #[cfg_attr(
+                    not(portable_atomic_no_cfg_target_has_atomic),
+                    cfg(any(
+                        target_has_atomic = "ptr",
+                        portable_atomic_unsafe_assume_single_core,
+                        target_arch = "avr",
+                        target_arch = "msp430"
+                    ))
+                )]
+                #[inline]
+                pub fn add(&self, val: $int_type, order: Ordering) {
+                    self.inner.add(val, order);
+                }
+            }
+
+            doc_comment! {
                 concat!("Subtracts from the current value, returning the previous value.
 
 This operation wraps around on overflow.
@@ -2579,6 +2868,55 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
                 #[inline]
                 pub fn fetch_sub(&self, val: $int_type, order: Ordering) -> $int_type {
                     self.inner.fetch_sub(val, order)
+                }
+            }
+
+            doc_comment! {
+                concat!("Subtracts from the current value.
+
+This operation wraps around on overflow.
+
+Unlike `fetch_sub`, this does not return the previous value.
+
+`sub` takes an [`Ordering`] argument which describes the memory ordering
+of this operation. All ordering modes are possible. Note that using
+[`Acquire`] makes the store part of this operation [`Relaxed`], and
+using [`Release`] makes the load part [`Relaxed`].
+
+This function may generate more efficient code than `fetch_sub` on some platforms.
+
+- MSP430: `sub` instead of disabling interrupts
+
+# Examples
+
+```
+use portable_atomic::{", stringify!($atomic_type), ", Ordering};
+
+let foo = ", stringify!($atomic_type), "::new(20);
+foo.sub(10, Ordering::SeqCst);
+assert_eq!(foo.load(Ordering::SeqCst), 10);
+```"),
+                #[cfg_attr(
+                    portable_atomic_no_cfg_target_has_atomic,
+                    cfg(any(
+                        not(portable_atomic_no_atomic_cas),
+                        portable_atomic_unsafe_assume_single_core,
+                        target_arch = "avr",
+                        target_arch = "msp430"
+                    ))
+                )]
+                #[cfg_attr(
+                    not(portable_atomic_no_cfg_target_has_atomic),
+                    cfg(any(
+                        target_has_atomic = "ptr",
+                        portable_atomic_unsafe_assume_single_core,
+                        target_arch = "avr",
+                        target_arch = "msp430"
+                    ))
+                )]
+                #[inline]
+                pub fn sub(&self, val: $int_type, order: Ordering) {
+                    self.inner.sub(val, order);
                 }
             }
 
@@ -2625,6 +2963,61 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b100001);
                 #[inline]
                 pub fn fetch_and(&self, val: $int_type, order: Ordering) -> $int_type {
                     self.inner.fetch_and(val, order)
+                }
+            }
+
+            doc_comment! {
+                concat!("Bitwise \"and\" with the current value.
+
+Performs a bitwise \"and\" operation on the current value and the argument `val`, and
+sets the new value to the result.
+
+Unlike `fetch_and`, this does not return the previous value.
+
+`and` takes an [`Ordering`] argument which describes the memory ordering
+of this operation. All ordering modes are possible. Note that using
+[`Acquire`] makes the store part of this operation [`Relaxed`], and
+using [`Release`] makes the load part [`Relaxed`].
+
+This function may generate more efficient code than `fetch_and` on some platforms.
+
+- x86: `lock and` instead of `cmpxchg` loop
+- MSP430: `and` instead of disabling interrupts
+
+Note: On x86, the use of either function should not usually
+affect the generated code, because LLVM can properly optimize the case
+where the result is unused.
+
+# Examples
+
+```
+use portable_atomic::{", stringify!($atomic_type), ", Ordering};
+
+let foo = ", stringify!($atomic_type), "::new(0b101101);
+assert_eq!(foo.fetch_and(0b110011, Ordering::SeqCst), 0b101101);
+assert_eq!(foo.load(Ordering::SeqCst), 0b100001);
+```"),
+                #[cfg_attr(
+                    portable_atomic_no_cfg_target_has_atomic,
+                    cfg(any(
+                        not(portable_atomic_no_atomic_cas),
+                        portable_atomic_unsafe_assume_single_core,
+                        target_arch = "avr",
+                        target_arch = "msp430"
+                    ))
+                )]
+                #[cfg_attr(
+                    not(portable_atomic_no_cfg_target_has_atomic),
+                    cfg(any(
+                        target_has_atomic = "ptr",
+                        portable_atomic_unsafe_assume_single_core,
+                        target_arch = "avr",
+                        target_arch = "msp430"
+                    ))
+                )]
+                #[inline]
+                pub fn and(&self, val: $int_type, order: Ordering) {
+                    self.inner.and(val, order);
                 }
             }
 
@@ -2721,6 +3114,61 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b111111);
             }
 
             doc_comment! {
+                concat!("Bitwise \"or\" with the current value.
+
+Performs a bitwise \"or\" operation on the current value and the argument `val`, and
+sets the new value to the result.
+
+Unlike `fetch_or`, this does not return the previous value.
+
+`or` takes an [`Ordering`] argument which describes the memory ordering
+of this operation. All ordering modes are possible. Note that using
+[`Acquire`] makes the store part of this operation [`Relaxed`], and
+using [`Release`] makes the load part [`Relaxed`].
+
+This function may generate more efficient code than `fetch_or` on some platforms.
+
+- x86: `lock or` instead of `cmpxchg` loop
+- MSP430: `or` instead of disabling interrupts
+
+Note: On x86, the use of either function should not usually
+affect the generated code, because LLVM can properly optimize the case
+where the result is unused.
+
+# Examples
+
+```
+use portable_atomic::{", stringify!($atomic_type), ", Ordering};
+
+let foo = ", stringify!($atomic_type), "::new(0b101101);
+assert_eq!(foo.fetch_or(0b110011, Ordering::SeqCst), 0b101101);
+assert_eq!(foo.load(Ordering::SeqCst), 0b111111);
+```"),
+                #[cfg_attr(
+                    portable_atomic_no_cfg_target_has_atomic,
+                    cfg(any(
+                        not(portable_atomic_no_atomic_cas),
+                        portable_atomic_unsafe_assume_single_core,
+                        target_arch = "avr",
+                        target_arch = "msp430"
+                    ))
+                )]
+                #[cfg_attr(
+                    not(portable_atomic_no_cfg_target_has_atomic),
+                    cfg(any(
+                        target_has_atomic = "ptr",
+                        portable_atomic_unsafe_assume_single_core,
+                        target_arch = "avr",
+                        target_arch = "msp430"
+                    ))
+                )]
+                #[inline]
+                pub fn or(&self, val: $int_type, order: Ordering) {
+                    self.inner.or(val, order);
+                }
+            }
+
+            doc_comment! {
                 concat!("Bitwise \"xor\" with the current value.
 
 Performs a bitwise \"xor\" operation on the current value and the argument `val`, and
@@ -2763,6 +3211,61 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b011110);
                 #[inline]
                 pub fn fetch_xor(&self, val: $int_type, order: Ordering) -> $int_type {
                     self.inner.fetch_xor(val, order)
+                }
+            }
+
+            doc_comment! {
+                concat!("Bitwise \"xor\" with the current value.
+
+Performs a bitwise \"xor\" operation on the current value and the argument `val`, and
+sets the new value to the result.
+
+Unlike `fetch_xor`, this does not return the previous value.
+
+`xor` takes an [`Ordering`] argument which describes the memory ordering
+of this operation. All ordering modes are possible. Note that using
+[`Acquire`] makes the store part of this operation [`Relaxed`], and
+using [`Release`] makes the load part [`Relaxed`].
+
+This function may generate more efficient code than `fetch_xor` on some platforms.
+
+- x86: `lock xor` instead of `cmpxchg` loop
+- MSP430: `xor` instead of disabling interrupts
+
+Note: On x86, the use of either function should not usually
+affect the generated code, because LLVM can properly optimize the case
+where the result is unused.
+
+# Examples
+
+```
+use portable_atomic::{", stringify!($atomic_type), ", Ordering};
+
+let foo = ", stringify!($atomic_type), "::new(0b101101);
+foo.xor(0b110011, Ordering::SeqCst);
+assert_eq!(foo.load(Ordering::SeqCst), 0b011110);
+```"),
+                #[cfg_attr(
+                    portable_atomic_no_cfg_target_has_atomic,
+                    cfg(any(
+                        not(portable_atomic_no_atomic_cas),
+                        portable_atomic_unsafe_assume_single_core,
+                        target_arch = "avr",
+                        target_arch = "msp430"
+                    ))
+                )]
+                #[cfg_attr(
+                    not(portable_atomic_no_cfg_target_has_atomic),
+                    cfg(any(
+                        target_has_atomic = "ptr",
+                        portable_atomic_unsafe_assume_single_core,
+                        target_arch = "avr",
+                        target_arch = "msp430"
+                    ))
+                )]
+                #[inline]
+                pub fn xor(&self, val: $int_type, order: Ordering) {
+                    self.inner.xor(val, order);
                 }
             }
 

--- a/src/tests/helper.rs
+++ b/src/tests/helper.rs
@@ -280,6 +280,19 @@ macro_rules! __test_atomic_int {
             }
         }
         #[test]
+        fn add() {
+            let a = <$atomic_type>::new(0);
+            test_swap_ordering(|order| a.add(0, order));
+            for order in swap_orderings() {
+                let a = <$atomic_type>::new(0);
+                a.add(10, order);
+                assert_eq!(a.load(Ordering::Relaxed), 10);
+                let a = <$atomic_type>::new($int_type::MAX);
+                a.add(1, order);
+                assert_eq!(a.load(Ordering::Relaxed), $int_type::MAX.wrapping_add(1));
+            }
+        }
+        #[test]
         fn fetch_sub() {
             let a = <$atomic_type>::new(20);
             test_swap_ordering(|order| a.fetch_sub(0, order));
@@ -293,12 +306,35 @@ macro_rules! __test_atomic_int {
             }
         }
         #[test]
+        fn sub() {
+            let a = <$atomic_type>::new(20);
+            test_swap_ordering(|order| a.sub(0, order));
+            for order in swap_orderings() {
+                let a = <$atomic_type>::new(20);
+                a.sub(10, order);
+                assert_eq!(a.load(Ordering::Relaxed), 10);
+                let a = <$atomic_type>::new($int_type::MIN);
+                a.sub(1, order);
+                assert_eq!(a.load(Ordering::Relaxed), $int_type::MIN.wrapping_sub(1));
+            }
+        }
+        #[test]
         fn fetch_and() {
             let a = <$atomic_type>::new(0b101101);
             test_swap_ordering(|order| a.fetch_and(0b101101, order));
             for order in swap_orderings() {
                 let a = <$atomic_type>::new(0b101101);
                 assert_eq!(a.fetch_and(0b110011, order), 0b101101);
+                assert_eq!(a.load(Ordering::Relaxed), 0b100001);
+            }
+        }
+        #[test]
+        fn and() {
+            let a = <$atomic_type>::new(0b101101);
+            test_swap_ordering(|order| a.and(0b101101, order));
+            for order in swap_orderings() {
+                let a = <$atomic_type>::new(0b101101);
+                a.and(0b110011, order);
                 assert_eq!(a.load(Ordering::Relaxed), 0b100001);
             }
         }
@@ -323,12 +359,32 @@ macro_rules! __test_atomic_int {
             }
         }
         #[test]
+        fn or() {
+            let a = <$atomic_type>::new(0b101101);
+            test_swap_ordering(|order| a.or(0, order));
+            for order in swap_orderings() {
+                let a = <$atomic_type>::new(0b101101);
+                a.or(0b110011, order);
+                assert_eq!(a.load(Ordering::Relaxed), 0b111111);
+            }
+        }
+        #[test]
         fn fetch_xor() {
             let a = <$atomic_type>::new(0b101101);
             test_swap_ordering(|order| a.fetch_xor(0, order));
             for order in swap_orderings() {
                 let a = <$atomic_type>::new(0b101101);
                 assert_eq!(a.fetch_xor(0b110011, order), 0b101101);
+                assert_eq!(a.load(Ordering::Relaxed), 0b011110);
+            }
+        }
+        #[test]
+        fn xor() {
+            let a = <$atomic_type>::new(0b101101);
+            test_swap_ordering(|order| a.xor(0, order));
+            for order in swap_orderings() {
+                let a = <$atomic_type>::new(0b101101);
+                a.xor(0b110011, order);
                 assert_eq!(a.load(Ordering::Relaxed), 0b011110);
             }
         }
@@ -897,6 +953,22 @@ macro_rules! __test_atomic_bool {
             }
         }
         #[test]
+        fn and() {
+            let a = <$atomic_type>::new(true);
+            test_swap_ordering(|order| a.and(true, order));
+            for order in swap_orderings() {
+                let a = <$atomic_type>::new(true);
+                a.and(false, order);
+                assert_eq!(a.load(Ordering::Relaxed), false);
+                let a = <$atomic_type>::new(true);
+                a.and(true, order);
+                assert_eq!(a.load(Ordering::Relaxed), true);
+                let a = <$atomic_type>::new(false);
+                a.and(false, order);
+                assert_eq!(a.load(Ordering::Relaxed), false);
+            }
+        }
+        #[test]
         fn fetch_nand() {
             let a = <$atomic_type>::new(true);
             test_swap_ordering(|order| assert_eq!(a.fetch_nand(false, order), true));
@@ -930,6 +1002,22 @@ macro_rules! __test_atomic_bool {
             }
         }
         #[test]
+        fn or() {
+            let a = <$atomic_type>::new(true);
+            test_swap_ordering(|order| a.or(false, order));
+            for order in swap_orderings() {
+                let a = <$atomic_type>::new(true);
+                a.or(false, order);
+                assert_eq!(a.load(Ordering::Relaxed), true);
+                let a = <$atomic_type>::new(true);
+                a.or(true, order);
+                assert_eq!(a.load(Ordering::Relaxed), true);
+                let a = <$atomic_type>::new(false);
+                a.or(false, order);
+                assert_eq!(a.load(Ordering::Relaxed), false);
+            }
+        }
+        #[test]
         fn fetch_xor() {
             let a = <$atomic_type>::new(true);
             test_swap_ordering(|order| assert_eq!(a.fetch_xor(false, order), true));
@@ -942,6 +1030,22 @@ macro_rules! __test_atomic_bool {
                 assert_eq!(a.load(Ordering::Relaxed), false);
                 let a = <$atomic_type>::new(false);
                 assert_eq!(a.fetch_xor(false, order), false);
+                assert_eq!(a.load(Ordering::Relaxed), false);
+            }
+        }
+        #[test]
+        fn xor() {
+            let a = <$atomic_type>::new(true);
+            test_swap_ordering(|order| a.xor(false, order));
+            for order in swap_orderings() {
+                let a = <$atomic_type>::new(true);
+                a.xor(false, order);
+                assert_eq!(a.load(Ordering::Relaxed), true);
+                let a = <$atomic_type>::new(true);
+                a.xor(true, order);
+                assert_eq!(a.load(Ordering::Relaxed), false);
+                let a = <$atomic_type>::new(false);
+                a.xor(false, order);
                 assert_eq!(a.load(Ordering::Relaxed), false);
             }
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -186,6 +186,51 @@ macro_rules! ifunc {
     }};
 }
 
+// We do not provide `nand` because it cannot be optimized on neither x86 nor MSP430.
+// https://godbolt.org/z/x88voWGov
+macro_rules! no_fetch_ops_impl {
+    ($atomic_type:ident, bool) => {
+        impl $atomic_type {
+            #[inline]
+            pub(crate) fn and(&self, val: bool, order: Ordering) {
+                self.fetch_and(val, order);
+            }
+            #[inline]
+            pub(crate) fn or(&self, val: bool, order: Ordering) {
+                self.fetch_or(val, order);
+            }
+            #[inline]
+            pub(crate) fn xor(&self, val: bool, order: Ordering) {
+                self.fetch_xor(val, order);
+            }
+        }
+    };
+    ($atomic_type:ident, $value_type:ident) => {
+        impl $atomic_type {
+            #[inline]
+            pub(crate) fn add(&self, val: $value_type, order: Ordering) {
+                self.fetch_add(val, order);
+            }
+            #[inline]
+            pub(crate) fn sub(&self, val: $value_type, order: Ordering) {
+                self.fetch_sub(val, order);
+            }
+            #[inline]
+            pub(crate) fn and(&self, val: $value_type, order: Ordering) {
+                self.fetch_and(val, order);
+            }
+            #[inline]
+            pub(crate) fn or(&self, val: $value_type, order: Ordering) {
+                self.fetch_or(val, order);
+            }
+            #[inline]
+            pub(crate) fn xor(&self, val: $value_type, order: Ordering) {
+                self.fetch_xor(val, order);
+            }
+        }
+    };
+}
+
 pub(crate) struct NoRefUnwindSafe(UnsafeCell<()>);
 // SAFETY: this is a marker type and we'll never access the value.
 unsafe impl Sync for NoRefUnwindSafe {}


### PR DESCRIPTION
This adds `Atomic{I,U}*::{add,sub,and,or,xor}` and `AtomicBool::{and,or,xor}` methods.

They are equivalent to the corresponding `fetch_*` methods, but do not return the previous value. They are intended for optimization on platforms that implement atomics using inline assembly, such as the MSP430.

Currently, optimizations by these methods are only guaranteed for MSP430; on x86, LLVM can optimize in most cases, so cases, where this would improve things, should be rare.

See https://github.com/pftbest/msp430-atomic/issues/7 for the context.
cc @cr1901 @YuhanLiin 