### PR TITLE
Improve support for AVR and MSP430 custom targets

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -48,6 +48,7 @@
   "ignorePaths": [
     // TODO
     "src/imp/**",
+    "target-specs/**",
     "**/linker.ld"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Fix build error when not using `portable_atomic_unsafe_assume_single_core` cfg on AVR and MSP430 custom targets. ([#50](https://github.com/taiki-e/portable-atomic/pull/50))
+
+  Since 0.3.11, atomic CAS was supported without the cfg on AVR and MSP430 builtin targets, but that change was not applied to custom targets.
+
 ## [0.3.17] - 2022-12-14
 
 - Optimize x86_64 128-bit atomic load/store on AMD CPU with AVX. ([#49](https://github.com/taiki-e/portable-atomic/pull/49))

--- a/target-specs/avr-unknown-gnu-atmega168.json
+++ b/target-specs/avr-unknown-gnu-atmega168.json
@@ -1,0 +1,20 @@
+{
+  "arch": "avr",
+  "atomic-cas": false,
+  "cpu": "atmega168",
+  "data-layout": "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
+  "eh-frame-header": false,
+  "exe-suffix": ".elf",
+  "late-link-args": {
+    "gcc": ["-lgcc"]
+  },
+  "linker": "avr-gcc",
+  "llvm-target": "avr-unknown-unknown",
+  "max-atomic-width": 0,
+  "pre-link-args": {
+    "gcc": ["-mmcu=atmega168"]
+  },
+  "relocation-model": "static",
+  "target-c-int-width": "16",
+  "target-pointer-width": "16"
+}

--- a/target-specs/msp430-unknown-none-elf.json
+++ b/target-specs/msp430-unknown-none-elf.json
@@ -1,0 +1,18 @@
+{
+  "arch": "msp430",
+  "asm-args": ["-mcpu=msp430"],
+  "atomic-cas": false,
+  "data-layout": "e-m:e-p:16:16-i32:16-i64:16-f32:16-f64:16-a:8-n8:16-S16",
+  "default-codegen-units": 1,
+  "eh-frame-header": false,
+  "emit-debug-gdb-scripts": false,
+  "linker": "msp430-elf-gcc",
+  "linker-is-gnu": false,
+  "llvm-target": "msp430-none-elf",
+  "max-atomic-width": 0,
+  "panic-strategy": "abort",
+  "relocation-model": "static",
+  "target-c-int-width": "16",
+  "target-pointer-width": "16",
+  "trap-unreachable": false
+}

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -9,14 +9,16 @@ trap -- 'exit 0' SIGINT
 
 default_targets=(
     # no atomic load/store (16-bit)
+    avr-unknown-gnu-atmega168 # for checking custom target
     avr-unknown-gnu-atmega328
     msp430-none-elf
+    msp430-unknown-none-elf # same as msp430-none-elf, but for checking custom target
     # no atomic load/store (32-bit)
     riscv32i-unknown-none-elf
     riscv32im-unknown-none-elf
     riscv32imc-unknown-none-elf
     # no atomic load/store (64-bit)
-    riscv64i-unknown-none-elf
+    riscv64i-unknown-none-elf # custom target
 
     # no atomic CAS (32-bit)
     thumbv4t-none-eabi


### PR DESCRIPTION
- Fix build error when not using `portable_atomic_unsafe_assume_single_core` cfg on AVR and MSP430 custom targets.

  Since 0.3.11, atomic CAS was supported without the cfg on AVR and MSP430 builtin targets, but that change was not applied to custom targets.