### PR TITLE
Add fetch_neg/neg/fetch_not/not

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,7 @@ jobs:
         target:
           - '' # x86_64-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
+          - i686-unknown-linux-gnu
           - powerpc64le-unknown-linux-gnu
           - s390x-unknown-linux-gnu
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Add `AtomicI*::{fetch_neg,neg}` and `AtomicF*::fetch_neg` methods.
+
+  `AtomicI*::neg` are equivalent to the corresponding `fetch_*` methods, but do not return the previous value. They are intended for optimization on platforms that have atomic instructions for the corresponding operation, such as x86's `lock neg`.
+
+  Currently, optimizations by these methods (`neg`) are only guaranteed for x86.
+
 ## [0.3.18] - 2022-12-15
 
 - Fix build error when not using `portable_atomic_unsafe_assume_single_core` cfg on AVR and MSP430 custom targets. ([#50](https://github.com/taiki-e/portable-atomic/pull/50))
@@ -27,6 +33,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 - Add `Atomic{I,U}*::{add,sub,and,or,xor}` and `AtomicBool::{and,or,xor}` methods. ([#47](https://github.com/taiki-e/portable-atomic/pull/47))
 
   They are equivalent to the corresponding `fetch_*` methods, but do not return the previous value. They are intended for optimization on platforms that implement atomics using inline assembly, such as the MSP430.
+
+  Currently, optimizations by these methods (`add`,`sub`,`and`,`or`,`xor`) are only guaranteed for MSP430; on x86, LLVM can optimize in most cases, so cases, where this would improve things, should be rare.
 
 - Various improvements to `portable_atomic_unsafe_assume_single_core` cfg. ([#44](https://github.com/taiki-e/portable-atomic/pull/44), [#40](https://github.com/taiki-e/portable-atomic/pull/40))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
   Currently, optimizations by these methods (`neg`) are only guaranteed for x86.
 
+- Add `Atomic{I,U}*::{fetch_not,not}` methods.
+
+  `Atomic{I,U}*::not` are equivalent to the corresponding `fetch_*` methods, but do not return the previous value. They are intended for optimization on platforms that have atomic instructions for the corresponding operation, such as x86's `lock not`, MSP430's `inv`.
+
+  Currently, optimizations by these methods (`not`) are only guaranteed for x86 and MSP430.
+
+  (Note: `AtomicBool` already has `fetch_not` and `not` methods.)
+
 ## [0.3.18] - 2022-12-15
 
 - Fix build error when not using `portable_atomic_unsafe_assume_single_core` cfg on AVR and MSP430 custom targets. ([#50](https://github.com/taiki-e/portable-atomic/pull/50))

--- a/src/imp/atomic128/aarch64.rs
+++ b/src/imp/atomic128/aarch64.rs
@@ -28,6 +28,9 @@
 // - https://lists.llvm.org/pipermail/llvm-dev/2016-May/099490.html
 // - https://lists.llvm.org/pipermail/llvm-dev/2018-June/123993.html
 //
+// Note: On Miri and ThreadSanitizer which do not support inline assembly, we don't use
+// this module and use intrinsics.rs instead.
+//
 // Refs:
 // - ARM Compiler armasm User Guide
 //   https://developer.arm.com/documentation/dui0801/latest

--- a/src/imp/atomic128/aarch64.rs
+++ b/src/imp/atomic128/aarch64.rs
@@ -960,8 +960,8 @@ unsafe fn atomic_umin(dst: *mut u128, val: u128, order: Ordering) -> u128 {
     }
 }
 
-atomic128!(AtomicI128, i128, atomic_max, atomic_min);
-atomic128!(AtomicU128, u128, atomic_umax, atomic_umin);
+atomic128!(int, AtomicI128, i128, atomic_max, atomic_min);
+atomic128!(uint, AtomicU128, u128, atomic_umax, atomic_umin);
 
 #[cfg(test)]
 mod tests {
@@ -997,8 +997,8 @@ mod tests_no_outline_atomics {
     // so we always use strong CAS.
     use self::atomic_compare_exchange as atomic_compare_exchange_weak;
 
-    atomic128!(AtomicI128, i128, atomic_max, atomic_min);
-    atomic128!(AtomicU128, u128, atomic_umax, atomic_umin);
+    atomic128!(int, AtomicI128, i128, atomic_max, atomic_min);
+    atomic128!(uint, AtomicU128, u128, atomic_umax, atomic_umin);
 
     mod tests {
         use super::*;

--- a/src/imp/atomic128/intrinsics.rs
+++ b/src/imp/atomic128/intrinsics.rs
@@ -405,7 +405,7 @@ unsafe fn atomic_umin(dst: *mut u128, val: u128, order: Ordering) -> u128 {
 }
 
 macro_rules! atomic128 {
-    ($atomic_type:ident, $int_type:ident, $atomic_max:ident, $atomic_min:ident) => {
+    (uint, $atomic_type:ident, $int_type:ident, $atomic_max:ident, $atomic_min:ident) => {
         #[repr(C, align(16))]
         pub(crate) struct $atomic_type {
             v: UnsafeCell<$int_type>,
@@ -584,10 +584,38 @@ macro_rules! atomic128 {
             }
         }
     };
+    (int, $atomic_type:ident, $int_type:ident, $atomic_max:ident, $atomic_min:ident) => {
+        atomic128!(uint, $atomic_type, $int_type, $atomic_max, $atomic_min);
+        impl $atomic_type {
+            #[inline]
+            pub(crate) fn fetch_neg(&self, order: Ordering) -> $int_type {
+                self.fetch_update_(order, |x| x.wrapping_neg())
+            }
+            #[inline]
+            pub(crate) fn neg(&self, order: Ordering) {
+                self.fetch_neg(order);
+            }
+            #[inline]
+            fn fetch_update_<F>(&self, set_order: Ordering, mut f: F) -> $int_type
+            where
+                F: FnMut($int_type) -> $int_type,
+            {
+                let fetch_order = crate::utils::strongest_failure_ordering(set_order);
+                let mut prev = self.load(fetch_order);
+                loop {
+                    let next = f(prev);
+                    match self.compare_exchange_weak(prev, next, set_order, fetch_order) {
+                        Ok(x) => return x,
+                        Err(next_prev) => prev = next_prev,
+                    }
+                }
+            }
+        }
+    };
 }
 
-atomic128!(AtomicI128, i128, atomic_max, atomic_min);
-atomic128!(AtomicU128, u128, atomic_umax, atomic_umin);
+atomic128!(int, AtomicI128, i128, atomic_max, atomic_min);
+atomic128!(uint, AtomicU128, u128, atomic_umax, atomic_umin);
 
 #[cfg(test)]
 mod tests {

--- a/src/imp/atomic128/intrinsics.rs
+++ b/src/imp/atomic128/intrinsics.rs
@@ -582,19 +582,16 @@ macro_rules! atomic128 {
                 // pointer passed in is valid because we got it from a reference.
                 unsafe { $atomic_min(self.v.get(), val, order) }
             }
-        }
-    };
-    (int, $atomic_type:ident, $int_type:ident, $atomic_max:ident, $atomic_min:ident) => {
-        atomic128!(uint, $atomic_type, $int_type, $atomic_max, $atomic_min);
-        impl $atomic_type {
+
             #[inline]
-            pub(crate) fn fetch_neg(&self, order: Ordering) -> $int_type {
-                self.fetch_update_(order, |x| x.wrapping_neg())
+            pub(crate) fn fetch_not(&self, order: Ordering) -> $int_type {
+                self.fetch_update_(order, |x| !x)
             }
             #[inline]
-            pub(crate) fn neg(&self, order: Ordering) {
-                self.fetch_neg(order);
+            pub(crate) fn not(&self, order: Ordering) {
+                self.fetch_not(order);
             }
+
             #[inline]
             fn fetch_update_<F>(&self, set_order: Ordering, mut f: F) -> $int_type
             where
@@ -609,6 +606,19 @@ macro_rules! atomic128 {
                         Err(next_prev) => prev = next_prev,
                     }
                 }
+            }
+        }
+    };
+    (int, $atomic_type:ident, $int_type:ident, $atomic_max:ident, $atomic_min:ident) => {
+        atomic128!(uint, $atomic_type, $int_type, $atomic_max, $atomic_min);
+        impl $atomic_type {
+            #[inline]
+            pub(crate) fn fetch_neg(&self, order: Ordering) -> $int_type {
+                self.fetch_update_(order, |x| x.wrapping_neg())
+            }
+            #[inline]
+            pub(crate) fn neg(&self, order: Ordering) {
+                self.fetch_neg(order);
             }
         }
     };

--- a/src/imp/atomic128/macros.rs
+++ b/src/imp/atomic128/macros.rs
@@ -1,6 +1,6 @@
 #[cfg(any(target_arch = "s390x", target_arch = "x86_64"))]
 macro_rules! atomic128 {
-    ($atomic_type:ident, $int_type:ident) => {
+    (uint, $atomic_type:ident, $int_type:ident) => {
         #[repr(C, align(16))]
         pub(crate) struct $atomic_type {
             v: core::cell::UnsafeCell<$int_type>,
@@ -203,11 +203,31 @@ macro_rules! atomic128 {
             }
         }
     };
+    (int, $atomic_type:ident, $int_type:ident) => {
+        atomic128!(uint, $atomic_type, $int_type);
+        impl $atomic_type {
+            #[inline]
+            pub(crate) fn fetch_neg(&self, order: Ordering) -> $int_type {
+                crate::utils::assert_swap_ordering(order);
+                // SAFETY: any data races are prevented by atomic intrinsics and the raw
+                // pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    atomic_update(self.v.get().cast(), order, |x| {
+                        (x as $int_type).wrapping_neg() as u128
+                    }) as $int_type
+                }
+            }
+            #[inline]
+            pub(crate) fn neg(&self, order: Ordering) {
+                self.fetch_neg(order);
+            }
+        }
+    };
 }
 
 #[cfg(any(target_arch = "aarch64", target_arch = "powerpc64"))]
 macro_rules! atomic128 {
-    ($atomic_type:ident, $int_type:ident, $atomic_max:ident, $atomic_min:ident) => {
+    (uint, $atomic_type:ident, $int_type:ident, $atomic_max:ident, $atomic_min:ident) => {
         #[repr(C, align(16))]
         pub(crate) struct $atomic_type {
             v: core::cell::UnsafeCell<$int_type>,
@@ -385,6 +405,35 @@ macro_rules! atomic128 {
                 // SAFETY: any data races are prevented by atomic intrinsics and the raw
                 // pointer passed in is valid because we got it from a reference.
                 unsafe { $atomic_min(self.v.get(), val, order) }
+            }
+        }
+    };
+    (int, $atomic_type:ident, $int_type:ident, $atomic_max:ident, $atomic_min:ident) => {
+        atomic128!(uint, $atomic_type, $int_type, $atomic_max, $atomic_min);
+        impl $atomic_type {
+            #[inline]
+            pub(crate) fn fetch_neg(&self, order: Ordering) -> $int_type {
+                // TODO: define atomic_neg function and use it
+                self.fetch_update_(order, |x| x.wrapping_neg())
+            }
+            #[inline]
+            pub(crate) fn neg(&self, order: Ordering) {
+                self.fetch_neg(order);
+            }
+            #[inline]
+            fn fetch_update_<F>(&self, set_order: Ordering, mut f: F) -> $int_type
+            where
+                F: FnMut($int_type) -> $int_type,
+            {
+                let fetch_order = crate::utils::strongest_failure_ordering(set_order);
+                let mut prev = self.load(fetch_order);
+                loop {
+                    let next = f(prev);
+                    match self.compare_exchange_weak(prev, next, set_order, fetch_order) {
+                        Ok(x) => return x,
+                        Err(next_prev) => prev = next_prev,
+                    }
+                }
             }
         }
     };

--- a/src/imp/atomic128/powerpc64.rs
+++ b/src/imp/atomic128/powerpc64.rs
@@ -13,6 +13,9 @@
 // for the compiler to insert operations that might clear the reservation between
 // LL and SC. See aarch64.rs for details.
 //
+// Note: On Miri and ThreadSanitizer which do not support inline assembly, we don't use
+// this module and use intrinsics.rs instead.
+//
 // Refs:
 // - Power ISA https://openpowerfoundation.org/specifications/isa
 // - AIX Assembler language reference https://www.ibm.com/docs/en/aix/7.3?topic=aix-assembler-language-reference

--- a/src/imp/atomic128/powerpc64.rs
+++ b/src/imp/atomic128/powerpc64.rs
@@ -689,8 +689,8 @@ unsafe fn atomic_umin(dst: *mut u128, val: u128, order: Ordering) -> u128 {
     }
 }
 
-atomic128!(AtomicI128, i128, atomic_max, atomic_min);
-atomic128!(AtomicU128, u128, atomic_umax, atomic_umin);
+atomic128!(int, AtomicI128, i128, atomic_max, atomic_min);
+atomic128!(uint, AtomicU128, u128, atomic_umax, atomic_umin);
 
 #[cfg(test)]
 mod tests {

--- a/src/imp/atomic128/s390x.rs
+++ b/src/imp/atomic128/s390x.rs
@@ -223,8 +223,8 @@ const fn is_always_lock_free() -> bool {
 }
 use is_always_lock_free as is_lock_free;
 
-atomic128!(AtomicI128, i128);
-atomic128!(AtomicU128, u128);
+atomic128!(int, AtomicI128, i128);
+atomic128!(uint, AtomicU128, u128);
 
 #[cfg(test)]
 mod tests {

--- a/src/imp/atomic128/x86_64.rs
+++ b/src/imp/atomic128/x86_64.rs
@@ -433,8 +433,8 @@ const fn is_always_lock_free() -> bool {
     cfg!(any(target_feature = "cmpxchg16b", portable_atomic_target_feature = "cmpxchg16b",))
 }
 
-atomic128!(AtomicI128, i128);
-atomic128!(AtomicU128, u128);
+atomic128!(int, AtomicI128, i128);
+atomic128!(uint, AtomicU128, u128);
 
 #[allow(clippy::undocumented_unsafe_blocks, clippy::wildcard_imports)]
 #[cfg(test)]
@@ -598,8 +598,8 @@ mod tests_no_cmpxchg16b {
     }
     use is_always_lock_free as is_lock_free;
 
-    atomic128!(AtomicI128, i128);
-    atomic128!(AtomicU128, u128);
+    atomic128!(int, AtomicI128, i128);
+    atomic128!(uint, AtomicU128, u128);
 
     test_atomic_int!(i128);
     test_atomic_int!(u128);

--- a/src/imp/core_atomic.rs
+++ b/src/imp/core_atomic.rs
@@ -169,7 +169,7 @@ impl<T> core::ops::DerefMut for AtomicPtr<T> {
 }
 
 macro_rules! atomic_int {
-    ($($atomic_type:ident($int_type:ident)),*) => {$(
+    (uint, $atomic_type:ident, $int_type:ident) => {
         #[repr(transparent)]
         pub(crate) struct $atomic_type {
             inner: core::sync::atomic::$atomic_type,
@@ -362,13 +362,42 @@ macro_rules! atomic_int {
                 &mut self.inner
             }
         }
-    )*};
+    };
+    (int, $atomic_type:ident, $int_type:ident) => {
+        atomic_int!(uint, $atomic_type, $int_type);
+        #[cfg_attr(
+            portable_atomic_no_cfg_target_has_atomic,
+            cfg(not(portable_atomic_no_atomic_cas))
+        )]
+        #[cfg_attr(not(portable_atomic_no_cfg_target_has_atomic), cfg(target_has_atomic = "ptr"))]
+        impl $atomic_type {
+            #[inline]
+            pub(crate) fn fetch_neg(&self, order: Ordering) -> $int_type {
+                self.fetch_update_(order, |x| x.wrapping_neg())
+            }
+            #[cfg(not(all(
+                not(any(miri, portable_atomic_sanitize_thread)),
+                any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
+                any(target_arch = "x86", target_arch = "x86_64")
+            )))]
+            #[inline]
+            pub(crate) fn neg(&self, order: Ordering) {
+                self.fetch_neg(order);
+            }
+        }
+    };
 }
 
-atomic_int!(AtomicIsize(isize), AtomicUsize(usize));
-atomic_int!(AtomicI8(i8), AtomicI16(i16), AtomicU8(u8), AtomicU16(u16));
+atomic_int!(int, AtomicIsize, isize);
+atomic_int!(uint, AtomicUsize, usize);
+atomic_int!(int, AtomicI8, i8);
+atomic_int!(uint, AtomicU8, u8);
+atomic_int!(int, AtomicI16, i16);
+atomic_int!(uint, AtomicU16, u16);
 #[cfg(not(target_pointer_width = "16"))] // cfg(target_has_atomic_load_store = "32")
-atomic_int!(AtomicI32(i32), AtomicU32(u32));
+atomic_int!(int, AtomicI32, i32);
+#[cfg(not(target_pointer_width = "16"))] // cfg(target_has_atomic_load_store = "32")
+atomic_int!(uint, AtomicU32, u32);
 #[cfg_attr(portable_atomic_no_cfg_target_has_atomic, cfg(not(portable_atomic_no_atomic_64)))]
 #[cfg_attr(
     not(portable_atomic_no_cfg_target_has_atomic),
@@ -377,4 +406,13 @@ atomic_int!(AtomicI32(i32), AtomicU32(u32));
         not(any(target_pointer_width = "16", target_pointer_width = "32"))
     )) // cfg(target_has_atomic_load_store = "64")
 )]
-atomic_int!(AtomicI64(i64), AtomicU64(u64));
+atomic_int!(int, AtomicI64, i64);
+#[cfg_attr(portable_atomic_no_cfg_target_has_atomic, cfg(not(portable_atomic_no_atomic_64)))]
+#[cfg_attr(
+    not(portable_atomic_no_cfg_target_has_atomic),
+    cfg(any(
+        target_has_atomic = "64",
+        not(any(target_pointer_width = "16", target_pointer_width = "32"))
+    )) // cfg(target_has_atomic_load_store = "64")
+)]
+atomic_int!(uint, AtomicU64, u64);

--- a/src/imp/fallback/imp.rs
+++ b/src/imp/fallback/imp.rs
@@ -305,6 +305,20 @@ macro_rules! atomic {
                 self.write(core::cmp::min(result, val), &guard);
                 result
             }
+
+            #[cfg(any(test, not(portable_atomic_cmpxchg16b_dynamic)))]
+            #[inline]
+            pub(crate) fn fetch_not(&self, _order: Ordering) -> $int_type {
+                let guard = lock(self.v.get() as usize).write();
+                let result = self.read(&guard);
+                self.write(!result, &guard);
+                result
+            }
+            #[cfg(any(test, not(portable_atomic_cmpxchg16b_dynamic)))]
+            #[inline]
+            pub(crate) fn not(&self, order: Ordering) {
+                self.fetch_not(order);
+            }
         }
     };
     (int, $atomic_type:ident, $int_type:ident, $align:expr) => {

--- a/src/imp/fallback/imp.rs
+++ b/src/imp/fallback/imp.rs
@@ -32,7 +32,7 @@ fn lock(addr: usize) -> &'static SeqLock {
 }
 
 macro_rules! atomic {
-    ($atomic_type:ident, $int_type:ident, $align:expr) => {
+    (uint, $atomic_type:ident, $int_type:ident, $align:expr) => {
         #[repr(C, align($align))]
         pub(crate) struct $atomic_type {
             v: UnsafeCell<$int_type>,
@@ -307,6 +307,24 @@ macro_rules! atomic {
             }
         }
     };
+    (int, $atomic_type:ident, $int_type:ident, $align:expr) => {
+        atomic!(uint, $atomic_type, $int_type, $align);
+        impl $atomic_type {
+            #[cfg(any(test, not(portable_atomic_cmpxchg16b_dynamic)))]
+            #[inline]
+            pub(crate) fn fetch_neg(&self, _order: Ordering) -> $int_type {
+                let guard = lock(self.v.get() as usize).write();
+                let result = self.read(&guard);
+                self.write(result.wrapping_neg(), &guard);
+                result
+            }
+            #[cfg(any(test, not(portable_atomic_cmpxchg16b_dynamic)))]
+            #[inline]
+            pub(crate) fn neg(&self, order: Ordering) {
+                self.fetch_neg(order);
+            }
+        }
+    };
 }
 
 #[cfg(any(target_pointer_width = "16", target_pointer_width = "32"))]
@@ -315,18 +333,18 @@ macro_rules! atomic {
     not(portable_atomic_no_cfg_target_has_atomic),
     cfg(any(test, not(target_has_atomic = "64")))
 )]
-atomic!(AtomicI64, i64, 8);
+atomic!(int, AtomicI64, i64, 8);
 #[cfg(any(target_pointer_width = "16", target_pointer_width = "32"))]
 #[cfg_attr(portable_atomic_no_cfg_target_has_atomic, cfg(any(test, portable_atomic_no_atomic_64)))]
 #[cfg_attr(
     not(portable_atomic_no_cfg_target_has_atomic),
     cfg(any(test, not(target_has_atomic = "64")))
 )]
-atomic!(AtomicU64, u64, 8);
+atomic!(uint, AtomicU64, u64, 8);
 
 #[cfg(any(test, not(portable_atomic_cmpxchg16b_dynamic)))]
-atomic!(AtomicI128, i128, 16);
-atomic!(AtomicU128, u128, 16);
+atomic!(int, AtomicI128, i128, 16);
+atomic!(uint, AtomicU128, u128, 16);
 
 #[cfg(test)]
 mod tests {

--- a/src/imp/float.rs
+++ b/src/imp/float.rs
@@ -165,6 +165,12 @@ macro_rules! atomic_float {
             }
 
             #[inline]
+            pub(crate) fn fetch_neg(&self, order: Ordering) -> $float_type {
+                const NEG_MASK: $int_type = !0 / 2 + 1;
+                $float_type::from_bits(self.as_bits().fetch_xor(NEG_MASK, order))
+            }
+
+            #[inline]
             pub(crate) fn fetch_abs(&self, order: Ordering) -> $float_type {
                 const ABS_MASK: $int_type = !0 / 2;
                 $float_type::from_bits(self.as_bits().fetch_and(ABS_MASK, order))

--- a/src/imp/interrupt/mod.rs
+++ b/src/imp/interrupt/mod.rs
@@ -444,9 +444,9 @@ macro_rules! atomic_int {
             }
         }
     };
-    (load_store_atomic, $atomic_type:ident, $int_type:ident, $align:expr) => {
+    ($kind:ident, load_store_atomic, $atomic_type:ident, $int_type:ident, $align:expr) => {
         atomic_int!(base, $atomic_type, $int_type, $align);
-        atomic_int!(cas, $atomic_type, $int_type);
+        atomic_int!($kind, cas, $atomic_type, $int_type);
         impl $atomic_type {
             #[inline]
             #[cfg_attr(all(debug_assertions, not(portable_atomic_no_track_caller)), track_caller)]
@@ -532,9 +532,11 @@ macro_rules! atomic_int {
             }
         }
     };
-    (load_store_critical_session, $atomic_type:ident, $int_type:ident, $align:expr) => {
+    (
+        $kind:ident, load_store_critical_session, $atomic_type:ident, $int_type:ident, $align:expr
+    ) => {
         atomic_int!(base, $atomic_type, $int_type, $align);
-        atomic_int!(cas, $atomic_type, $int_type);
+        atomic_int!($kind, cas, $atomic_type, $int_type);
         no_fetch_ops_impl!($atomic_type, $int_type);
         impl $atomic_type {
             #[inline]
@@ -558,7 +560,7 @@ macro_rules! atomic_int {
             }
         }
     };
-    (cas, $atomic_type:ident, $int_type:ident) => {
+    (uint, cas, $atomic_type:ident, $int_type:ident) => {
         impl $atomic_type {
             #[inline]
             pub(crate) fn swap(&self, val: $int_type, _order: Ordering) -> $int_type {
@@ -701,56 +703,76 @@ macro_rules! atomic_int {
             }
         }
     };
+    (int, cas, $atomic_type:ident, $int_type:ident) => {
+        atomic_int!(uint, cas, $atomic_type, $int_type);
+        impl $atomic_type {
+            #[inline]
+            pub(crate) fn fetch_neg(&self, _order: Ordering) -> $int_type {
+                // SAFETY: any data races are prevented by disabling interrupts (see
+                // module-level comments) and the raw pointer is valid because we got it
+                // from a reference.
+                with(|| unsafe {
+                    let result = self.v.get().read();
+                    self.v.get().write(result.wrapping_neg());
+                    result
+                })
+            }
+            #[inline]
+            pub(crate) fn neg(&self, order: Ordering) {
+                self.fetch_neg(order);
+            }
+        }
+    };
 }
 
 #[cfg(target_pointer_width = "16")]
-atomic_int!(load_store_atomic, AtomicIsize, isize, 2);
+atomic_int!(int, load_store_atomic, AtomicIsize, isize, 2);
 #[cfg(target_pointer_width = "16")]
-atomic_int!(load_store_atomic, AtomicUsize, usize, 2);
+atomic_int!(uint, load_store_atomic, AtomicUsize, usize, 2);
 #[cfg(target_pointer_width = "32")]
-atomic_int!(load_store_atomic, AtomicIsize, isize, 4);
+atomic_int!(int, load_store_atomic, AtomicIsize, isize, 4);
 #[cfg(target_pointer_width = "32")]
-atomic_int!(load_store_atomic, AtomicUsize, usize, 4);
+atomic_int!(uint, load_store_atomic, AtomicUsize, usize, 4);
 #[cfg(target_pointer_width = "64")]
-atomic_int!(load_store_atomic, AtomicIsize, isize, 8);
+atomic_int!(int, load_store_atomic, AtomicIsize, isize, 8);
 #[cfg(target_pointer_width = "64")]
-atomic_int!(load_store_atomic, AtomicUsize, usize, 8);
+atomic_int!(uint, load_store_atomic, AtomicUsize, usize, 8);
 #[cfg(target_pointer_width = "128")]
-atomic_int!(load_store_atomic, AtomicIsize, isize, 16);
+atomic_int!(int, load_store_atomic, AtomicIsize, isize, 16);
 #[cfg(target_pointer_width = "128")]
-atomic_int!(load_store_atomic, AtomicUsize, usize, 16);
+atomic_int!(uint, load_store_atomic, AtomicUsize, usize, 16);
 
-atomic_int!(load_store_atomic, AtomicI8, i8, 1);
-atomic_int!(load_store_atomic, AtomicU8, u8, 1);
-atomic_int!(load_store_atomic, AtomicI16, i16, 2);
-atomic_int!(load_store_atomic, AtomicU16, u16, 2);
+atomic_int!(int, load_store_atomic, AtomicI8, i8, 1);
+atomic_int!(uint, load_store_atomic, AtomicU8, u8, 1);
+atomic_int!(int, load_store_atomic, AtomicI16, i16, 2);
+atomic_int!(uint, load_store_atomic, AtomicU16, u16, 2);
 
 #[cfg(not(target_pointer_width = "16"))]
-atomic_int!(load_store_atomic, AtomicI32, i32, 4);
+atomic_int!(int, load_store_atomic, AtomicI32, i32, 4);
 #[cfg(not(target_pointer_width = "16"))]
-atomic_int!(load_store_atomic, AtomicU32, u32, 4);
+atomic_int!(uint, load_store_atomic, AtomicU32, u32, 4);
 #[cfg(target_pointer_width = "16")]
 #[cfg(any(test, feature = "fallback"))]
-atomic_int!(load_store_critical_session, AtomicI32, i32, 4);
+atomic_int!(int, load_store_critical_session, AtomicI32, i32, 4);
 #[cfg(target_pointer_width = "16")]
 #[cfg(any(test, feature = "fallback"))]
-atomic_int!(load_store_critical_session, AtomicU32, u32, 4);
+atomic_int!(uint, load_store_critical_session, AtomicU32, u32, 4);
 
 #[cfg(not(any(target_pointer_width = "16", target_pointer_width = "32")))]
-atomic_int!(load_store_atomic, AtomicI64, i64, 8);
+atomic_int!(int, load_store_atomic, AtomicI64, i64, 8);
 #[cfg(not(any(target_pointer_width = "16", target_pointer_width = "32")))]
-atomic_int!(load_store_atomic, AtomicU64, u64, 8);
+atomic_int!(uint, load_store_atomic, AtomicU64, u64, 8);
 #[cfg(any(target_pointer_width = "16", target_pointer_width = "32"))]
 #[cfg(any(test, feature = "fallback"))]
-atomic_int!(load_store_critical_session, AtomicI64, i64, 8);
+atomic_int!(int, load_store_critical_session, AtomicI64, i64, 8);
 #[cfg(any(target_pointer_width = "16", target_pointer_width = "32"))]
 #[cfg(any(test, feature = "fallback"))]
-atomic_int!(load_store_critical_session, AtomicU64, u64, 8);
+atomic_int!(uint, load_store_critical_session, AtomicU64, u64, 8);
 
 #[cfg(any(test, feature = "fallback"))]
-atomic_int!(load_store_critical_session, AtomicI128, i128, 16);
+atomic_int!(int, load_store_critical_session, AtomicI128, i128, 16);
 #[cfg(any(test, feature = "fallback"))]
-atomic_int!(load_store_critical_session, AtomicU128, u128, 16);
+atomic_int!(uint, load_store_critical_session, AtomicU128, u128, 16);
 
 #[cfg(test)]
 mod tests {

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -77,6 +77,14 @@ pub(crate) mod msp430;
 #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
 mod riscv;
 
+// Miri and Sanitizer do not support inline assembly.
+#[cfg(all(
+    not(any(miri, portable_atomic_sanitize_thread)),
+    any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
+mod x86;
+
 // -----------------------------------------------------------------------------
 // Lock-based fallback implementations
 

--- a/src/imp/x86.rs
+++ b/src/imp/x86.rs
@@ -1,0 +1,75 @@
+// Atomic operations implementation on x86.
+//
+// Note: On Miri and ThreadSanitizer which do not support inline assembly, we don't use
+// this module and use CAS loop instead.
+
+#[cfg(not(portable_atomic_no_asm))]
+use core::arch::asm;
+use core::sync::atomic::Ordering;
+
+use super::core_atomic as imp;
+
+#[cfg(target_pointer_width = "32")]
+macro_rules! ptr_modifier {
+    () => {
+        ":e"
+    };
+}
+#[cfg(target_pointer_width = "64")]
+macro_rules! ptr_modifier {
+    () => {
+        ""
+    };
+}
+
+macro_rules! atomic_int {
+    ($int_type:ident, $atomic_type:ident, $val_reg:tt, $val_modifier:tt, $ptr_size:tt) => {
+        impl imp::$atomic_type {
+            #[inline]
+            pub(crate) fn neg(&self, _order: Ordering) {
+                let dst = self.as_mut_ptr();
+                // SAFETY: any data races are prevented by atomic intrinsics and the raw
+                // pointer passed in is valid because we got it from a reference.
+                //
+                // https://www.felixcloutier.com/x86/neg
+                unsafe {
+                    // atomic RMW is always SeqCst.
+                    asm!(
+                        concat!("lock neg ", $ptr_size, " ptr [{dst", ptr_modifier!(), "}]"),
+                        dst = inout(reg) dst => _,
+                        // Do not use `preserves_flags` because NEG modifies the CF, OF, SF, ZF, AF, and PF flag.
+                        options(nostack),
+                    );
+                }
+            }
+
+            #[inline]
+            pub(crate) fn as_mut_ptr(&self) -> *mut $int_type {
+                // SAFETY: Self is #[repr(C)] and internally UnsafeCell<$int_type>.
+                // See also https://github.com/rust-lang/rust/pull/66705 and
+                // https://github.com/rust-lang/rust/issues/66136#issuecomment-557867116.
+                unsafe {
+                    (*(self as *const Self as *const core::cell::UnsafeCell<$int_type>)).get()
+                }
+            }
+        }
+    };
+}
+
+atomic_int!(i8, AtomicI8, reg_byte, "", "byte");
+atomic_int!(i16, AtomicI16, reg, ":x", "word");
+atomic_int!(i32, AtomicI32, reg, ":e", "dword");
+#[cfg(target_arch = "x86_64")]
+atomic_int!(i64, AtomicI64, reg, "", "qword");
+#[cfg(target_pointer_width = "32")]
+atomic_int!(isize, AtomicIsize, reg, ":e", "dword");
+#[cfg(target_pointer_width = "64")]
+atomic_int!(isize, AtomicIsize, reg, "", "qword");
+
+#[cfg(target_arch = "x86")]
+impl imp::AtomicI64 {
+    #[inline]
+    pub(crate) fn neg(&self, order: Ordering) {
+        self.fetch_neg(order);
+    }
+}

--- a/src/imp/x86.rs
+++ b/src/imp/x86.rs
@@ -23,7 +23,38 @@ macro_rules! ptr_modifier {
 }
 
 macro_rules! atomic_int {
-    ($int_type:ident, $atomic_type:ident, $val_reg:tt, $val_modifier:tt, $ptr_size:tt) => {
+    (uint, $int_type:ident, $atomic_type:ident, $val_reg:tt, $val_modifier:tt, $ptr_size:tt) => {
+        impl imp::$atomic_type {
+            #[inline]
+            pub(crate) fn not(&self, _order: Ordering) {
+                let dst = self.as_mut_ptr();
+                // SAFETY: any data races are prevented by atomic intrinsics and the raw
+                // pointer passed in is valid because we got it from a reference.
+                //
+                // https://www.felixcloutier.com/x86/not
+                unsafe {
+                    // atomic RMW is always SeqCst.
+                    asm!(
+                        concat!("lock not ", $ptr_size, " ptr [{dst", ptr_modifier!(), "}]"),
+                        dst = inout(reg) dst => _,
+                        options(nostack, preserves_flags),
+                    );
+                }
+            }
+
+            #[inline]
+            pub(crate) fn as_mut_ptr(&self) -> *mut $int_type {
+                // SAFETY: Self is #[repr(C)] and internally UnsafeCell<$int_type>.
+                // See also https://github.com/rust-lang/rust/pull/66705 and
+                // https://github.com/rust-lang/rust/issues/66136#issuecomment-557867116.
+                unsafe {
+                    (*(self as *const Self as *const core::cell::UnsafeCell<$int_type>)).get()
+                }
+            }
+        }
+    };
+    (int, $int_type:ident, $atomic_type:ident, $val_reg:tt, $val_modifier:tt, $ptr_size:tt) => {
+        atomic_int!(uint, $int_type, $atomic_type, $val_reg, $val_modifier, $ptr_size);
         impl imp::$atomic_type {
             #[inline]
             pub(crate) fn neg(&self, _order: Ordering) {
@@ -42,34 +73,44 @@ macro_rules! atomic_int {
                     );
                 }
             }
-
-            #[inline]
-            pub(crate) fn as_mut_ptr(&self) -> *mut $int_type {
-                // SAFETY: Self is #[repr(C)] and internally UnsafeCell<$int_type>.
-                // See also https://github.com/rust-lang/rust/pull/66705 and
-                // https://github.com/rust-lang/rust/issues/66136#issuecomment-557867116.
-                unsafe {
-                    (*(self as *const Self as *const core::cell::UnsafeCell<$int_type>)).get()
-                }
-            }
         }
     };
 }
 
-atomic_int!(i8, AtomicI8, reg_byte, "", "byte");
-atomic_int!(i16, AtomicI16, reg, ":x", "word");
-atomic_int!(i32, AtomicI32, reg, ":e", "dword");
+atomic_int!(int, i8, AtomicI8, reg_byte, "", "byte");
+atomic_int!(uint, u8, AtomicU8, reg_byte, "", "byte");
+atomic_int!(int, i16, AtomicI16, reg, ":x", "word");
+atomic_int!(uint, u16, AtomicU16, reg, ":x", "word");
+atomic_int!(int, i32, AtomicI32, reg, ":e", "dword");
+atomic_int!(uint, u32, AtomicU32, reg, ":e", "dword");
 #[cfg(target_arch = "x86_64")]
-atomic_int!(i64, AtomicI64, reg, "", "qword");
+atomic_int!(int, i64, AtomicI64, reg, "", "qword");
+#[cfg(target_arch = "x86_64")]
+atomic_int!(uint, u64, AtomicU64, reg, "", "qword");
 #[cfg(target_pointer_width = "32")]
-atomic_int!(isize, AtomicIsize, reg, ":e", "dword");
+atomic_int!(int, isize, AtomicIsize, reg, ":e", "dword");
+#[cfg(target_pointer_width = "32")]
+atomic_int!(uint, usize, AtomicUsize, reg, ":e", "dword");
 #[cfg(target_pointer_width = "64")]
-atomic_int!(isize, AtomicIsize, reg, "", "qword");
+atomic_int!(int, isize, AtomicIsize, reg, "", "qword");
+#[cfg(target_pointer_width = "64")]
+atomic_int!(uint, usize, AtomicUsize, reg, "", "qword");
 
 #[cfg(target_arch = "x86")]
 impl imp::AtomicI64 {
     #[inline]
+    pub(crate) fn not(&self, order: Ordering) {
+        self.fetch_not(order);
+    }
+    #[inline]
     pub(crate) fn neg(&self, order: Ordering) {
         self.fetch_neg(order);
+    }
+}
+#[cfg(target_arch = "x86")]
+impl imp::AtomicU64 {
+    #[inline]
+    pub(crate) fn not(&self, order: Ordering) {
+        self.fetch_not(order);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1233,11 +1233,11 @@ impl AtomicBool {
     /// use portable_atomic::{AtomicBool, Ordering};
     ///
     /// let foo = AtomicBool::new(true);
-    /// assert_eq!(foo.fetch_not(Ordering::SeqCst), true);
+    /// foo.not(Ordering::SeqCst);
     /// assert_eq!(foo.load(Ordering::SeqCst), false);
     ///
     /// let foo = AtomicBool::new(false);
-    /// assert_eq!(foo.fetch_not(Ordering::SeqCst), false);
+    /// foo.not(Ordering::SeqCst);
     /// assert_eq!(foo.load(Ordering::SeqCst), true);
     /// ```
     #[cfg_attr(
@@ -3479,6 +3479,97 @@ assert_eq!(min_foo, 12);
                 #[inline]
                 pub fn fetch_min(&self, val: $int_type, order: Ordering) -> $int_type {
                     self.inner.fetch_min(val, order)
+                }
+            }
+
+            doc_comment! {
+                concat!("Logical negates the current value, and sets the new value to the result.
+
+Returns the previous value.
+
+`fetch_not` takes an [`Ordering`] argument which describes the memory ordering
+of this operation. All ordering modes are possible. Note that using
+[`Acquire`] makes the store part of this operation [`Relaxed`], and
+using [`Release`] makes the load part [`Relaxed`].
+
+# Examples
+
+```
+use portable_atomic::{", stringify!($atomic_type), ", Ordering};
+
+let foo = ", stringify!($atomic_type), "::new(0);
+assert_eq!(foo.fetch_not(Ordering::Relaxed), 0);
+assert_eq!(foo.load(Ordering::Relaxed), !0);
+```"),
+                #[cfg_attr(
+                    portable_atomic_no_cfg_target_has_atomic,
+                    cfg(any(
+                        not(portable_atomic_no_atomic_cas),
+                        portable_atomic_unsafe_assume_single_core,
+                        target_arch = "avr",
+                        target_arch = "msp430"
+                    ))
+                )]
+                #[cfg_attr(
+                    not(portable_atomic_no_cfg_target_has_atomic),
+                    cfg(any(
+                        target_has_atomic = "ptr",
+                        portable_atomic_unsafe_assume_single_core,
+                        target_arch = "avr",
+                        target_arch = "msp430"
+                    ))
+                )]
+                #[inline]
+                pub fn fetch_not(&self, order: Ordering) -> $int_type {
+                    self.inner.fetch_not(order)
+                }
+
+                doc_comment! {
+                    concat!("Logical negates the current value, and sets the new value to the result.
+
+Unlike `fetch_not`, this does not return the previous value.
+
+`not` takes an [`Ordering`] argument which describes the memory ordering
+of this operation. All ordering modes are possible. Note that using
+[`Acquire`] makes the store part of this operation [`Relaxed`], and
+using [`Release`] makes the load part [`Relaxed`].
+
+This function may generate more efficient code than `fetch_not` on some platforms.
+
+- x86: `lock not` instead of `cmpxchg` loop
+- MSP430: `inv` instead of disabling interrupts
+
+# Examples
+
+```
+use portable_atomic::{", stringify!($atomic_type), ", Ordering};
+
+let foo = ", stringify!($atomic_type), "::new(0);
+foo.not(Ordering::Relaxed);
+assert_eq!(foo.load(Ordering::Relaxed), !0);
+```"),
+                    #[cfg_attr(
+                        portable_atomic_no_cfg_target_has_atomic,
+                        cfg(any(
+                            not(portable_atomic_no_atomic_cas),
+                            portable_atomic_unsafe_assume_single_core,
+                            target_arch = "avr",
+                            target_arch = "msp430"
+                        ))
+                    )]
+                    #[cfg_attr(
+                        not(portable_atomic_no_cfg_target_has_atomic),
+                        cfg(any(
+                            target_has_atomic = "ptr",
+                            portable_atomic_unsafe_assume_single_core,
+                            target_arch = "avr",
+                            target_arch = "msp430"
+                        ))
+                    )]
+                    #[inline]
+                    pub fn not(&self, order: Ordering) {
+                        self.inner.not(order);
+                    }
                 }
             }
 

--- a/src/tests/helper.rs
+++ b/src/tests/helper.rs
@@ -217,7 +217,29 @@ macro_rules! __test_atomic_ptr_load_store {
 }
 
 macro_rules! __test_atomic_int {
+    ($atomic_type:ty, u8, single_thread) => {
+        __test_atomic_int!(uint, $atomic_type, u8, single_thread);
+    };
+    ($atomic_type:ty, u16, single_thread) => {
+        __test_atomic_int!(uint, $atomic_type, u16, single_thread);
+    };
+    ($atomic_type:ty, u32, single_thread) => {
+        __test_atomic_int!(uint, $atomic_type, u32, single_thread);
+    };
+    ($atomic_type:ty, u64, single_thread) => {
+        __test_atomic_int!(uint, $atomic_type, u64, single_thread);
+    };
+    ($atomic_type:ty, u128, single_thread) => {
+        __test_atomic_int!(uint, $atomic_type, u128, single_thread);
+    };
+    ($atomic_type:ty, usize, single_thread) => {
+        __test_atomic_int!(uint, $atomic_type, usize, single_thread);
+    };
     ($atomic_type:ty, $int_type:ident, single_thread) => {
+        __test_atomic_int!(int, $atomic_type, $int_type, single_thread);
+        __test_atomic_int!(uint, $atomic_type, $int_type, single_thread);
+    };
+    (uint, $atomic_type:ty, $int_type:ident, single_thread) => {
         use core::$int_type;
         #[test]
         fn swap() {
@@ -600,6 +622,54 @@ macro_rules! __test_atomic_int {
             }
         }
     };
+    (int, $atomic_type:ty, $int_type:ident, single_thread) => {
+        #[test]
+        fn fetch_neg() {
+            let a = <$atomic_type>::new(5);
+            test_swap_ordering(|order| a.fetch_neg(order));
+            for &order in &swap_orderings() {
+                let a = <$atomic_type>::new(5);
+                assert_eq!(a.fetch_neg(order), 5);
+                assert_eq!(a.load(Ordering::Relaxed), -5);
+                assert_eq!(a.fetch_neg(order), -5);
+                assert_eq!(a.load(Ordering::Relaxed), 5);
+            }
+        }
+        #[test]
+        fn neg() {
+            let a = <$atomic_type>::new(5);
+            test_swap_ordering(|order| a.neg(order));
+            for &order in &swap_orderings() {
+                let a = <$atomic_type>::new(5);
+                a.neg(order);
+                assert_eq!(a.load(Ordering::Relaxed), -5);
+                a.neg(order);
+                assert_eq!(a.load(Ordering::Relaxed), 5);
+            }
+        }
+        ::quickcheck::quickcheck! {
+            fn quickcheck_fetch_neg(x: $int_type) -> bool {
+                for &order in &swap_orderings() {
+                    let a = <$atomic_type>::new(x);
+                    assert_eq!(a.fetch_neg(order), x);
+                    assert_eq!(a.load(Ordering::Relaxed), x.wrapping_neg());
+                    assert_eq!(a.fetch_neg(order), x.wrapping_neg());
+                    assert_eq!(a.load(Ordering::Relaxed), x);
+                }
+                true
+            }
+            fn quickcheck_neg(x: $int_type) -> bool {
+                for &order in &swap_orderings() {
+                    let a = <$atomic_type>::new(x);
+                    a.neg(order);
+                    assert_eq!(a.load(Ordering::Relaxed), x.wrapping_neg());
+                    a.neg(order);
+                    assert_eq!(a.load(Ordering::Relaxed), x);
+                }
+                true
+            }
+        }
+    };
     ($atomic_type:ty, $int_type:ident) => {
         __test_atomic_int!($atomic_type, $int_type, single_thread);
 
@@ -833,6 +903,18 @@ macro_rules! __test_atomic_float {
             }
         }
         #[test]
+        fn fetch_neg() {
+            let a = <$atomic_type>::new(5.0);
+            test_swap_ordering(|order| a.fetch_neg(order));
+            for &order in &swap_orderings() {
+                let a = <$atomic_type>::new(5.0);
+                assert_eq!(a.fetch_neg(order), 5.0);
+                assert_eq!(a.load(Ordering::Relaxed), -5.0);
+                assert_eq!(a.fetch_neg(order), -5.0);
+                assert_eq!(a.load(Ordering::Relaxed), 5.0);
+            }
+        }
+        #[test]
         fn fetch_abs() {
             let a = <$atomic_type>::new(23.0);
             test_swap_ordering(|order| a.fetch_abs(order));
@@ -923,6 +1005,16 @@ macro_rules! __test_atomic_float {
                     let a = <$atomic_type>::new(y);
                     assert_float_op_eq!(a.fetch_min(x, order), y);
                     assert_float_op_eq!(a.load(Ordering::Relaxed), y.min(x));
+                }
+                true
+            }
+            fn quickcheck_fetch_neg(x: $float_type) -> bool {
+                for &order in &swap_orderings() {
+                    let a = <$atomic_type>::new(x);
+                    assert_float_op_eq!(a.fetch_neg(order), x);
+                    assert_float_op_eq!(a.load(Ordering::Relaxed), -x);
+                    assert_float_op_eq!(a.fetch_neg(order), -x);
+                    assert_float_op_eq!(a.load(Ordering::Relaxed), x);
                 }
                 true
             }

--- a/src/tests/helper.rs
+++ b/src/tests/helper.rs
@@ -440,6 +440,26 @@ macro_rules! __test_atomic_int {
                 assert_eq!(a.load(Ordering::Relaxed), 0);
             }
         }
+        #[test]
+        fn fetch_not() {
+            let a = <$atomic_type>::new(1);
+            test_swap_ordering(|order| a.fetch_not(order));
+            for &order in &swap_orderings() {
+                let a = <$atomic_type>::new(1);
+                assert_eq!(a.fetch_not(order), 1);
+                assert_eq!(a.load(Ordering::Relaxed), !1);
+            }
+        }
+        #[test]
+        fn not() {
+            let a = <$atomic_type>::new(1);
+            test_swap_ordering(|order| a.not(order));
+            for &order in &swap_orderings() {
+                let a = <$atomic_type>::new(1);
+                a.not(order);
+                assert_eq!(a.load(Ordering::Relaxed), !1);
+            }
+        }
         ::quickcheck::quickcheck! {
             fn quickcheck_swap(x: $int_type, y: $int_type) -> bool {
                 for &order in &swap_orderings() {
@@ -617,6 +637,26 @@ macro_rules! __test_atomic_int {
                     let a = <$atomic_type>::new(y);
                     assert_eq!(a.fetch_min(x, order), y);
                     assert_eq!(a.load(Ordering::Relaxed), core::cmp::min(y, x));
+                }
+                true
+            }
+            fn quickcheck_fetch_not(x: $int_type) -> bool {
+                for &order in &swap_orderings() {
+                    let a = <$atomic_type>::new(x);
+                    assert_eq!(a.fetch_not(order), x);
+                    assert_eq!(a.load(Ordering::Relaxed), !x);
+                    assert_eq!(a.fetch_not(order), !x);
+                    assert_eq!(a.load(Ordering::Relaxed), x);
+                }
+                true
+            }
+            fn quickcheck_not(x: $int_type) -> bool {
+                for &order in &swap_orderings() {
+                    let a = <$atomic_type>::new(x);
+                    a.not(order);
+                    assert_eq!(a.load(Ordering::Relaxed), !x);
+                    a.not(order);
+                    assert_eq!(a.load(Ordering::Relaxed), x);
                 }
                 true
             }

--- a/tests/api-test/src/helper.rs
+++ b/tests/api-test/src/helper.rs
@@ -222,6 +222,22 @@ macro_rules! __test_atomic_int {
                 assert_eq!(a.load(Ordering::Relaxed), 0);
             }
         }
+        fetch_not();
+        fn fetch_not() {
+            for order in helper::swap_orderings().iter().copied() {
+                let a = <$atomic_type>::new(1);
+                assert_eq!(a.fetch_not(order), 1);
+                assert_eq!(a.load(Ordering::Relaxed), !1);
+            }
+        }
+        not();
+        fn not() {
+            for order in helper::swap_orderings().iter().copied() {
+                let a = <$atomic_type>::new(1);
+                a.not(order);
+                assert_eq!(a.load(Ordering::Relaxed), !1);
+            }
+        }
         fetch_update();
         fn fetch_update() {
             for (success, failure) in helper::compare_exchange_orderings().iter().copied() {

--- a/tests/api-test/src/helper.rs
+++ b/tests/api-test/src/helper.rs
@@ -1,7 +1,29 @@
 use core::sync::atomic::Ordering;
 
 macro_rules! __test_atomic_int {
+    ($atomic_type:ty, u8) => {
+        __test_atomic_int!(uint, $atomic_type, u8);
+    };
+    ($atomic_type:ty, u16) => {
+        __test_atomic_int!(uint, $atomic_type, u16);
+    };
+    ($atomic_type:ty, u32) => {
+        __test_atomic_int!(uint, $atomic_type, u32);
+    };
+    ($atomic_type:ty, u64) => {
+        __test_atomic_int!(uint, $atomic_type, u64);
+    };
+    ($atomic_type:ty, u128) => {
+        __test_atomic_int!(uint, $atomic_type, u128);
+    };
+    ($atomic_type:ty, usize) => {
+        __test_atomic_int!(uint, $atomic_type, usize);
+    };
     ($atomic_type:ty, $int_type:ident) => {
+        __test_atomic_int!(int, $atomic_type, $int_type);
+        __test_atomic_int!(uint, $atomic_type, $int_type);
+    };
+    (uint, $atomic_type:ty, $int_type:ident) => {
         misc();
         fn misc() {
             static _VAL: $atomic_type = <$atomic_type>::new(5);
@@ -211,6 +233,28 @@ macro_rules! __test_atomic_int {
             }
         }
     };
+    (int, $atomic_type:ty, $int_type:ident) => {
+        fetch_neg();
+        fn fetch_neg() {
+            for order in helper::swap_orderings().iter().copied() {
+                let a = <$atomic_type>::new(5);
+                assert_eq!(a.fetch_neg(order), 5);
+                assert_eq!(a.load(Ordering::Relaxed), -5);
+                assert_eq!(a.fetch_neg(order), -5);
+                assert_eq!(a.load(Ordering::Relaxed), 5);
+            }
+        }
+        neg();
+        fn neg() {
+            for order in helper::swap_orderings().iter().copied() {
+                let a = <$atomic_type>::new(5);
+                a.neg(order);
+                assert_eq!(a.load(Ordering::Relaxed), -5);
+                a.neg(order);
+                assert_eq!(a.load(Ordering::Relaxed), 5);
+            }
+        }
+    };
 }
 macro_rules! __test_atomic_float {
     ($atomic_type:ty, $float_type:ident) => {
@@ -332,6 +376,16 @@ macro_rules! __test_atomic_float {
                 assert_eq!(a.load(Ordering::Relaxed), 0.0);
                 assert_eq!(a.fetch_min(1.0, order), 0.0);
                 assert_eq!(a.load(Ordering::Relaxed), 0.0);
+            }
+        }
+        fetch_neg();
+        fn fetch_neg() {
+            for order in helper::swap_orderings().iter().copied() {
+                let a = <$atomic_type>::new(5.0);
+                assert_eq!(a.fetch_neg(order), 5.0);
+                assert_eq!(a.load(Ordering::Relaxed), -5.0);
+                assert_eq!(a.fetch_neg(order), -5.0);
+                assert_eq!(a.load(Ordering::Relaxed), 5.0);
             }
         }
         fetch_abs();


### PR DESCRIPTION
Part of #48

- Add `AtomicI*::{fetch_neg,neg}` and `AtomicF*::fetch_neg` methods.

  `AtomicI*::neg` are equivalent to the corresponding `fetch_*` methods, but do not return the previous value. They are intended for optimization on platforms that have atomic instructions for the corresponding operation, such as x86's `lock neg`.

  Currently, optimizations by these methods (`neg`) are only guaranteed for x86.

- Add `Atomic{I,U}*::{fetch_not,not}` methods.

  `Atomic{I,U}*::not` are equivalent to the corresponding `fetch_*` methods, but do not return the previous value. They are intended for optimization on platforms that have atomic instructions for the corresponding operation, such as x86's `lock not`, MSP430's `inv`.

  Currently, optimizations by these methods (`not`) are only guaranteed for x86 and MSP430.

  (Note: `AtomicBool` already has `fetch_not` and `not` methods.)
