### PR TITLE
Test no-std RISC-V targets with QEMU on CI

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -15,6 +15,7 @@ doctests
 Dpkg
 endianness
 FIQs
+hartid
 hstdout
 ifunc
 impls
@@ -32,11 +33,13 @@ nand
 nographic
 nostack
 nproc
+opensbi
 prefetcher
 quadword
 rclass
 semihosting
 seqlock
+sifive
 SIGINT
 skiboot
 sourceware
@@ -50,4 +53,6 @@ syscall
 systemsim
 tagme
 Tlink
+uart
+virt
 vmlinux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,9 +291,18 @@ jobs:
       - name: Install Rust
         run: rustup toolchain add nightly --no-self-update && rustup default nightly
       - run: |
+          set -euxo pipefail
           sudo apt-get -o Acquire::Retries=10 -qq update && sudo apt-get -o Acquire::Retries=10 -o Dpkg::Use-Pty=0 install -y \
             binutils-arm-none-eabi \
-            qemu-system-arm
+            qemu-system-arm \
+            qemu-system-misc
+          # APT's qemu package doesn't provide firmware for riscv32: https://packages.ubuntu.com/en/jammy/all/qemu-system-data/filelist
+          OPENSBI_VERSION=1.1
+          curl --proto '=https' --tlsv1.2 -fsSL --retry 10 --retry-connrefused "https://github.com/riscv-software-src/opensbi/releases/download/v${OPENSBI_VERSION}/opensbi-${OPENSBI_VERSION}-rv-bin.tar.xz" \
+            | tar xJf -
+          sudo mv "opensbi-${OPENSBI_VERSION}-rv-bin/share/opensbi/ilp32/generic/firmware/fw_dynamic.bin" /usr/share/qemu/opensbi-riscv32-generic-fw_dynamic.bin
+          sudo mv "opensbi-${OPENSBI_VERSION}-rv-bin/share/opensbi/ilp32/generic/firmware/fw_dynamic.elf" /usr/share/qemu/opensbi-riscv32-generic-fw_dynamic.elf
+          rm -rf "opensbi-${OPENSBI_VERSION}-rv-bin"
       - run: tools/no-std.sh
 
   miri:

--- a/tests/riscv/.cargo/config.toml
+++ b/tests/riscv/.cargo/config.toml
@@ -1,0 +1,10 @@
+[build]
+target-dir = "../../target"
+
+[target.'cfg(all(target_arch = "riscv32", target_os = "none"))']
+runner = "qemu-system-riscv32 -M virt -serial stdio -display none -kernel"
+rustflags = ["-C", "link-arg=-Tlink32.ld"]
+
+[target.'cfg(all(target_arch = "riscv64", target_os = "none"))']
+runner = "qemu-system-riscv64 -M virt -serial stdio -display none -kernel"
+rustflags = ["-C", "link-arg=-Tlink64.ld"]

--- a/tests/riscv/Cargo.toml
+++ b/tests/riscv/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "riscv-test"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[workspace]
+resolver = "2"
+
+[features]
+float = ["portable-atomic/float"]
+
+[dependencies]
+portable-atomic = { path = "../.." }
+
+fdt = "0.1"
+paste = "1"

--- a/tests/riscv/build.rs
+++ b/tests/riscv/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=link32.ld");
+    println!("cargo:rerun-if-changed=link64.ld");
+}

--- a/tests/riscv/link32.ld
+++ b/tests/riscv/link32.ld
@@ -1,0 +1,21 @@
+/* Linker script for riscv32 test
+ * Adapted from https://github.com/andre-richter/qemu-exit/blob/v3.0.1/tests/riscv64_virt/link.ld.
+ */
+
+ENTRY(_start)
+
+SECTIONS
+{
+  /* Set current address to the address where OpenSBI will jump */
+  . = 0x80200000;
+
+  .text : {
+    *(.text._start)
+    *(.text)
+  }
+  .rodata : { *(.rodata*) }
+
+  /* https://github.com/riscv-non-isa/riscv-eabi-spec/blob/HEAD/EABI.adoc#eabi-stack-alignment */
+  . = ALIGN(8);
+  PROVIDE(_stack = . + 1M);
+}

--- a/tests/riscv/link64.ld
+++ b/tests/riscv/link64.ld
@@ -1,0 +1,21 @@
+/* Linker script for riscv64 test
+ * Adapted from https://github.com/andre-richter/qemu-exit/blob/v3.0.1/tests/riscv64_virt/link.ld.
+ */
+
+ENTRY(_start)
+
+SECTIONS
+{
+  /* Set current address to the address where OpenSBI will jump */
+  . = 0x80200000;
+
+  .text : {
+    *(.text._start)
+    *(.text)
+  }
+  .rodata : { *(.rodata*) }
+
+  /* https://github.com/riscv-non-isa/riscv-eabi-spec/blob/HEAD/EABI.adoc#eabi-stack-alignment */
+  . = ALIGN(16);
+  PROVIDE(_stack = . + 1M);
+}

--- a/tests/riscv/src/main.rs
+++ b/tests/riscv/src/main.rs
@@ -1,0 +1,175 @@
+#![no_main]
+#![no_std]
+#![warn(rust_2018_idioms, unsafe_op_in_unsafe_fn)]
+#![feature(panic_info_message)]
+
+#[macro_use]
+#[path = "../../api-test/src/helper.rs"]
+mod helper;
+
+use core::{arch::asm, ptr, sync::atomic::Ordering};
+
+use portable_atomic::*;
+
+macro_rules! print {
+    ($($tt:tt)*) => {
+        if let Some(mut uart) = $crate::semihosting::Uart::new() {
+            use core::fmt::Write as _;
+            let _ = write!(uart, $($tt)*);
+        }
+    };
+}
+macro_rules! println {
+    ($($tt:tt)*) => {
+        if let Some(mut uart) = $crate::semihosting::Uart::new() {
+            use core::fmt::Write as _;
+            let _ = writeln!(uart, $($tt)*);
+        }
+    };
+}
+
+#[no_mangle]
+unsafe fn _start(_hartid: usize, fdt_address: usize) -> ! {
+    unsafe {
+        asm!("la sp, _stack");
+        semihosting::init(fdt_address);
+    }
+
+    macro_rules! test_atomic_int {
+        ($int_type:ident) => {
+            paste::paste! {
+                fn [<test_atomic_ $int_type>]() {
+                    __test_atomic_int!([<Atomic $int_type:camel>], $int_type);
+                }
+                print!("test test_atomic_{} ... ", stringify!($int_type));
+                [<test_atomic_ $int_type>]();
+                println!("ok");
+            }
+        };
+    }
+    #[cfg(feature = "float")]
+    macro_rules! test_atomic_float {
+        ($float_type:ident) => {
+            paste::paste! {
+                fn [<test_atomic_ $float_type>]() {
+                    __test_atomic_float!([<Atomic $float_type:camel>], $float_type);
+                }
+                print!("test test_atomic_{} ... ", stringify!($float_type));
+                [<test_atomic_ $float_type>]();
+                println!("ok");
+            }
+        };
+    }
+    macro_rules! test_atomic_bool {
+        () => {
+            fn test_atomic_bool() {
+                __test_atomic_bool!(AtomicBool);
+            }
+            print!("test test_atomic_bool ... ");
+            test_atomic_bool();
+            println!("ok");
+        };
+    }
+    macro_rules! test_atomic_ptr {
+        () => {
+            fn test_atomic_ptr() {
+                __test_atomic_ptr!(AtomicPtr<u8>);
+            }
+            print!("test test_atomic_ptr ... ");
+            test_atomic_ptr();
+            println!("ok");
+        };
+    }
+
+    test_atomic_bool!();
+    test_atomic_ptr!();
+    test_atomic_int!(isize);
+    test_atomic_int!(usize);
+    test_atomic_int!(i8);
+    test_atomic_int!(u8);
+    test_atomic_int!(i16);
+    test_atomic_int!(u16);
+    test_atomic_int!(i32);
+    test_atomic_int!(u32);
+    test_atomic_int!(i64);
+    test_atomic_int!(u64);
+    test_atomic_int!(i128);
+    test_atomic_int!(u128);
+    #[cfg(feature = "float")]
+    test_atomic_float!(f32);
+    #[cfg(feature = "float")]
+    test_atomic_float!(f64);
+
+    semihosting::exit(semihosting::EXIT_SUCCESS)
+}
+
+#[inline(never)]
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
+    if let Some(s) = info.message() {
+        if let Some(l) = info.location() {
+            println!("panicked at '{:?}', {}", s, l);
+        } else {
+            println!("panicked at '{:?}' (no location info)", s);
+        }
+    } else {
+        println!("panic occurred (no message)");
+    }
+
+    semihosting::exit(semihosting::EXIT_FAILURE)
+}
+
+mod semihosting {
+    // Inspired by https://github.com/SimonSapin/riscv-qemu-demo
+
+    use core::{
+        fmt,
+        ptr::{self, NonNull},
+        sync::atomic::Ordering,
+    };
+
+    use portable_atomic::AtomicPtr;
+
+    #[inline(always)]
+    pub unsafe fn init(fdt_address: usize) {
+        unsafe {
+            let fdt = &fdt::Fdt::from_ptr(fdt_address as _).unwrap();
+            EXIT_HANDLE.store(find_compatible(fdt, "sifive,test0").cast(), Ordering::Release);
+            UART_HANDLE.store(find_compatible(fdt, "ns16550a").cast(), Ordering::Release);
+        }
+    }
+
+    #[inline(always)]
+    fn find_compatible(fdt: &fdt::Fdt<'_>, with: &str) -> *mut () {
+        let device = fdt.find_compatible(&[with]).unwrap();
+        let register = device.reg().unwrap().next().unwrap();
+        register.starting_address as _
+    }
+
+    static EXIT_HANDLE: AtomicPtr<u32> = AtomicPtr::new(ptr::null_mut());
+    pub const EXIT_SUCCESS: u32 = 0;
+    pub const EXIT_FAILURE: u32 = 1;
+    pub fn exit(exit_code: u32) -> ! {
+        if let Some(ptr) = NonNull::new(EXIT_HANDLE.load(Ordering::Acquire)) {
+            unsafe { ptr.as_ptr().write_volatile(exit_code << 16 | 0x3333) }
+        }
+        loop {}
+    }
+
+    static UART_HANDLE: AtomicPtr<u8> = AtomicPtr::new(ptr::null_mut());
+    pub struct Uart(NonNull<u8>);
+    impl Uart {
+        pub fn new() -> Option<Self> {
+            let ptr = UART_HANDLE.load(Ordering::Acquire);
+            NonNull::new(ptr).map(Self)
+        }
+    }
+    impl fmt::Write for Uart {
+        fn write_str(&mut self, s: &str) -> fmt::Result {
+            for b in s.bytes() {
+                unsafe { self.0.as_ptr().write_volatile(b) }
+            }
+            Ok(())
+        }
+    }
+}

--- a/tools/no-std.sh
+++ b/tools/no-std.sh
@@ -23,6 +23,16 @@ default_targets=(
     thumbv8m.base-none-eabi
     thumbv8m.main-none-eabi
     thumbv8m.main-none-eabihf
+
+    # riscv64
+    riscv64i-unknown-none-elf
+    riscv64imac-unknown-none-elf
+    riscv64gc-unknown-none-elf
+    # riscv32
+    riscv32i-unknown-none-elf
+    riscv32im-unknown-none-elf
+    riscv32imc-unknown-none-elf
+    riscv32imac-unknown-none-elf
 )
 
 x() {
@@ -100,12 +110,15 @@ run() {
     fi
 
     case "${target}" in
-        thumb* | arm*) ;; # TODO: float
+        thumb* | arm* | riscv??i-* | riscv??im-* | riscv??imc-* | riscv??imac-*) ;; # TODO: float
         *) args+=(--all-features) ;;
     esac
     case "${target}" in
         thumbv[4-5]t* | armv[4-5]t* | thumbv6m*)
             target_rustflags="${target_rustflags} --cfg portable_atomic_unsafe_assume_single_core"
+            ;;
+        riscv??i-* | riscv??im-* | riscv??imc-*)
+            target_rustflags="${target_rustflags} --cfg portable_atomic_unsafe_assume_single_core --cfg portable_atomic_s_mode"
             ;;
     esac
     local test_dir
@@ -117,6 +130,14 @@ run() {
         thumb*)
             test_dir=tests/cortex-m
             target_rustflags="${target_rustflags} -C link-arg=-Tlink.x"
+            ;;
+        riscv*)
+            test_dir=tests/riscv
+            case "${target}" in
+                riscv32*) target_rustflags="${target_rustflags} -C link-arg=-Tlink32.ld" ;;
+                riscv64*) target_rustflags="${target_rustflags} -C link-arg=-Tlink64.ld" ;;
+                *) bail "unrecognized target '${target}'" ;;
+            esac
             ;;
         *) bail "unrecognized target '${target}'" ;;
     esac


### PR DESCRIPTION
Currently, CI for these targets is build-only. Some code has already been tested on riscv64-linux and riscv32-linux, but interrupt-related code cannot be tested with user-mode.