### PR TITLE
Optimize Atomic{I,U}*::{fetch_not,not}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Optimize `Atomic{I,U}*::{fetch_not,not}` methods.
+
 ## [1.0.0] - 2023-01-15
 
 - Add `critical-section` feature to use [critical-section](https://github.com/rust-embedded/critical-section) on targets where atomic CAS is not natively available. ([#51](https://github.com/taiki-e/portable-atomic/pull/51), thanks @Dirbaio)

--- a/src/imp/atomic128/powerpc64.rs
+++ b/src/imp/atomic128/powerpc64.rs
@@ -508,6 +508,12 @@ unsafe fn atomic_xor(dst: *mut u128, val: u128, order: Ordering) -> u128 {
 }
 
 #[inline]
+unsafe fn atomic_not(dst: *mut u128, order: Ordering) -> u128 {
+    // SAFETY: the caller must uphold the safety contract for `atomic_not`.
+    unsafe { atomic_xor(dst, core::u128::MAX, order) }
+}
+
+#[inline]
 unsafe fn atomic_max(dst: *mut i128, val: i128, order: Ordering) -> i128 {
     debug_assert!(dst as usize % 16 == 0);
 


### PR DESCRIPTION
Replace CAS loop with fetch_xor(-1i*)/fetch_xor(u*::MAX).