### PR TITLE
Add Cargo feature to use critical-section.

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -39,6 +39,7 @@ opensbi
 prefetcher
 quadword
 rclass
+reentrancy
 semihosting
 seqlock
 sifive

--- a/.github/.cspell/rust-dependencies.txt
+++ b/.github/.cspell/rust-dependencies.txt
@@ -4,11 +4,13 @@
 assertions
 atomic
 criterion
+critical
 crossbeam
 fastrand
 paste
 portable
 quickcheck
+section
 serde
 sptr
 static

--- a/.github/.cspell/rust-dependencies.txt
+++ b/.github/.cspell/rust-dependencies.txt
@@ -3,10 +3,12 @@
 
 assertions
 atomic
+cell
 criterion
 critical
 crossbeam
 fastrand
+once
 paste
 portable
 quickcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
     uses: taiki-e/workflows/.github/workflows/msrv.yml@main
     with:
       event_name: ${{ github.event_name }}
-      # Exclude serde feature because the MSRV when it is enabled depends on the MSRV of serde
-      args: -vvv --feature-powerset --depth 2 --optional-deps --exclude-features serde
+      # Exclude serde and critical-section features because the MSRV when it is enabled depends on the MSRV of them
+      args: -vvv --feature-powerset --depth 2 --optional-deps --exclude-features serde,critical-section
   tidy:
     uses: taiki-e/workflows/.github/workflows/tidy-rust.yml@main
 
@@ -346,7 +346,7 @@ jobs:
           MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-retag-fields -Zmiri-disable-isolation
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -Z randomize-layout
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -Z randomize-layout
-          QUICKCHECK_TESTS: 50
+          QUICKCHECK_TESTS: 20
 
   san:
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,9 @@ outline-atomics = []
 # - The MSRV when this feature enables depends on the MSRV of serde.
 serde = { version = "1.0.103", optional = true, default-features = false }
 
+# Use `critical-section`.
+critical-section = { version = "1", optional = true }
+
 [dev-dependencies]
 crossbeam-utils = "0.8"
 fastrand = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,9 +62,10 @@ serde = { version = "1.0.103", optional = true, default-features = false }
 critical-section = { version = "1", optional = true }
 
 [dev-dependencies]
-critical-section = { version = "1", features = ["std"] }
+critical-section = { version = "1", features = ["restore-state-bool"] }
 crossbeam-utils = "0.8"
 fastrand = "1"
+once_cell = "1"
 paste = "1"
 quickcheck = { default-features = false, git = "https://github.com/taiki-e/quickcheck.git", branch = "dev" } # https://github.com/BurntSushi/quickcheck/pull/304 + https://github.com/BurntSushi/quickcheck/pull/282 + lower MSRV
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ serde = { version = "1.0.103", optional = true, default-features = false }
 critical-section = { version = "1", optional = true }
 
 [dev-dependencies]
+critical-section = { version = "1", features = ["std"] }
 crossbeam-utils = "0.8"
 fastrand = "1"
 paste = "1"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ See [this list](https://github.com/taiki-e/portable-atomic/issues/10#issuecommen
   Note:
   - The MSRV when this feature enables depends on the MSRV of [serde].
 
+- **`critical-section`**<br>
+  When this feature is enabled, this crate uses [critical-section] to provide atomic CAS for targets where
+  it is not natively available. When enabling it, you should provide a suitable critical section implementation
+  for the current target, see the [critical-section] documentation for details on how to do so.
+
+  `critical-section` support is useful to get atomic CAS when `--cfg portable_atomic_unsafe_assume_single_core` can't be used,
+  such as multi-core targets, unprivileged code running under some RTOS, or environments where disabling interrupts
+  needs extra care due to e.g. real-time requirements.
+
+  Note that with the `critical-section` feature, critical sections are taken for all atomic operations, while with
+  `portable_atomic_unsafe_assume_single_core` some operations don't require disabling interrupts (loads and stores, but
+  additionally on MSP430 `add`, `sub`, `and`, `or`, `xor`, `not`). Therefore, for better performance, if
+  all the `critical-section` implementation for your target does is disable interrupts, prefer using
+  `--cfg portable_atomic_unsafe_assume_single_core` instead.
+  
+  Note:
+  - The MSRV when this feature enables depends on the MSRV of [critical-section].
+
 ## Optional cfg
 
 - **`--cfg portable_atomic_unsafe_assume_single_core`**<br>
@@ -125,6 +143,7 @@ See [this list](https://github.com/taiki-e/portable-atomic/issues/10#issuecommen
 [atomic-memcpy]: https://github.com/taiki-e/atomic-memcpy
 [rust-lang/rust#100650]: https://github.com/rust-lang/rust/issues/100650
 [serde]: https://github.com/serde-rs/serde
+[critical-section]: https://github.com/rust-embedded/critical-section
 
 ## License
 

--- a/src/imp/float.rs
+++ b/src/imp/float.rs
@@ -69,6 +69,7 @@ macro_rules! atomic_float {
             cfg(any(
                 not(portable_atomic_no_atomic_cas),
                 portable_atomic_unsafe_assume_single_core,
+                feature = "critical-section",
                 target_arch = "avr",
                 target_arch = "msp430"
             ))
@@ -78,6 +79,7 @@ macro_rules! atomic_float {
             cfg(any(
                 target_has_atomic = "ptr",
                 portable_atomic_unsafe_assume_single_core,
+                feature = "critical-section",
                 target_arch = "avr",
                 target_arch = "msp430"
             ))
@@ -189,6 +191,7 @@ atomic_float!(AtomicF32, f32, AtomicU32, u32, 4);
             any(
                 not(portable_atomic_no_atomic_cas),
                 portable_atomic_unsafe_assume_single_core,
+                feature = "critical-section",
                 target_arch = "avr",
                 target_arch = "msp430"
             )
@@ -205,6 +208,7 @@ atomic_float!(AtomicF32, f32, AtomicU32, u32, 4);
             any(
                 target_has_atomic = "ptr",
                 portable_atomic_unsafe_assume_single_core,
+                feature = "critical-section",
                 target_arch = "avr",
                 target_arch = "msp430"
             )

--- a/src/imp/interrupt/mod.rs
+++ b/src/imp/interrupt/mod.rs
@@ -31,8 +31,14 @@
 // called while interrupts are disabled, and since the load/store is
 // atomic, it is not affected by interrupts even if interrupts are enabled.
 #[cfg(not(target_arch = "avr"))]
+#[cfg(not(feature = "critical-section"))]
 use arch::atomic;
 
+#[cfg(not(target_arch = "avr"))]
+#[cfg(feature = "critical-section")]
+use core::sync::atomic;
+
+#[cfg(not(feature = "critical-section"))]
 #[cfg_attr(
     all(
         target_arch = "arm",
@@ -59,6 +65,16 @@ use core::{cell::UnsafeCell, sync::atomic::Ordering};
 // provided in a similar way by the Linux kernel to be lock-free.)
 const IS_ALWAYS_LOCK_FREE: bool = true;
 
+#[cfg(feature = "critical-section")]
+#[inline]
+fn with<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    critical_section::with(|_| f())
+}
+
+#[cfg(not(feature = "critical-section"))]
 #[inline]
 fn with<F, R>(f: F) -> R
 where

--- a/src/imp/interrupt/mod.rs
+++ b/src/imp/interrupt/mod.rs
@@ -22,6 +22,8 @@
 // [^avr1]: https://github.com/llvm/llvm-project/blob/llvmorg-15.0.0/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp#L1008
 // [^avr2]: https://github.com/llvm/llvm-project/blob/llvmorg-15.0.0/llvm/test/CodeGen/AVR/atomics/load16.ll#L5
 
+#![cfg_attr(test, allow(dead_code))]
+
 // On some platforms, atomic load/store can be implemented in a more efficient
 // way than disabling interrupts. On MSP430, some RMWs that do not return the
 // previous value can also be optimized.

--- a/src/imp/interrupt/mod.rs
+++ b/src/imp/interrupt/mod.rs
@@ -1,6 +1,13 @@
 // Critical section based fallback implementations
 //
-// Critical session (disabling interrupts) based fallback is not sound on multi-core systems.
+// This module supports two different critical section implementations:
+// - Built-in "disable all interrupts".
+// - Call into the `critical-section` crate (which allows the user to plug any implementation).
+//
+// The `critical-section`-based fallback is enabled when the user asks for it with the `critical-section`
+// Cargo feature.
+//
+// The "disable interrupts" fallback is not sound on multi-core systems.
 // Also, this uses privileged instructions to disable interrupts, so it usually
 // doesn't work on unprivileged mode. Using this fallback in an environment where privileged
 // instructions are not available is also usually considered **unsound**,

--- a/src/imp/interrupt/mod.rs
+++ b/src/imp/interrupt/mod.rs
@@ -62,9 +62,14 @@ mod arch;
 
 use core::{cell::UnsafeCell, sync::atomic::Ordering};
 
+// Critical section implementations might use locks internally.
+#[cfg(feature = "critical-section")]
+const IS_ALWAYS_LOCK_FREE: bool = false;
+
 // Consider atomic operations based on disabling interrupts on single-core
 // systems are lock-free. (We consider the pre-v6 ARM Linux's atomic operations
 // provided in a similar way by the Linux kernel to be lock-free.)
+#[cfg(not(feature = "critical-section"))]
 const IS_ALWAYS_LOCK_FREE: bool = true;
 
 #[cfg(feature = "critical-section")]

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -5,6 +5,7 @@
 #[cfg(not(any(
     portable_atomic_no_atomic_load_store,
     portable_atomic_unsafe_assume_single_core,
+    feature = "critical-section",
     target_arch = "avr",
     target_arch = "msp430",
 )))]
@@ -126,6 +127,7 @@ mod fallback;
 #[cfg(any(
     all(test, target_os = "none"),
     portable_atomic_unsafe_assume_single_core,
+    feature = "critical-section",
     target_arch = "avr",
     target_arch = "msp430",
 ))]
@@ -135,6 +137,7 @@ mod fallback;
     cfg(any(test, not(target_has_atomic = "ptr")))
 )]
 #[cfg(any(
+    feature = "critical-section",
     target_arch = "arm",
     target_arch = "avr",
     target_arch = "msp430",
@@ -155,6 +158,7 @@ pub(crate) mod float;
 #[cfg(not(any(
     portable_atomic_no_atomic_load_store,
     portable_atomic_unsafe_assume_single_core,
+    feature = "critical-section",
     target_arch = "avr",
     target_arch = "msp430",
 )))]
@@ -179,6 +183,7 @@ pub(crate) use self::riscv::{
 // no core Atomic{Isize,Usize,Bool,Ptr}/Atomic{I,U}{8,16} & assume single core => critical section based fallback
 #[cfg(any(
     portable_atomic_unsafe_assume_single_core,
+    feature = "critical-section",
     target_arch = "avr",
     target_arch = "msp430"
 ))]
@@ -192,6 +197,7 @@ pub(crate) use self::interrupt::{
 #[cfg(not(any(
     portable_atomic_no_atomic_load_store,
     portable_atomic_unsafe_assume_single_core,
+    feature = "critical-section",
     target_arch = "avr",
     target_arch = "msp430",
 )))]
@@ -204,7 +210,7 @@ pub(crate) use self::interrupt::{
 )]
 pub(crate) use self::core_atomic::{AtomicI32, AtomicU32};
 // RISC-V without A-extension
-#[cfg(not(portable_atomic_unsafe_assume_single_core))]
+#[cfg(not(any(portable_atomic_unsafe_assume_single_core, feature = "critical-section")))]
 #[cfg_attr(portable_atomic_no_cfg_target_has_atomic, cfg(portable_atomic_no_atomic_cas))]
 #[cfg_attr(not(portable_atomic_no_cfg_target_has_atomic), cfg(not(target_has_atomic = "ptr")))]
 #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
@@ -213,6 +219,7 @@ pub(crate) use self::riscv::{AtomicI32, AtomicU32};
 #[cfg(any(not(target_pointer_width = "16"), feature = "fallback"))]
 #[cfg(any(
     portable_atomic_unsafe_assume_single_core,
+    feature = "critical-section",
     target_arch = "avr",
     target_arch = "msp430"
 ))]
@@ -224,6 +231,7 @@ pub(crate) use self::interrupt::{AtomicI32, AtomicU32};
 #[cfg(not(any(
     portable_atomic_no_atomic_load_store,
     portable_atomic_unsafe_assume_single_core,
+    feature = "critical-section",
 )))]
 #[cfg_attr(portable_atomic_no_cfg_target_has_atomic, cfg(not(portable_atomic_no_atomic_64)))]
 #[cfg_attr(
@@ -241,7 +249,7 @@ pub(crate) use self::interrupt::{AtomicI32, AtomicU32};
 )]
 pub(crate) use self::core_atomic::{AtomicI64, AtomicU64};
 // RISC-V without A-extension
-#[cfg(not(portable_atomic_unsafe_assume_single_core))]
+#[cfg(not(any(portable_atomic_unsafe_assume_single_core, feature = "critical-section")))]
 #[cfg_attr(portable_atomic_no_cfg_target_has_atomic, cfg(portable_atomic_no_atomic_cas))]
 #[cfg_attr(not(portable_atomic_no_cfg_target_has_atomic), cfg(not(target_has_atomic = "ptr")))]
 #[cfg(target_arch = "riscv64")]
@@ -264,6 +272,7 @@ pub(crate) use self::fallback::{AtomicI64, AtomicU64};
 ))]
 #[cfg(any(
     portable_atomic_unsafe_assume_single_core,
+    feature = "critical-section",
     target_arch = "avr",
     target_arch = "msp430"
 ))]
@@ -331,6 +340,7 @@ pub(crate) use self::fallback::{AtomicI128, AtomicU128};
 #[cfg(feature = "fallback")]
 #[cfg(any(
     portable_atomic_unsafe_assume_single_core,
+    feature = "critical-section",
     target_arch = "avr",
     target_arch = "msp430"
 ))]

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -5,14 +5,17 @@
 #[cfg(not(any(
     portable_atomic_no_atomic_load_store,
     portable_atomic_unsafe_assume_single_core,
-    feature = "critical-section",
     target_arch = "avr",
     target_arch = "msp430",
 )))]
 #[cfg_attr(
+    portable_atomic_no_cfg_target_has_atomic,
+    cfg(not(all(feature = "critical-section", portable_atomic_no_atomic_cas)))
+)]
+#[cfg_attr(
     not(portable_atomic_no_cfg_target_has_atomic),
     cfg(not(all(
-        any(target_arch = "riscv32", target_arch = "riscv64"),
+        any(target_arch = "riscv32", target_arch = "riscv64", feature = "critical-section"),
         not(target_has_atomic = "ptr")
     )))
 )]
@@ -158,14 +161,17 @@ pub(crate) mod float;
 #[cfg(not(any(
     portable_atomic_no_atomic_load_store,
     portable_atomic_unsafe_assume_single_core,
-    feature = "critical-section",
     target_arch = "avr",
     target_arch = "msp430",
 )))]
 #[cfg_attr(
+    portable_atomic_no_cfg_target_has_atomic,
+    cfg(not(all(feature = "critical-section", portable_atomic_no_atomic_cas)))
+)]
+#[cfg_attr(
     not(portable_atomic_no_cfg_target_has_atomic),
     cfg(not(all(
-        any(target_arch = "riscv32", target_arch = "riscv64"),
+        any(target_arch = "riscv32", target_arch = "riscv64", feature = "critical-section"),
         not(target_has_atomic = "ptr")
     )))
 )]
@@ -197,14 +203,17 @@ pub(crate) use self::interrupt::{
 #[cfg(not(any(
     portable_atomic_no_atomic_load_store,
     portable_atomic_unsafe_assume_single_core,
-    feature = "critical-section",
     target_arch = "avr",
     target_arch = "msp430",
 )))]
 #[cfg_attr(
+    portable_atomic_no_cfg_target_has_atomic,
+    cfg(not(all(feature = "critical-section", portable_atomic_no_atomic_cas)))
+)]
+#[cfg_attr(
     not(portable_atomic_no_cfg_target_has_atomic),
     cfg(not(all(
-        any(target_arch = "riscv32", target_arch = "riscv64"),
+        any(target_arch = "riscv32", target_arch = "riscv64", feature = "critical-section"),
         not(target_has_atomic = "ptr")
     )))
 )]
@@ -231,9 +240,14 @@ pub(crate) use self::interrupt::{AtomicI32, AtomicU32};
 #[cfg(not(any(
     portable_atomic_no_atomic_load_store,
     portable_atomic_unsafe_assume_single_core,
-    feature = "critical-section",
 )))]
-#[cfg_attr(portable_atomic_no_cfg_target_has_atomic, cfg(not(portable_atomic_no_atomic_64)))]
+#[cfg_attr(
+    portable_atomic_no_cfg_target_has_atomic,
+    cfg(not(any(
+        portable_atomic_no_atomic_64,
+        not(all(feature = "critical-section", portable_atomic_no_atomic_cas))
+    )))
+)]
 #[cfg_attr(
     not(portable_atomic_no_cfg_target_has_atomic),
     cfg(any(
@@ -241,7 +255,11 @@ pub(crate) use self::interrupt::{AtomicI32, AtomicU32};
         all(
             not(any(target_pointer_width = "16", target_pointer_width = "32")),
             not(all(
-                any(target_arch = "riscv32", target_arch = "riscv64"),
+                any(
+                    target_arch = "riscv32",
+                    target_arch = "riscv64",
+                    feature = "critical-section"
+                ),
                 not(target_has_atomic = "ptr")
             ))
         )

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -179,7 +179,7 @@ pub(crate) use self::core_atomic::{
     AtomicBool, AtomicI16, AtomicI8, AtomicIsize, AtomicPtr, AtomicU16, AtomicU8, AtomicUsize,
 };
 // RISC-V without A-extension
-#[cfg(not(portable_atomic_unsafe_assume_single_core))]
+#[cfg(not(any(portable_atomic_unsafe_assume_single_core, feature = "critical-section")))]
 #[cfg_attr(portable_atomic_no_cfg_target_has_atomic, cfg(portable_atomic_no_atomic_cas))]
 #[cfg_attr(not(portable_atomic_no_cfg_target_has_atomic), cfg(not(target_has_atomic = "ptr")))]
 #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
@@ -243,10 +243,13 @@ pub(crate) use self::interrupt::{AtomicI32, AtomicU32};
 )))]
 #[cfg_attr(
     portable_atomic_no_cfg_target_has_atomic,
-    cfg(not(any(
-        portable_atomic_no_atomic_64,
-        not(all(feature = "critical-section", portable_atomic_no_atomic_cas))
-    )))
+    cfg(any(
+        not(portable_atomic_no_atomic_64),
+        all(
+            not(any(target_pointer_width = "16", target_pointer_width = "32")),
+            not(all(feature = "critical-section", portable_atomic_no_atomic_cas))
+        ),
+    ))
 )]
 #[cfg_attr(
     not(portable_atomic_no_cfg_target_has_atomic),

--- a/src/imp/msp430.rs
+++ b/src/imp/msp430.rs
@@ -9,6 +9,8 @@
 //
 // Note: Ordering is always SeqCst.
 
+#![cfg_attr(feature = "critical-section", allow(dead_code))]
+
 #[cfg(not(portable_atomic_no_asm))]
 use core::arch::asm;
 use core::{cell::UnsafeCell, sync::atomic::Ordering};

--- a/src/imp/riscv.rs
+++ b/src/imp/riscv.rs
@@ -8,6 +8,8 @@
 // Generated asm:
 // - riscv64gc https://godbolt.org/z/6z47vqj5v
 
+#![cfg_attr(feature = "critical-section", allow(dead_code))]
+
 #[cfg(not(portable_atomic_no_asm))]
 use core::arch::asm;
 use core::{cell::UnsafeCell, sync::atomic::Ordering};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,7 +341,7 @@ compile_error!(
     "cfg(portable_atomic_s_mode) may only be used together with cfg(portable_atomic_unsafe_assume_single_core)"
 );
 
-#[cfg(all(portable_atomic_unsafe_assume_single_core, feature="critical-section"))]
+#[cfg(all(portable_atomic_unsafe_assume_single_core, feature = "critical-section"))]
 compile_error!(
     "You may not enable feature `critical-section` and cfg(portable_atomic_unsafe_assume_single_core) at the same time."
 );
@@ -2656,7 +2656,7 @@ assert_eq!(some_var.swap(10, Ordering::Relaxed), 5);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2666,7 +2666,7 @@ assert_eq!(some_var.swap(10, Ordering::Relaxed), 5);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2721,7 +2721,7 @@ assert_eq!(some_var.load(Ordering::Relaxed), 10);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2731,7 +2731,7 @@ assert_eq!(some_var.load(Ordering::Relaxed), 10);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2795,7 +2795,7 @@ loop {
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2805,7 +2805,7 @@ loop {
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2851,7 +2851,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2861,7 +2861,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2902,7 +2902,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2912,7 +2912,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2947,7 +2947,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2957,7 +2957,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2998,7 +2998,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3008,7 +3008,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3046,7 +3046,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b100001);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3056,7 +3056,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b100001);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3103,7 +3103,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b100001);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3113,7 +3113,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b100001);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3151,7 +3151,7 @@ assert_eq!(foo.load(Ordering::SeqCst), !(0x13 & 0x31));
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3161,7 +3161,7 @@ assert_eq!(foo.load(Ordering::SeqCst), !(0x13 & 0x31));
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3199,7 +3199,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b111111);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3209,7 +3209,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b111111);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3256,7 +3256,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b111111);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3266,7 +3266,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b111111);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3304,7 +3304,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b011110);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3314,7 +3314,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b011110);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3361,7 +3361,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b011110);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3371,7 +3371,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b011110);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3429,7 +3429,7 @@ assert_eq!(x.load(Ordering::SeqCst), 9);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3439,7 +3439,7 @@ assert_eq!(x.load(Ordering::SeqCst), 9);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3507,7 +3507,7 @@ assert!(max_foo == 42);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3517,7 +3517,7 @@ assert!(max_foo == 42);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3568,7 +3568,7 @@ assert_eq!(min_foo, 12);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3578,7 +3578,7 @@ assert_eq!(min_foo, 12);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
-                        feature="critical-section",
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3613,6 +3613,7 @@ assert_eq!(foo.load(Ordering::Relaxed), !0);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3622,6 +3623,7 @@ assert_eq!(foo.load(Ordering::Relaxed), !0);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3660,6 +3662,7 @@ assert_eq!(foo.load(Ordering::Relaxed), !0);
                         cfg(any(
                             not(portable_atomic_no_atomic_cas),
                             portable_atomic_unsafe_assume_single_core,
+                            feature = "critical-section",
                             target_arch = "avr",
                             target_arch = "msp430"
                         ))
@@ -3669,6 +3672,7 @@ assert_eq!(foo.load(Ordering::Relaxed), !0);
                         cfg(any(
                             target_has_atomic = "ptr",
                             portable_atomic_unsafe_assume_single_core,
+                            feature = "critical-section",
                             target_arch = "avr",
                             target_arch = "msp430"
                         ))
@@ -3718,6 +3722,7 @@ assert_eq!(foo.load(Ordering::Relaxed), 5);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3727,6 +3732,7 @@ assert_eq!(foo.load(Ordering::Relaxed), 5);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
+                        feature = "critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3766,6 +3772,7 @@ assert_eq!(foo.load(Ordering::Relaxed), 5);
                         cfg(any(
                             not(portable_atomic_no_atomic_cas),
                             portable_atomic_unsafe_assume_single_core,
+                            feature = "critical-section",
                             target_arch = "avr",
                             target_arch = "msp430"
                         ))
@@ -3775,6 +3782,7 @@ assert_eq!(foo.load(Ordering::Relaxed), 5);
                         cfg(any(
                             target_has_atomic = "ptr",
                             portable_atomic_unsafe_assume_single_core,
+                            feature = "critical-section",
                             target_arch = "avr",
                             target_arch = "msp430"
                         ))
@@ -3937,7 +3945,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
                     portable_atomic_unsafe_assume_single_core,
-                    feature="critical-section",
+                    feature = "critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -3947,7 +3955,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     target_has_atomic = "ptr",
                     portable_atomic_unsafe_assume_single_core,
-                    feature="critical-section",
+                    feature = "critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -3980,7 +3988,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
                     portable_atomic_unsafe_assume_single_core,
-                    feature="critical-section",
+                    feature = "critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -3990,7 +3998,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     target_has_atomic = "ptr",
                     portable_atomic_unsafe_assume_single_core,
-                    feature="critical-section",
+                    feature = "critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4032,7 +4040,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
                     portable_atomic_unsafe_assume_single_core,
-                    feature="critical-section",
+                    feature = "critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4042,7 +4050,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     target_has_atomic = "ptr",
                     portable_atomic_unsafe_assume_single_core,
-                    feature="critical-section",
+                    feature = "critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4073,7 +4081,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
                     portable_atomic_unsafe_assume_single_core,
-                    feature="critical-section",
+                    feature = "critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4083,7 +4091,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     target_has_atomic = "ptr",
                     portable_atomic_unsafe_assume_single_core,
-                    feature="critical-section",
+                    feature = "critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4106,7 +4114,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
                     portable_atomic_unsafe_assume_single_core,
-                    feature="critical-section",
+                    feature = "critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4116,7 +4124,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     target_has_atomic = "ptr",
                     portable_atomic_unsafe_assume_single_core,
-                    feature="critical-section",
+                    feature = "critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4160,7 +4168,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
                     portable_atomic_unsafe_assume_single_core,
-                    feature="critical-section",
+                    feature = "critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4170,7 +4178,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     target_has_atomic = "ptr",
                     portable_atomic_unsafe_assume_single_core,
-                    feature="critical-section",
+                    feature = "critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4212,7 +4220,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
                     portable_atomic_unsafe_assume_single_core,
-                    feature="critical-section",
+                    feature = "critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4222,7 +4230,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     target_has_atomic = "ptr",
                     portable_atomic_unsafe_assume_single_core,
-                    feature="critical-section",
+                    feature = "critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4248,7 +4256,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
                     portable_atomic_unsafe_assume_single_core,
-                    feature="critical-section",
+                    feature = "critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4258,7 +4266,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     target_has_atomic = "ptr",
                     portable_atomic_unsafe_assume_single_core,
-                    feature="critical-section",
+                    feature = "critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4281,6 +4289,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
                     portable_atomic_unsafe_assume_single_core,
+                    feature = "critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4290,6 +4299,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     target_has_atomic = "ptr",
                     portable_atomic_unsafe_assume_single_core,
+                    feature = "critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4313,7 +4323,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
                     portable_atomic_unsafe_assume_single_core,
-                    feature="critical-section",
+                    feature = "critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4323,7 +4333,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     target_has_atomic = "ptr",
                     portable_atomic_unsafe_assume_single_core,
-                    feature="critical-section",
+                    feature = "critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,6 +341,11 @@ compile_error!(
     "cfg(portable_atomic_s_mode) may only be used together with cfg(portable_atomic_unsafe_assume_single_core)"
 );
 
+#[cfg(all(portable_atomic_unsafe_assume_single_core, feature="critical-section"))]
+compile_error!(
+    "You may not enable feature `critical-section` and cfg(portable_atomic_unsafe_assume_single_core) at the same time."
+);
+
 #[cfg(any(test, feature = "std"))]
 extern crate std;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -633,6 +633,7 @@ impl AtomicBool {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430",
         ))
@@ -642,6 +643,7 @@ impl AtomicBool {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -692,6 +694,7 @@ impl AtomicBool {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -701,6 +704,7 @@ impl AtomicBool {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -758,6 +762,7 @@ impl AtomicBool {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -767,6 +772,7 @@ impl AtomicBool {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -818,6 +824,7 @@ impl AtomicBool {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -827,6 +834,7 @@ impl AtomicBool {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -879,6 +887,7 @@ impl AtomicBool {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -888,6 +897,7 @@ impl AtomicBool {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -932,6 +942,7 @@ impl AtomicBool {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -941,6 +952,7 @@ impl AtomicBool {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -984,6 +996,7 @@ impl AtomicBool {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -993,6 +1006,7 @@ impl AtomicBool {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1045,6 +1059,7 @@ impl AtomicBool {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1054,6 +1069,7 @@ impl AtomicBool {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1097,6 +1113,7 @@ impl AtomicBool {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1106,6 +1123,7 @@ impl AtomicBool {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1158,6 +1176,7 @@ impl AtomicBool {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1167,6 +1186,7 @@ impl AtomicBool {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1206,6 +1226,7 @@ impl AtomicBool {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1215,6 +1236,7 @@ impl AtomicBool {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1263,6 +1285,7 @@ impl AtomicBool {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1272,6 +1295,7 @@ impl AtomicBool {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1333,6 +1357,7 @@ impl AtomicBool {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1342,6 +1367,7 @@ impl AtomicBool {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1605,6 +1631,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1614,6 +1641,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1657,6 +1685,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1666,6 +1695,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1723,6 +1753,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1732,6 +1763,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1807,6 +1839,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1816,6 +1849,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1878,6 +1912,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1887,6 +1922,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1931,6 +1967,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1940,6 +1977,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1980,6 +2018,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -1989,6 +2028,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -2041,6 +2081,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -2050,6 +2091,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -2117,6 +2159,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -2126,6 +2169,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -2191,6 +2235,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -2200,6 +2245,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -2264,6 +2310,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -2273,6 +2320,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -2301,6 +2349,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             not(portable_atomic_no_atomic_cas),
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -2310,6 +2359,7 @@ impl<T> AtomicPtr<T> {
         cfg(any(
             target_has_atomic = "ptr",
             portable_atomic_unsafe_assume_single_core,
+            feature = "critical-section",
             target_arch = "avr",
             target_arch = "msp430"
         ))
@@ -2601,6 +2651,7 @@ assert_eq!(some_var.swap(10, Ordering::Relaxed), 5);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2610,6 +2661,7 @@ assert_eq!(some_var.swap(10, Ordering::Relaxed), 5);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2664,6 +2716,7 @@ assert_eq!(some_var.load(Ordering::Relaxed), 10);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2673,6 +2726,7 @@ assert_eq!(some_var.load(Ordering::Relaxed), 10);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2736,6 +2790,7 @@ loop {
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2745,6 +2800,7 @@ loop {
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2790,6 +2846,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2799,6 +2856,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2839,6 +2897,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2848,6 +2907,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2882,6 +2942,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2891,6 +2952,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2931,6 +2993,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2940,6 +3003,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 10);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2977,6 +3041,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b100001);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -2986,6 +3051,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b100001);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3032,6 +3098,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b100001);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3041,6 +3108,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b100001);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3078,6 +3146,7 @@ assert_eq!(foo.load(Ordering::SeqCst), !(0x13 & 0x31));
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3087,6 +3156,7 @@ assert_eq!(foo.load(Ordering::SeqCst), !(0x13 & 0x31));
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3124,6 +3194,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b111111);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3133,6 +3204,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b111111);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3179,6 +3251,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b111111);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3188,6 +3261,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b111111);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3225,6 +3299,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b011110);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3234,6 +3309,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b011110);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3280,6 +3356,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b011110);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3289,6 +3366,7 @@ assert_eq!(foo.load(Ordering::SeqCst), 0b011110);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3346,6 +3424,7 @@ assert_eq!(x.load(Ordering::SeqCst), 9);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3355,6 +3434,7 @@ assert_eq!(x.load(Ordering::SeqCst), 9);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3422,6 +3502,7 @@ assert!(max_foo == 42);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3431,6 +3512,7 @@ assert!(max_foo == 42);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3481,6 +3563,7 @@ assert_eq!(min_foo, 12);
                     cfg(any(
                         not(portable_atomic_no_atomic_cas),
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3490,6 +3573,7 @@ assert_eq!(min_foo, 12);
                     cfg(any(
                         target_has_atomic = "ptr",
                         portable_atomic_unsafe_assume_single_core,
+                        feature="critical-section",
                         target_arch = "avr",
                         target_arch = "msp430"
                     ))
@@ -3848,6 +3932,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
                     portable_atomic_unsafe_assume_single_core,
+                    feature="critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -3857,6 +3942,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     target_has_atomic = "ptr",
                     portable_atomic_unsafe_assume_single_core,
+                    feature="critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -3889,6 +3975,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
                     portable_atomic_unsafe_assume_single_core,
+                    feature="critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -3898,6 +3985,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     target_has_atomic = "ptr",
                     portable_atomic_unsafe_assume_single_core,
+                    feature="critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -3939,6 +4027,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
                     portable_atomic_unsafe_assume_single_core,
+                    feature="critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -3948,6 +4037,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     target_has_atomic = "ptr",
                     portable_atomic_unsafe_assume_single_core,
+                    feature="critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -3978,6 +4068,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
                     portable_atomic_unsafe_assume_single_core,
+                    feature="critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -3987,6 +4078,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     target_has_atomic = "ptr",
                     portable_atomic_unsafe_assume_single_core,
+                    feature="critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4009,6 +4101,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
                     portable_atomic_unsafe_assume_single_core,
+                    feature="critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4018,6 +4111,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     target_has_atomic = "ptr",
                     portable_atomic_unsafe_assume_single_core,
+                    feature="critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4061,6 +4155,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
                     portable_atomic_unsafe_assume_single_core,
+                    feature="critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4070,6 +4165,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     target_has_atomic = "ptr",
                     portable_atomic_unsafe_assume_single_core,
+                    feature="critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4111,6 +4207,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
                     portable_atomic_unsafe_assume_single_core,
+                    feature="critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4120,6 +4217,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     target_has_atomic = "ptr",
                     portable_atomic_unsafe_assume_single_core,
+                    feature="critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4145,6 +4243,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
                     portable_atomic_unsafe_assume_single_core,
+                    feature="critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4154,6 +4253,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     target_has_atomic = "ptr",
                     portable_atomic_unsafe_assume_single_core,
+                    feature="critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4208,6 +4308,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     not(portable_atomic_no_atomic_cas),
                     portable_atomic_unsafe_assume_single_core,
+                    feature="critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4217,6 +4318,7 @@ This type has the same in-memory representation as the underlying floating point
                 cfg(any(
                     target_has_atomic = "ptr",
                     portable_atomic_unsafe_assume_single_core,
+                    feature="critical-section",
                     target_arch = "avr",
                     target_arch = "msp430"
                 ))
@@ -4279,6 +4381,7 @@ atomic_int!(AtomicU32, u32, 4);
             any(
                 not(portable_atomic_no_atomic_cas),
                 portable_atomic_unsafe_assume_single_core,
+                feature = "critical-section",
                 target_arch = "avr",
                 target_arch = "msp430"
             )
@@ -4295,6 +4398,7 @@ atomic_int!(AtomicU32, u32, 4);
             any(
                 target_has_atomic = "ptr",
                 portable_atomic_unsafe_assume_single_core,
+                feature = "critical-section",
                 target_arch = "avr",
                 target_arch = "msp430"
             )
@@ -4312,6 +4416,7 @@ atomic_int!(AtomicI64, i64, 8);
             any(
                 not(portable_atomic_no_atomic_cas),
                 portable_atomic_unsafe_assume_single_core,
+                feature = "critical-section",
                 target_arch = "avr",
                 target_arch = "msp430"
             )
@@ -4328,6 +4433,7 @@ atomic_int!(AtomicI64, i64, 8);
             any(
                 target_has_atomic = "ptr",
                 portable_atomic_unsafe_assume_single_core,
+                feature = "critical-section",
                 target_arch = "avr",
                 target_arch = "msp430"
             )
@@ -4370,6 +4476,7 @@ atomic_int!(AtomicU64, u64, 8);
     cfg(any(
         not(portable_atomic_no_atomic_cas),
         portable_atomic_unsafe_assume_single_core,
+        feature = "critical-section",
         target_arch = "avr",
         target_arch = "msp430"
     ))
@@ -4379,6 +4486,7 @@ atomic_int!(AtomicU64, u64, 8);
     cfg(any(
         target_has_atomic = "ptr",
         portable_atomic_unsafe_assume_single_core,
+        feature = "critical-section",
         target_arch = "avr",
         target_arch = "msp430"
     ))
@@ -4416,6 +4524,7 @@ atomic_int!(AtomicI128, i128, 16);
     cfg(any(
         not(portable_atomic_no_atomic_cas),
         portable_atomic_unsafe_assume_single_core,
+        feature = "critical-section",
         target_arch = "avr",
         target_arch = "msp430"
     ))
@@ -4425,6 +4534,7 @@ atomic_int!(AtomicI128, i128, 16);
     cfg(any(
         target_has_atomic = "ptr",
         portable_atomic_unsafe_assume_single_core,
+        feature = "critical-section",
         target_arch = "avr",
         target_arch = "msp430"
     ))

--- a/src/tests/critical_section_std.rs
+++ b/src/tests/critical_section_std.rs
@@ -1,0 +1,68 @@
+// Based on https://github.com/rust-embedded/critical-section/blob/v1.1.1/src/std.rs,
+// but compatible with Rust 1.59 that we run test.
+
+use std::{
+    cell::Cell,
+    mem::MaybeUninit,
+    sync::{Mutex, MutexGuard},
+};
+
+use once_cell::sync::Lazy;
+
+static GLOBAL_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+// This is initialized if a thread has acquired the CS, uninitialized otherwise.
+static mut GLOBAL_GUARD: MaybeUninit<MutexGuard<'static, ()>> = MaybeUninit::uninit();
+
+std::thread_local!(static IS_LOCKED: Cell<bool> = Cell::new(false));
+
+struct StdCriticalSection;
+critical_section::set_impl!(StdCriticalSection);
+
+unsafe impl critical_section::Impl for StdCriticalSection {
+    unsafe fn acquire() -> bool {
+        // Allow reentrancy by checking thread local state
+        IS_LOCKED.with(|l| {
+            if l.get() {
+                // CS already acquired in the current thread.
+                return true;
+            }
+
+            // Note: it is fine to set this flag *before* acquiring the mutex because it's thread local.
+            // No other thread can see its value, there's no potential for races.
+            // This way, we hold the mutex for slightly less time.
+            l.set(true);
+
+            // Not acquired in the current thread, acquire it.
+            let guard = match GLOBAL_MUTEX.lock() {
+                Ok(guard) => guard,
+                Err(err) => {
+                    // Ignore poison on the global mutex in case a panic occurred
+                    // while the mutex was held.
+                    err.into_inner()
+                }
+            };
+            unsafe {
+                GLOBAL_GUARD.write(guard);
+            }
+
+            false
+        })
+    }
+
+    unsafe fn release(nested_cs: bool) {
+        if !nested_cs {
+            // SAFETY: As per the acquire/release safety contract, release can only be called
+            // if the critical section is acquired in the current thread,
+            // in which case we know the GLOBAL_GUARD is initialized.
+            unsafe {
+                GLOBAL_GUARD.as_mut_ptr().drop_in_place();
+            }
+
+            // Note: it is fine to clear this flag *after* releasing the mutex because it's thread local.
+            // No other thread can see its value, there's no potential for races.
+            // This way, we hold the mutex for slightly less time.
+            IS_LOCKED.with(|l| l.set(false));
+        }
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -9,6 +9,8 @@
 #[macro_use]
 pub(crate) mod helper;
 
+#[cfg(feature = "critical-section")]
+mod critical_section_std;
 #[cfg(feature = "serde")]
 mod serde;
 

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -246,6 +246,10 @@ build() {
     )
     # outline-atomics　feature is no-op since https://github.com/taiki-e/portable-atomic/pull/57.
     args+=(--exclude-features "outline-atomics")
+    # critical-section requires 1.54
+    if [[ "${rustc_minor_version}" -lt 54 ]]; then
+        args+=(--exclude-features "critical-section")
+    fi
     case "${target}" in
         *-none* | *-cuda* | avr-* | *-esp-espidf)
             args+=(--exclude-features "std")
@@ -256,15 +260,15 @@ build() {
                         bpf*) args+=(--exclude portable-atomic-util) ;; # TODO, Arc can't be used here yet
                         *)
                             RUSTFLAGS="${target_rustflags} --cfg portable_atomic_unsafe_assume_single_core" \
-                                x_cargo "${args[@]}" --target-dir target/assume-single-core "$@"
+                                x_cargo "${args[@]}" --exclude-features "critical-section" --target-dir target/assume-single-core "$@"
                             case "${target}" in
                                 thumbv[4-5]t* | armv[4-5]t*)
                                     RUSTFLAGS="${target_rustflags} --cfg portable_atomic_unsafe_assume_single_core --cfg portable_atomic_disable_fiq" \
-                                        x_cargo "${args[@]}" --target-dir target/assume-single-core-disable-fiq "$@"
+                                        x_cargo "${args[@]}" --exclude-features "critical-section" --target-dir target/assume-single-core-disable-fiq "$@"
                                     ;;
                                 riscv*)
                                     RUSTFLAGS="${target_rustflags} --cfg portable_atomic_unsafe_assume_single_core --cfg portable_atomic_s_mode" \
-                                        x_cargo "${args[@]}" --target-dir target/assume-single-core-s-mode "$@"
+                                        x_cargo "${args[@]}" --exclude-features "critical-section" --target-dir target/assume-single-core-s-mode "$@"
                                     ;;
                             esac
                             ;;


### PR DESCRIPTION
I want to depreecate `atomic-polyfill` in favor of `portable-atomic`. This is the only thing left that `portable-atomic` can't do, so here it goes.

PR is still missing updating docs. I'll do it if you confirm you're onboard with the idea of supporting using `critical-section`.