### PR TITLE
Improve support for very old nightly

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -68,7 +68,22 @@ fn main() {
     }
     // asm stabilized in Rust 1.59 (nightly-2021-12-16): https://github.com/rust-lang/rust/pull/91728
     let no_asm = !version.probe(59, 2021, 12, 15);
+    let mut unstable_asm = false;
     if no_asm {
+        if version.nightly
+            && version.probe(46, 2020, 6, 20)
+            && (target_arch != "x86_64" || version.llvm >= 10)
+            && is_allowed_feature("asm")
+        {
+            // This feature was added in Rust 1.45 (nightly-2020-05-20), but
+            // concat! in asm! requires Rust 1.46 (nightly-2020-06-21).
+            // x86 intel syntax requires LLVM 10.
+            // The part of this feature we use has not been changed since nightly-2020-06-21
+            // until it was stabilized in nightly-2021-12-16, so it can be safely enabled in
+            // nightly, which is older than nightly-2021-12-16.
+            println!("cargo:rustc-cfg=portable_atomic_unstable_asm");
+            unstable_asm = true;
+        }
         println!("cargo:rustc-cfg=portable_atomic_no_asm");
     }
     // aarch64_target_feature stabilized in Rust 1.61 (nightly-2022-03-16): https://github.com/rust-lang/rust/pull/90621
@@ -82,8 +97,11 @@ fn main() {
 
     // feature(cfg_target_has_atomic) stabilized in Rust 1.60 (nightly-2022-02-11): https://github.com/rust-lang/rust/pull/93824
     if !version.probe(60, 2022, 2, 10) {
-        if version.nightly && is_allowed_feature("cfg_target_has_atomic") {
-            // This feature has not been changed since the change in nightly-2019-10-14
+        if version.nightly
+            && version.probe(40, 2019, 10, 13)
+            && is_allowed_feature("cfg_target_has_atomic")
+        {
+            // This feature has not been changed since the change in Rust 1.40 (nightly-2019-10-14)
             // until it was stabilized in nightly-2022-02-11, so it can be safely enabled in
             // nightly, which is older than nightly-2022-02-11.
             println!("cargo:rustc-cfg=portable_atomic_unstable_cfg_target_has_atomic");
@@ -150,6 +168,7 @@ fn main() {
             // It is unlikely that rustc will support that name, so we will ignore it for now.
             target_feature_if("cmpxchg16b", has_cmpxchg16b, &version, None, true);
             if version.nightly
+                && (!no_asm || unstable_asm)
                 && cfg!(feature = "fallback")
                 && cfg!(feature = "outline-atomics")
                 && is_allowed_feature("cmpxchg16b_target_feature")

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -26,12 +26,12 @@ mod aarch64;
     any(miri, portable_atomic_sanitize_thread),
     portable_atomic_new_atomic_intrinsics
 )))]
-#[cfg(any(not(portable_atomic_no_asm), portable_atomic_nightly))]
+#[cfg(any(not(portable_atomic_no_asm), portable_atomic_unstable_asm))]
 #[cfg(target_arch = "aarch64")]
 #[path = "atomic128/aarch64.rs"]
 mod aarch64;
 
-#[cfg(any(not(portable_atomic_no_asm), portable_atomic_nightly))]
+#[cfg(any(not(portable_atomic_no_asm), portable_atomic_unstable_asm))]
 #[cfg(any(
     target_feature = "cmpxchg16b",
     portable_atomic_target_feature = "cmpxchg16b",
@@ -84,10 +84,13 @@ mod riscv;
 #[cfg(any(
     test,
     not(any(
-        all(any(not(portable_atomic_no_asm), portable_atomic_nightly), target_arch = "aarch64"),
         all(
-            any(not(portable_atomic_no_asm), portable_atomic_nightly),
-            any(target_feature = "cmpxchg16b", portable_atomic_target_feature = "cmpxchg16b"),
+            any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
+            target_arch = "aarch64"
+        ),
+        all(
+            any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
+            any(target_feature = "cmpxchg16b", portable_atomic_target_feature = "cmpxchg16b",),
             target_arch = "x86_64",
         ),
         all(
@@ -263,13 +266,13 @@ pub(crate) use self::interrupt::{AtomicI64, AtomicU64};
 // Atomic{I,U}128
 // aarch64 stable
 #[cfg(all(
-    any(not(portable_atomic_no_asm), portable_atomic_nightly),
+    any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
     target_arch = "aarch64"
 ))]
 pub(crate) use self::aarch64::{AtomicI128, AtomicU128};
 // no core Atomic{I,U}128 & has cmpxchg16b => use cmpxchg16b
 #[cfg(all(
-    any(not(portable_atomic_no_asm), portable_atomic_nightly),
+    any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
     any(
         target_feature = "cmpxchg16b",
         portable_atomic_target_feature = "cmpxchg16b",
@@ -293,9 +296,9 @@ pub(crate) use self::s390x::{AtomicI128, AtomicU128};
 // no core Atomic{I,U}128 & has CAS => use lock-base fallback
 #[cfg(feature = "fallback")]
 #[cfg(not(any(
-    all(any(not(portable_atomic_no_asm), portable_atomic_nightly), target_arch = "aarch64"),
+    all(any(not(portable_atomic_no_asm), portable_atomic_unstable_asm), target_arch = "aarch64"),
     all(
-        any(not(portable_atomic_no_asm), portable_atomic_nightly),
+        any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
         any(
             target_feature = "cmpxchg16b",
             portable_atomic_target_feature = "cmpxchg16b",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,15 +206,16 @@ See [this list](https://github.com/taiki-e/portable-atomic/issues/10#issuecommen
     feature(asm_experimental_arch)
 )]
 // Old nightly only
-// These features are already stable or have already been removed from compilers,
+// These features are already stabilized or have already been removed from compilers,
 // and can safely be enabled for old nightly as long as version detection works.
-// cfg(cfg_target_has_atomic) on old nightly
+// - cfg(target_has_atomic)
+// - asm! on ARM, AArch64, RISC-V, x86_64
+// - llvm_asm! on AVR (tier 3) and MSP430 (tier 3)
+// - #[instruction_set] on non-Linux pre-v6 ARM (tier 3)
 #![cfg_attr(portable_atomic_unstable_cfg_target_has_atomic, feature(cfg_target_has_atomic))]
-// asm on old nightly
 #![cfg_attr(
     all(
-        portable_atomic_nightly,
-        portable_atomic_no_asm,
+        portable_atomic_unstable_asm,
         any(
             all(
                 any(target_arch = "arm", target_arch = "riscv32", target_arch = "riscv64"),
@@ -226,12 +227,10 @@ See [this list](https://github.com/taiki-e/portable-atomic/issues/10#issuecommen
     ),
     feature(asm)
 )]
-// llvm_asm on old nightly
 #![cfg_attr(
     all(any(target_arch = "avr", target_arch = "msp430"), portable_atomic_no_asm),
     feature(llvm_asm)
 )]
-// non-Linux armv4t (tier 3) on old nightly
 #![cfg_attr(
     all(
         portable_atomic_unstable_isa_attribute,
@@ -243,7 +242,7 @@ See [this list](https://github.com/taiki-e/portable-atomic/issues/10#issuecommen
     feature(isa_attribute)
 )]
 // Miri and/or ThreadSanitizer only
-// They do not support inline assembly, so we need to use unstable features instead of it.
+// They do not support inline assembly, so we need to use unstable features instead.
 // Since they require nightly compilers anyway, we can use the unstable features.
 #![cfg_attr(
     all(
@@ -4086,9 +4085,12 @@ atomic_int!(AtomicU64, u64, 8);
 #[cfg_attr(
     not(feature = "fallback"),
     cfg(any(
-        all(any(not(portable_atomic_no_asm), portable_atomic_nightly), target_arch = "aarch64"),
         all(
-            any(not(portable_atomic_no_asm), portable_atomic_nightly),
+            any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
+            target_arch = "aarch64"
+        ),
+        all(
+            any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
             any(
                 target_feature = "cmpxchg16b",
                 portable_atomic_target_feature = "cmpxchg16b",
@@ -4129,9 +4131,12 @@ atomic_int!(AtomicI128, i128, 16);
 #[cfg_attr(
     not(feature = "fallback"),
     cfg(any(
-        all(any(not(portable_atomic_no_asm), portable_atomic_nightly), target_arch = "aarch64"),
         all(
-            any(not(portable_atomic_no_asm), portable_atomic_nightly),
+            any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
+            target_arch = "aarch64"
+        ),
+        all(
+            any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
             any(
                 target_feature = "cmpxchg16b",
                 portable_atomic_target_feature = "cmpxchg16b",

--- a/src/tests/helper.rs
+++ b/src/tests/helper.rs
@@ -55,8 +55,7 @@ macro_rules! __test_atomic_int_load_store {
             static VAR: $atomic_type = <$atomic_type>::new(10);
             test_load_ordering(|order| VAR.load(order));
             test_store_ordering(|order| VAR.store(10, order));
-            for (load_order, store_order) in load_orderings().iter().copied().zip(store_orderings())
-            {
+            for (&load_order, &store_order) in load_orderings().iter().zip(&store_orderings()) {
                 assert_eq!(VAR.load(load_order), 10);
                 VAR.store(5, store_order);
                 assert_eq!(VAR.load(load_order), 5);
@@ -129,8 +128,7 @@ macro_rules! __test_atomic_float_load_store {
             static VAR: $atomic_type = <$atomic_type>::new(10.0);
             test_load_ordering(|order| VAR.load(order));
             test_store_ordering(|order| VAR.store(10.0, order));
-            for (load_order, store_order) in load_orderings().iter().copied().zip(store_orderings())
-            {
+            for (&load_order, &store_order) in load_orderings().iter().zip(&store_orderings()) {
                 assert_eq!(VAR.load(load_order), 10.0);
                 VAR.store(5.0, store_order);
                 assert_eq!(VAR.load(load_order), 5.0);
@@ -163,8 +161,7 @@ macro_rules! __test_atomic_bool_load_store {
             static VAR: $atomic_type = <$atomic_type>::new(false);
             test_load_ordering(|order| VAR.load(order));
             test_store_ordering(|order| VAR.store(false, order));
-            for (load_order, store_order) in load_orderings().iter().copied().zip(store_orderings())
-            {
+            for (&load_order, &store_order) in load_orderings().iter().zip(&store_orderings()) {
                 assert_eq!(VAR.load(load_order), false);
                 VAR.store(true, store_order);
                 assert_eq!(VAR.load(load_order), true);
@@ -201,8 +198,7 @@ macro_rules! __test_atomic_ptr_load_store {
             test_store_ordering(|order| VAR.store(ptr::null_mut(), order));
             let mut v = 1_u8;
             let p = &mut v as *mut u8;
-            for (load_order, store_order) in load_orderings().iter().copied().zip(store_orderings())
-            {
+            for (&load_order, &store_order) in load_orderings().iter().zip(&store_orderings()) {
                 assert_eq!(VAR.load(load_order), ptr::null_mut());
                 VAR.store(p, store_order);
                 assert_eq!(VAR.load(load_order), p);
@@ -227,7 +223,7 @@ macro_rules! __test_atomic_int {
         fn swap() {
             let a = <$atomic_type>::new(5);
             test_swap_ordering(|order| a.swap(5, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 assert_eq!(a.swap(10, order), 5);
                 assert_eq!(a.swap(5, order), 10);
             }
@@ -238,7 +234,7 @@ macro_rules! __test_atomic_int {
             test_compare_exchange_ordering(|success, failure| {
                 a.compare_exchange(5, 5, success, failure)
             });
-            for (success, failure) in compare_exchange_orderings() {
+            for &(success, failure) in &compare_exchange_orderings() {
                 let a = <$atomic_type>::new(5);
                 assert_eq!(a.compare_exchange(5, 10, success, failure), Ok(5));
                 assert_eq!(a.load(Ordering::Relaxed), 10);
@@ -252,7 +248,7 @@ macro_rules! __test_atomic_int {
             test_compare_exchange_ordering(|success, failure| {
                 a.compare_exchange_weak(4, 4, success, failure)
             });
-            for (success, failure) in compare_exchange_orderings() {
+            for &(success, failure) in &compare_exchange_orderings() {
                 let a = <$atomic_type>::new(4);
                 assert_eq!(a.compare_exchange_weak(6, 8, success, failure), Err(4));
                 let mut old = a.load(Ordering::Relaxed);
@@ -270,7 +266,7 @@ macro_rules! __test_atomic_int {
         fn fetch_add() {
             let a = <$atomic_type>::new(0);
             test_swap_ordering(|order| a.fetch_add(0, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(0);
                 assert_eq!(a.fetch_add(10, order), 0);
                 assert_eq!(a.load(Ordering::Relaxed), 10);
@@ -283,7 +279,7 @@ macro_rules! __test_atomic_int {
         fn add() {
             let a = <$atomic_type>::new(0);
             test_swap_ordering(|order| a.add(0, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(0);
                 a.add(10, order);
                 assert_eq!(a.load(Ordering::Relaxed), 10);
@@ -296,7 +292,7 @@ macro_rules! __test_atomic_int {
         fn fetch_sub() {
             let a = <$atomic_type>::new(20);
             test_swap_ordering(|order| a.fetch_sub(0, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(20);
                 assert_eq!(a.fetch_sub(10, order), 20);
                 assert_eq!(a.load(Ordering::Relaxed), 10);
@@ -309,7 +305,7 @@ macro_rules! __test_atomic_int {
         fn sub() {
             let a = <$atomic_type>::new(20);
             test_swap_ordering(|order| a.sub(0, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(20);
                 a.sub(10, order);
                 assert_eq!(a.load(Ordering::Relaxed), 10);
@@ -322,7 +318,7 @@ macro_rules! __test_atomic_int {
         fn fetch_and() {
             let a = <$atomic_type>::new(0b101101);
             test_swap_ordering(|order| a.fetch_and(0b101101, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(0b101101);
                 assert_eq!(a.fetch_and(0b110011, order), 0b101101);
                 assert_eq!(a.load(Ordering::Relaxed), 0b100001);
@@ -332,7 +328,7 @@ macro_rules! __test_atomic_int {
         fn and() {
             let a = <$atomic_type>::new(0b101101);
             test_swap_ordering(|order| a.and(0b101101, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(0b101101);
                 a.and(0b110011, order);
                 assert_eq!(a.load(Ordering::Relaxed), 0b100001);
@@ -342,7 +338,7 @@ macro_rules! __test_atomic_int {
         fn fetch_nand() {
             let a = <$atomic_type>::new(0x13);
             test_swap_ordering(|order| a.fetch_nand(0x31, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(0x13);
                 assert_eq!(a.fetch_nand(0x31, order), 0x13);
                 assert_eq!(a.load(Ordering::Relaxed), !(0x13 & 0x31));
@@ -352,7 +348,7 @@ macro_rules! __test_atomic_int {
         fn fetch_or() {
             let a = <$atomic_type>::new(0b101101);
             test_swap_ordering(|order| a.fetch_or(0, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(0b101101);
                 assert_eq!(a.fetch_or(0b110011, order), 0b101101);
                 assert_eq!(a.load(Ordering::Relaxed), 0b111111);
@@ -362,7 +358,7 @@ macro_rules! __test_atomic_int {
         fn or() {
             let a = <$atomic_type>::new(0b101101);
             test_swap_ordering(|order| a.or(0, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(0b101101);
                 a.or(0b110011, order);
                 assert_eq!(a.load(Ordering::Relaxed), 0b111111);
@@ -372,7 +368,7 @@ macro_rules! __test_atomic_int {
         fn fetch_xor() {
             let a = <$atomic_type>::new(0b101101);
             test_swap_ordering(|order| a.fetch_xor(0, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(0b101101);
                 assert_eq!(a.fetch_xor(0b110011, order), 0b101101);
                 assert_eq!(a.load(Ordering::Relaxed), 0b011110);
@@ -382,7 +378,7 @@ macro_rules! __test_atomic_int {
         fn xor() {
             let a = <$atomic_type>::new(0b101101);
             test_swap_ordering(|order| a.xor(0, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(0b101101);
                 a.xor(0b110011, order);
                 assert_eq!(a.load(Ordering::Relaxed), 0b011110);
@@ -392,7 +388,7 @@ macro_rules! __test_atomic_int {
         fn fetch_max() {
             let a = <$atomic_type>::new(23);
             test_swap_ordering(|order| a.fetch_max(23, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(23);
                 assert_eq!(a.fetch_max(22, order), 23);
                 assert_eq!(a.load(Ordering::Relaxed), 23);
@@ -409,7 +405,7 @@ macro_rules! __test_atomic_int {
         fn fetch_min() {
             let a = <$atomic_type>::new(23);
             test_swap_ordering(|order| a.fetch_min(23, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(23);
                 assert_eq!(a.fetch_min(24, order), 23);
                 assert_eq!(a.load(Ordering::Relaxed), 23);
@@ -424,7 +420,7 @@ macro_rules! __test_atomic_int {
         }
         ::quickcheck::quickcheck! {
             fn quickcheck_swap(x: $int_type, y: $int_type) -> bool {
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_eq!(a.swap(y, order), x);
                     assert_eq!(a.swap(x, order), y);
@@ -450,7 +446,7 @@ macro_rules! __test_atomic_int {
                         break z;
                     }
                 };
-                for (success, failure) in compare_exchange_orderings() {
+                for &(success, failure) in &compare_exchange_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_eq!(a.compare_exchange(x, y, success, failure).unwrap(), x);
                     assert_eq!(a.load(Ordering::Relaxed), y);
@@ -460,7 +456,7 @@ macro_rules! __test_atomic_int {
                 true
             }
             fn quickcheck_fetch_add(x: $int_type, y: $int_type) -> bool {
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_eq!(a.fetch_add(y, order), x);
                     assert_eq!(a.load(Ordering::Relaxed), x.wrapping_add(y));
@@ -471,7 +467,7 @@ macro_rules! __test_atomic_int {
                 true
             }
             fn quickcheck_fetch_sub(x: $int_type, y: $int_type) -> bool {
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_eq!(a.fetch_sub(y, order), x);
                     assert_eq!(a.load(Ordering::Relaxed), x.wrapping_sub(y));
@@ -482,7 +478,7 @@ macro_rules! __test_atomic_int {
                 true
             }
             fn quickcheck_fetch_and(x: $int_type, y: $int_type) -> bool {
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_eq!(a.fetch_and(y, order), x);
                     assert_eq!(a.load(Ordering::Relaxed), x & y);
@@ -493,7 +489,7 @@ macro_rules! __test_atomic_int {
                 true
             }
             fn quickcheck_fetch_nand(x: $int_type, y: $int_type) -> bool {
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_eq!(a.fetch_nand(y, order), x);
                     assert_eq!(a.load(Ordering::Relaxed), !(x & y));
@@ -504,7 +500,7 @@ macro_rules! __test_atomic_int {
                 true
             }
             fn quickcheck_fetch_or(x: $int_type, y: $int_type) -> bool {
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_eq!(a.fetch_or(y, order), x);
                     assert_eq!(a.load(Ordering::Relaxed), x | y);
@@ -515,7 +511,7 @@ macro_rules! __test_atomic_int {
                 true
             }
             fn quickcheck_fetch_xor(x: $int_type, y: $int_type) -> bool {
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_eq!(a.fetch_xor(y, order), x);
                     assert_eq!(a.load(Ordering::Relaxed), x ^ y);
@@ -526,7 +522,7 @@ macro_rules! __test_atomic_int {
                 true
             }
             fn quickcheck_fetch_max(x: $int_type, y: $int_type) -> bool {
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_eq!(a.fetch_max(y, order), x);
                     assert_eq!(a.load(Ordering::Relaxed), core::cmp::max(x, y));
@@ -537,7 +533,7 @@ macro_rules! __test_atomic_int {
                 true
             }
             fn quickcheck_fetch_min(x: $int_type, y: $int_type) -> bool {
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_eq!(a.fetch_min(y, order), x);
                     assert_eq!(a.load(Ordering::Relaxed), core::cmp::min(x, y));
@@ -692,7 +688,7 @@ macro_rules! __test_atomic_float {
         fn swap() {
             let a = <$atomic_type>::new(5.0);
             test_swap_ordering(|order| a.swap(5.0, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 assert_eq!(a.swap(10.0, order), 5.0);
                 assert_eq!(a.swap(5.0, order), 10.0);
             }
@@ -703,7 +699,7 @@ macro_rules! __test_atomic_float {
             test_compare_exchange_ordering(|success, failure| {
                 a.compare_exchange(5.0, 5.0, success, failure)
             });
-            for (success, failure) in compare_exchange_orderings() {
+            for &(success, failure) in &compare_exchange_orderings() {
                 let a = <$atomic_type>::new(5.0);
                 assert_eq!(a.compare_exchange(5.0, 10.0, success, failure), Ok(5.0));
                 assert_eq!(a.load(Ordering::Relaxed), 10.0);
@@ -717,7 +713,7 @@ macro_rules! __test_atomic_float {
             test_compare_exchange_ordering(|success, failure| {
                 a.compare_exchange_weak(4.0, 4.0, success, failure)
             });
-            for (success, failure) in compare_exchange_orderings() {
+            for &(success, failure) in &compare_exchange_orderings() {
                 let a = <$atomic_type>::new(4.0);
                 assert_eq!(a.compare_exchange_weak(6.0, 8.0, success, failure), Err(4.0));
                 let mut old = a.load(Ordering::Relaxed);
@@ -735,7 +731,7 @@ macro_rules! __test_atomic_float {
         fn fetch_add() {
             let a = <$atomic_type>::new(0.0);
             test_swap_ordering(|order| a.fetch_add(0.0, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(0.0);
                 assert_eq!(a.fetch_add(10.0, order), 0.0);
                 assert_eq!(a.load(Ordering::Relaxed), 10.0);
@@ -748,7 +744,7 @@ macro_rules! __test_atomic_float {
         fn fetch_sub() {
             let a = <$atomic_type>::new(20.0);
             test_swap_ordering(|order| a.fetch_sub(0.0, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(20.0);
                 assert_eq!(a.fetch_sub(10.0, order), 20.0);
                 assert_eq!(a.load(Ordering::Relaxed), 10.0);
@@ -761,7 +757,7 @@ macro_rules! __test_atomic_float {
         fn fetch_max() {
             let a = <$atomic_type>::new(23.0);
             test_swap_ordering(|order| a.fetch_max(23.0, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(23.0);
                 assert_eq!(a.fetch_max(22.0, order), 23.0);
                 assert_eq!(a.load(Ordering::Relaxed), 23.0);
@@ -773,7 +769,7 @@ macro_rules! __test_atomic_float {
         fn fetch_min() {
             let a = <$atomic_type>::new(23.0);
             test_swap_ordering(|order| a.fetch_min(23.0, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(23.0);
                 assert_eq!(a.fetch_min(24.0, order), 23.0);
                 assert_eq!(a.load(Ordering::Relaxed), 23.0);
@@ -785,7 +781,7 @@ macro_rules! __test_atomic_float {
         fn fetch_abs() {
             let a = <$atomic_type>::new(23.0);
             test_swap_ordering(|order| a.fetch_abs(order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(-23.0);
                 assert_eq!(a.fetch_abs(order), -23.0);
                 assert_eq!(a.load(Ordering::Relaxed), 23.0);
@@ -795,7 +791,7 @@ macro_rules! __test_atomic_float {
         }
         ::quickcheck::quickcheck! {
             fn quickcheck_swap(x: $float_type, y: $float_type) -> bool {
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_float_op_eq!(a.swap(y, order), x);
                     assert_float_op_eq!(a.swap(x, order), y);
@@ -809,7 +805,7 @@ macro_rules! __test_atomic_float {
                         break z;
                     }
                 };
-                for (success, failure) in compare_exchange_orderings() {
+                for &(success, failure) in &compare_exchange_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_float_op_eq!(a.compare_exchange(x, y, success, failure).unwrap(), x);
                     assert_float_op_eq!(a.load(Ordering::Relaxed), y);
@@ -827,7 +823,7 @@ macro_rules! __test_atomic_float {
                     // https://github.com/rust-lang/rust/issues/73288
                     return true;
                 }
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_float_op_eq!(a.fetch_add(y, order), x);
                     assert_float_op_eq!(a.load(Ordering::Relaxed), x + y);
@@ -843,7 +839,7 @@ macro_rules! __test_atomic_float {
                     // https://github.com/rust-lang/rust/issues/73288
                     return true;
                 }
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_float_op_eq!(a.fetch_sub(y, order), x);
                     assert_float_op_eq!(a.load(Ordering::Relaxed), x - y);
@@ -854,7 +850,7 @@ macro_rules! __test_atomic_float {
                 true
             }
             fn quickcheck_fetch_max(x: $float_type, y: $float_type) -> bool {
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_float_op_eq!(a.fetch_max(y, order), x);
                     assert_float_op_eq!(a.load(Ordering::Relaxed), x.max(y));
@@ -865,7 +861,7 @@ macro_rules! __test_atomic_float {
                 true
             }
             fn quickcheck_fetch_min(x: $float_type, y: $float_type) -> bool {
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_float_op_eq!(a.fetch_min(y, order), x);
                     assert_float_op_eq!(a.load(Ordering::Relaxed), x.min(y));
@@ -876,7 +872,7 @@ macro_rules! __test_atomic_float {
                 true
             }
             fn quickcheck_fetch_abs(x: $float_type) -> bool {
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_float_op_eq!(a.fetch_abs(order), x);
                     assert_float_op_eq!(a.fetch_abs(order), x.abs());
@@ -897,7 +893,7 @@ macro_rules! __test_atomic_bool {
         fn swap() {
             let a = <$atomic_type>::new(true);
             test_swap_ordering(|order| a.swap(true, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 assert_eq!(a.swap(false, order), true);
                 assert_eq!(a.swap(true, order), false);
             }
@@ -908,7 +904,7 @@ macro_rules! __test_atomic_bool {
             test_compare_exchange_ordering(|success, failure| {
                 a.compare_exchange(true, true, success, failure)
             });
-            for (success, failure) in compare_exchange_orderings() {
+            for &(success, failure) in &compare_exchange_orderings() {
                 let a = <$atomic_type>::new(true);
                 assert_eq!(a.compare_exchange(true, false, success, failure), Ok(true));
                 assert_eq!(a.load(Ordering::Relaxed), false);
@@ -922,7 +918,7 @@ macro_rules! __test_atomic_bool {
             test_compare_exchange_ordering(|success, failure| {
                 a.compare_exchange_weak(false, false, success, failure)
             });
-            for (success, failure) in compare_exchange_orderings() {
+            for &(success, failure) in &compare_exchange_orderings() {
                 let a = <$atomic_type>::new(false);
                 assert_eq!(a.compare_exchange_weak(true, true, success, failure), Err(false));
                 let mut old = a.load(Ordering::Relaxed);
@@ -940,7 +936,7 @@ macro_rules! __test_atomic_bool {
         fn fetch_and() {
             let a = <$atomic_type>::new(true);
             test_swap_ordering(|order| assert_eq!(a.fetch_and(true, order), true));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(true);
                 assert_eq!(a.fetch_and(false, order), true);
                 assert_eq!(a.load(Ordering::Relaxed), false);
@@ -956,7 +952,7 @@ macro_rules! __test_atomic_bool {
         fn and() {
             let a = <$atomic_type>::new(true);
             test_swap_ordering(|order| a.and(true, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(true);
                 a.and(false, order);
                 assert_eq!(a.load(Ordering::Relaxed), false);
@@ -972,7 +968,7 @@ macro_rules! __test_atomic_bool {
         fn fetch_nand() {
             let a = <$atomic_type>::new(true);
             test_swap_ordering(|order| assert_eq!(a.fetch_nand(false, order), true));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(true);
                 assert_eq!(a.fetch_nand(false, order), true);
                 assert_eq!(a.load(Ordering::Relaxed), true);
@@ -989,7 +985,7 @@ macro_rules! __test_atomic_bool {
         fn fetch_or() {
             let a = <$atomic_type>::new(true);
             test_swap_ordering(|order| assert_eq!(a.fetch_or(false, order), true));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(true);
                 assert_eq!(a.fetch_or(false, order), true);
                 assert_eq!(a.load(Ordering::Relaxed), true);
@@ -1005,7 +1001,7 @@ macro_rules! __test_atomic_bool {
         fn or() {
             let a = <$atomic_type>::new(true);
             test_swap_ordering(|order| a.or(false, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(true);
                 a.or(false, order);
                 assert_eq!(a.load(Ordering::Relaxed), true);
@@ -1021,7 +1017,7 @@ macro_rules! __test_atomic_bool {
         fn fetch_xor() {
             let a = <$atomic_type>::new(true);
             test_swap_ordering(|order| assert_eq!(a.fetch_xor(false, order), true));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(true);
                 assert_eq!(a.fetch_xor(false, order), true);
                 assert_eq!(a.load(Ordering::Relaxed), true);
@@ -1037,7 +1033,7 @@ macro_rules! __test_atomic_bool {
         fn xor() {
             let a = <$atomic_type>::new(true);
             test_swap_ordering(|order| a.xor(false, order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(true);
                 a.xor(false, order);
                 assert_eq!(a.load(Ordering::Relaxed), true);
@@ -1051,7 +1047,7 @@ macro_rules! __test_atomic_bool {
         }
         ::quickcheck::quickcheck! {
             fn quickcheck_swap(x: bool, y: bool) -> bool {
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_eq!(a.swap(y, order), x);
                     assert_eq!(a.swap(x, order), y);
@@ -1060,7 +1056,7 @@ macro_rules! __test_atomic_bool {
             }
             fn quickcheck_compare_exchange(x: bool, y: bool) -> bool {
                 let z = !y;
-                for (success, failure) in compare_exchange_orderings() {
+                for &(success, failure) in &compare_exchange_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_eq!(a.compare_exchange(x, y, success, failure).unwrap(), x);
                     assert_eq!(a.load(Ordering::Relaxed), y);
@@ -1070,7 +1066,7 @@ macro_rules! __test_atomic_bool {
                 true
             }
             fn quickcheck_fetch_and(x: bool, y: bool) -> bool {
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_eq!(a.fetch_and(y, order), x);
                     assert_eq!(a.load(Ordering::Relaxed), x & y);
@@ -1081,7 +1077,7 @@ macro_rules! __test_atomic_bool {
                 true
             }
             fn quickcheck_fetch_nand(x: bool, y: bool) -> bool {
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_eq!(a.fetch_nand(y, order), x);
                     assert_eq!(a.load(Ordering::Relaxed), !(x & y));
@@ -1092,7 +1088,7 @@ macro_rules! __test_atomic_bool {
                 true
             }
             fn quickcheck_fetch_or(x: bool, y: bool) -> bool {
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_eq!(a.fetch_or(y, order), x);
                     assert_eq!(a.load(Ordering::Relaxed), x | y);
@@ -1103,7 +1099,7 @@ macro_rules! __test_atomic_bool {
                 true
             }
             fn quickcheck_fetch_xor(x: bool, y: bool) -> bool {
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_eq!(a.fetch_xor(y, order), x);
                     assert_eq!(a.load(Ordering::Relaxed), x ^ y);
@@ -1127,7 +1123,7 @@ macro_rules! __test_atomic_ptr {
             let a = <$atomic_type>::new(ptr::null_mut());
             test_swap_ordering(|order| a.swap(ptr::null_mut(), order));
             let x = &mut 1;
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 assert_eq!(a.swap(x, order), ptr::null_mut());
                 assert_eq!(a.swap(ptr::null_mut(), order), x as _);
             }
@@ -1138,7 +1134,7 @@ macro_rules! __test_atomic_ptr {
             test_compare_exchange_ordering(|success, failure| {
                 a.compare_exchange(ptr::null_mut(), ptr::null_mut(), success, failure)
             });
-            for (success, failure) in compare_exchange_orderings() {
+            for &(success, failure) in &compare_exchange_orderings() {
                 let a = <$atomic_type>::new(ptr::null_mut());
                 let x = &mut 1;
                 assert_eq!(
@@ -1159,7 +1155,7 @@ macro_rules! __test_atomic_ptr {
             test_compare_exchange_ordering(|success, failure| {
                 a.compare_exchange_weak(ptr::null_mut(), ptr::null_mut(), success, failure)
             });
-            for (success, failure) in compare_exchange_orderings() {
+            for &(success, failure) in &compare_exchange_orderings() {
                 let a = <$atomic_type>::new(ptr::null_mut());
                 let x = &mut 1;
                 assert_eq!(a.compare_exchange_weak(x, x, success, failure), Err(ptr::null_mut()));
@@ -1198,7 +1194,7 @@ macro_rules! __test_atomic_int_pub {
         fn fetch_update() {
             let a = <$atomic_type>::new(7);
             test_compare_exchange_ordering(|set, fetch| a.fetch_update(set, fetch, |x| Some(x)));
-            for (success, failure) in compare_exchange_orderings() {
+            for &(success, failure) in &compare_exchange_orderings() {
                 let a = <$atomic_type>::new(7);
                 assert_eq!(a.fetch_update(success, failure, |_| None), Err(7));
                 assert_eq!(a.fetch_update(success, failure, |x| Some(x + 1)), Ok(7));
@@ -1215,7 +1211,7 @@ macro_rules! __test_atomic_float_pub {
         fn fetch_update() {
             let a = <$atomic_type>::new(7.0);
             test_compare_exchange_ordering(|set, fetch| a.fetch_update(set, fetch, |x| Some(x)));
-            for (success, failure) in compare_exchange_orderings() {
+            for &(success, failure) in &compare_exchange_orderings() {
                 let a = <$atomic_type>::new(7.0);
                 assert_eq!(a.fetch_update(success, failure, |_| None), Err(7.0));
                 assert_eq!(a.fetch_update(success, failure, |x| Some(x + 1.0)), Ok(7.0));
@@ -1239,7 +1235,7 @@ macro_rules! __test_atomic_bool_pub {
         fn fetch_not() {
             let a = <$atomic_type>::new(true);
             test_swap_ordering(|order| a.fetch_not(order));
-            for order in swap_orderings() {
+            for &order in &swap_orderings() {
                 let a = <$atomic_type>::new(true);
                 assert_eq!(a.fetch_not(order), true);
                 assert_eq!(a.load(Ordering::Relaxed), false);
@@ -1252,7 +1248,7 @@ macro_rules! __test_atomic_bool_pub {
         fn fetch_update() {
             let a = <$atomic_type>::new(false);
             test_compare_exchange_ordering(|set, fetch| a.fetch_update(set, fetch, |x| Some(x)));
-            for (success, failure) in compare_exchange_orderings() {
+            for &(success, failure) in &compare_exchange_orderings() {
                 let a = <$atomic_type>::new(false);
                 assert_eq!(a.fetch_update(success, failure, |_| None), Err(false));
                 assert_eq!(a.fetch_update(success, failure, |x| Some(!x)), Ok(false));
@@ -1269,7 +1265,7 @@ macro_rules! __test_atomic_bool_pub {
         }
         ::quickcheck::quickcheck! {
             fn quickcheck_fetch_not(x: bool, y: bool) -> bool {
-                for order in swap_orderings() {
+                for &order in &swap_orderings() {
                     let a = <$atomic_type>::new(x);
                     assert_eq!(a.fetch_not(order), x);
                     assert_eq!(a.load(Ordering::Relaxed), !x);
@@ -1290,7 +1286,7 @@ macro_rules! __test_atomic_ptr_pub {
         fn fetch_update() {
             let a = <$atomic_type>::new(ptr::null_mut());
             test_compare_exchange_ordering(|set, fetch| a.fetch_update(set, fetch, |x| Some(x)));
-            for (success, failure) in compare_exchange_orderings() {
+            for &(success, failure) in &compare_exchange_orderings() {
                 let a = <$atomic_type>::new(ptr::null_mut());
                 assert_eq!(a.fetch_update(success, failure, |_| None), Err(ptr::null_mut()));
                 assert_eq!(
@@ -1659,7 +1655,7 @@ impl FloatExt for f64 {
     }
 }
 
-#[track_caller]
+#[cfg_attr(not(portable_atomic_no_track_caller), track_caller)]
 pub(crate) fn assert_panic<T: std::fmt::Debug>(f: impl FnOnce() -> T) -> std::string::String {
     let backtrace = std::env::var_os("RUST_BACKTRACE");
     let hook = std::panic::take_hook();

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -167,7 +167,7 @@ build() {
     fi
     cfgs=$(RUSTC_BOOTSTRAP=1 rustc ${pre_args[@]+"${pre_args[@]}"} --print cfg "${target_flags[@]}")
     has_atomic_cas='1'
-    # target_has_atomic changed in 1.40.0-nightly https://github.com/rust-lang/rust/pull/65214
+    # target_has_atomic changed in 1.40.0-nightly: https://github.com/rust-lang/rust/pull/65214
     if [[ "${rustc_minor_version}" -gt 39 ]]; then
         if ! grep <<<"${cfgs}" -q 'target_has_atomic='; then
             has_atomic_cas=''


### PR DESCRIPTION
Tested on x86_64-unknown-linux-gnu and aarch64-unknown-linux-gnu.

```sh
cargo update -p serde --precise=1.0.103
cargo update -p serde_test --precise=1.0.103
cargo update -p syn --precise=1.0.90
cargo update -p proc-macro2 --precise=1.0.43
cargo +nightly-2020-06-21 test --all-features # has unstable asm
cargo +nightly-2020-06-20 test --all-features # no unstable asm
```

Note: Old nightly compilers are essentially fragile, so support for them is on a best-effort basis.