### PR TITLE
aarch64: Support FEAT_LSE128 and FEAT_LRCPC3

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -56,6 +56,8 @@ isync
 kuser
 ldar
 ldaxp
+ldclrp
+ldsetp
 ldxp
 lghi
 libcalls
@@ -127,6 +129,7 @@ subc
 subfe
 subfic
 subfze
+swpp
 syscall
 sysctlbyname
 systemsim

--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -57,6 +57,7 @@ kuser
 ldar
 ldaxp
 ldclrp
+ldiapp
 ldsetp
 ldxp
 lghi
@@ -120,6 +121,7 @@ sreg
 sstatus
 stdarch
 stdsimd
+stilp
 stlxp
 stpq
 stqcx

--- a/build.rs
+++ b/build.rs
@@ -217,12 +217,14 @@ fn main() {
             let is_macos = target_os == "macos";
             let mut has_lse = is_macos;
             // FEAT_LSE2 doesn't imply FEAT_LSE. FEAT_LSE128 implies FEAT_LSE but not FEAT_LSE2.
-            // As of rustc 1.70, target_feature "lse2"/"lse128" is not available on rustc side:
+            // As of rustc 1.70, target_feature "lse2"/"lse128"/"rcpc3" is not available on rustc side:
             // https://github.com/rust-lang/rust/blob/1.70.0/compiler/rustc_codegen_ssa/src/target_features.rs#L58
             target_feature_if("lse2", is_macos, &version, None, false);
-            // LLVM supports FEAT_LSE128 on LLVM 16+:
+            // LLVM supports FEAT_LRCPC3 and FEAT_LSE128 on LLVM 16+:
+            // https://github.com/llvm/llvm-project/commit/a6aaa969f7caec58a994142f8d855861cf3a1463
             // https://github.com/llvm/llvm-project/commit/7fea6f2e0e606e5339c3359568f680eaf64aa306
             has_lse |= target_feature_if("lse128", false, &version, None, false);
+            target_feature_if("rcpc3", false, &version, None, false);
             // aarch64_target_feature stabilized in Rust 1.61.
             target_feature_if("lse", has_lse, &version, Some(61), true);
 

--- a/build.rs
+++ b/build.rs
@@ -215,11 +215,16 @@ fn main() {
             // aarch64 macOS always support FEAT_LSE and FEAT_LSE2 because it is armv8.5-a:
             // https://github.com/llvm/llvm-project/blob/llvmorg-16.0.0/llvm/include/llvm/TargetParser/AArch64TargetParser.h#L458
             let is_macos = target_os == "macos";
-            // aarch64_target_feature stabilized in Rust 1.61.
-            target_feature_if("lse", is_macos, &version, Some(61), true);
-            // As of rustc 1.70, target_feature "lse2" is not available on rustc side:
+            let mut has_lse = is_macos;
+            // FEAT_LSE2 doesn't imply FEAT_LSE. FEAT_LSE128 implies FEAT_LSE but not FEAT_LSE2.
+            // As of rustc 1.70, target_feature "lse2"/"lse128" is not available on rustc side:
             // https://github.com/rust-lang/rust/blob/1.70.0/compiler/rustc_codegen_ssa/src/target_features.rs#L58
             target_feature_if("lse2", is_macos, &version, None, false);
+            // LLVM supports FEAT_LSE128 on LLVM 16+:
+            // https://github.com/llvm/llvm-project/commit/7fea6f2e0e606e5339c3359568f680eaf64aa306
+            has_lse |= target_feature_if("lse128", false, &version, None, false);
+            // aarch64_target_feature stabilized in Rust 1.61.
+            target_feature_if("lse", has_lse, &version, Some(61), true);
 
             // As of Apple M1/M1 Pro, on Apple hardware, CAS loop-based RMW is much slower than LL/SC
             // loop-based RMW: https://github.com/taiki-e/portable-atomic/pull/89
@@ -338,7 +343,7 @@ fn target_feature_if(
     version: &Version,
     stabilized: Option<u32>,
     is_rustc_target_feature: bool,
-) {
+) -> bool {
     // HACK: Currently, it seems that the only way to handle unstable target
     // features on the stable is to parse the `-C target-feature` in RUSTFLAGS.
     //
@@ -353,7 +358,7 @@ fn target_feature_if(
         && (version.nightly || stabilized.map_or(false, |stabilized| version.minor >= stabilized))
     {
         // In this case, cfg(target_feature = "...") would work, so skip emitting our own target_feature cfg.
-        return;
+        return false;
     } else if let Some(rustflags) = env::var_os("CARGO_ENCODED_RUSTFLAGS") {
         for mut flag in rustflags.to_string_lossy().split('\x1f') {
             flag = strip_prefix(flag, "-C").unwrap_or(flag);
@@ -373,6 +378,7 @@ fn target_feature_if(
     if has_target_feature {
         println!("cargo:rustc-cfg=portable_atomic_target_feature=\"{}\"", name);
     }
+    has_target_feature
 }
 
 fn target_cpu() -> Option<String> {

--- a/src/imp/atomic128/README.md
+++ b/src/imp/atomic128/README.md
@@ -7,7 +7,7 @@ Here is the table of targets that support 128-bit atomics and the instructions u
 | target_arch | load | store | CAS | RMW | note |
 | ----------- | ---- | ----- | --- | --- | ---- |
 | x86_64 | cmpxchg16b or vmovdqa | cmpxchg16b or vmovdqa | cmpxchg16b | cmpxchg16b | cmpxchg16b target feature required. vmovdqa requires Intel or AMD CPU with AVX. <br> Both compile-time and run-time detection are supported for cmpxchg16b. vmovdqa is currently run-time detection only.  <br> Requires rustc 1.59+ when cmpxchg16b target feature is enabled at compile-time, otherwise requires rustc 1.69+ |
-| aarch64 | ldxp/stxp or casp or ldp | ldxp/stxp or casp or stp | ldxp/stxp or casp | ldxp/stxp or casp | casp requires lse target feature, ldp/stp requires lse2 target feature. <br> Both compile-time and run-time detection are supported for lse. lse2 is currently compile-time detection only.  <br> Requires rustc 1.59+ |
+| aarch64 | ldxp/stxp or casp or ldp | ldxp/stxp or casp or stp/swpp | ldxp/stxp or casp | ldxp/stxp or casp/swpp/ldclrp/ldsetp | casp requires lse target feature, ldp/stp requires lse2 target feature, swpp/ldclrp/ldsetp requires lse128 target feature. <br> Both compile-time and run-time detection are supported for lse. lse2 and lse128 are currently compile-time detection only.  <br> Requires rustc 1.59+ |
 | powerpc64 | lq | stq | lqarx/stqcx. | lqarx/stqcx. | Requires target-cpu pwr8+ (powerpc64le is pwr8 by default). Both compile-time and run-time detection are supported (run-time detection is currently disabled by default). <br> Requires nightly |
 | s390x | lpq | stpq | cdsg | cdsg | Requires nightly |
 

--- a/src/imp/atomic128/README.md
+++ b/src/imp/atomic128/README.md
@@ -7,7 +7,7 @@ Here is the table of targets that support 128-bit atomics and the instructions u
 | target_arch | load | store | CAS | RMW | note |
 | ----------- | ---- | ----- | --- | --- | ---- |
 | x86_64 | cmpxchg16b or vmovdqa | cmpxchg16b or vmovdqa | cmpxchg16b | cmpxchg16b | cmpxchg16b target feature required. vmovdqa requires Intel or AMD CPU with AVX. <br> Both compile-time and run-time detection are supported for cmpxchg16b. vmovdqa is currently run-time detection only.  <br> Requires rustc 1.59+ when cmpxchg16b target feature is enabled at compile-time, otherwise requires rustc 1.69+ |
-| aarch64 | ldxp/stxp or casp or ldp | ldxp/stxp or casp or stp/swpp | ldxp/stxp or casp | ldxp/stxp or casp/swpp/ldclrp/ldsetp | casp requires lse target feature, ldp/stp requires lse2 target feature, swpp/ldclrp/ldsetp requires lse128 target feature. <br> Both compile-time and run-time detection are supported for lse. lse2 and lse128 are currently compile-time detection only.  <br> Requires rustc 1.59+ |
+| aarch64 | ldxp/stxp or casp or ldp/ldiapp | ldxp/stxp or casp or stp/stilp/swpp | ldxp/stxp or casp | ldxp/stxp or casp/swpp/ldclrp/ldsetp | casp requires lse target feature, ldp/stp requires lse2 target feature, ldiapp/stilp requires lse2 and rcpc3 target features, swpp/ldclrp/ldsetp requires lse128 target feature. <br> Both compile-time and run-time detection are supported for lse. Others are currently compile-time detection only.  <br> Requires rustc 1.59+ |
 | powerpc64 | lq | stq | lqarx/stqcx. | lqarx/stqcx. | Requires target-cpu pwr8+ (powerpc64le is pwr8 by default). Both compile-time and run-time detection are supported (run-time detection is currently disabled by default). <br> Requires nightly |
 | s390x | lpq | stpq | cdsg | cdsg | Requires nightly |
 

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -583,6 +583,13 @@ build() {
                         x_cargo "${args[@]}" "$@"
                     ;;
             esac
+            # Support for FEAT_LRCPC3 and FEAT_LSE128 requires LLVM 16+ (Rust 1.70+).
+            if [[ "${rustc_minor_version}" -ge 70 ]]; then
+                # FEAT_LSE128 implies FEAT_LSE but not FEAT_LSE2.
+                CARGO_TARGET_DIR="${target_dir}/lse128" \
+                    RUSTFLAGS="${target_rustflags} -C target-feature=+lse2,+lse128" \
+                    x_cargo "${args[@]}" "$@"
+            fi
             ;;
         powerpc64-*)
             # powerpc64le- (little-endian) is skipped because it is pwr8 by default

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -407,7 +407,7 @@ build() {
         return 0
     else
         if [[ -n "${CI:-}" ]]; then
-            if [[ ${count} -lt 10 ]]; then
+            if [[ ${count} -lt 6 ]]; then
                 : $((count++))
             else
                 count=0
@@ -585,9 +585,15 @@ build() {
             esac
             # Support for FEAT_LRCPC3 and FEAT_LSE128 requires LLVM 16+ (Rust 1.70+).
             if [[ "${rustc_minor_version}" -ge 70 ]]; then
+                CARGO_TARGET_DIR="${target_dir}/rcpc3" \
+                    RUSTFLAGS="${target_rustflags} -C target-feature=+lse,+lse2,+rcpc3" \
+                    x_cargo "${args[@]}" "$@"
                 # FEAT_LSE128 implies FEAT_LSE but not FEAT_LSE2.
                 CARGO_TARGET_DIR="${target_dir}/lse128" \
                     RUSTFLAGS="${target_rustflags} -C target-feature=+lse2,+lse128" \
+                    x_cargo "${args[@]}" "$@"
+                CARGO_TARGET_DIR="${target_dir}/lse128-rcpc3" \
+                    RUSTFLAGS="${target_rustflags} -C target-feature=+lse2,+lse128,+rcpc3" \
                     x_cargo "${args[@]}" "$@"
             fi
             ;;


### PR DESCRIPTION
armv9.4-a added the following instructions as FEAT_LSE128:

- LDCLRP(AL) -- 128-bit atomic bit clear: https://developer.arm.com/documentation/ddi0602/2022-12/Base-Instructions/LDCLRP--LDCLRPA--LDCLRPAL--LDCLRPL--Atomic-bit-clear-on-quadword-in-memory-?lang=en
- LDSETP(AL) -- 128-bit atomic bit set/or: https://developer.arm.com/documentation/ddi0602/2022-12/Base-Instructions/LDSETP--LDSETPA--LDSETPAL--LDSETPL--Atomic-bit-set-on-quadword-in-memory-?lang=en
- SWPP(AL) -- 128-bit atomic swap: https://developer.arm.com/documentation/ddi0602/2022-12/Base-Instructions/SWPP--SWPPA--SWPPAL--SWPPL--Swap-quadword-in-memory-?lang=en

armv8.9-a/armv9.4-a added the following instructions as FEAT_LRCPC3:
- LDIAPP -- 128-bit acquire-load: https://developer.arm.com/documentation/ddi0602/2022-09/Base-Instructions/LDIAPP--Load-Acquire-RCpc-ordered-Pair-of-registers-
- STILP -- 128-bit release-store: https://developer.arm.com/documentation/ddi0602/2022-09/Base-Instructions/STILP--Store-Release-ordered-Pair-of-registers-

This PR optimizes aarch64 128-bit acquire-load/release-store when FEAT_LSE2 and FEAT_LRCPC3 are enabled and optimizes aarch64 128-bit fetch_and/fetch_or/swap/{release,seqcst}-store when FEAT_LSE128 is enabled.

See also the relevant LLVM patches: [D141406](https://reviews.llvm.org/D141406) (FEAT_LSE128), [D141429](https://reviews.llvm.org/D141429) (FEAT_LRCPC3)), [D143506](https://reviews.llvm.org/D143506)

This PR is still marked as a draft because:
- ~~LLVM added support for FEAT_LSE128/FEAT_LRCPC3 on LLVM 16 (https://github.com/llvm/llvm-project/commit/7fea6f2e0e606e5339c3359568f680eaf64aa306, https://github.com/llvm/llvm-project/commit/a6aaa969f7caec58a994142f8d855861cf3a1463), so we need to wait for https://github.com/rust-lang/rust/pull/107224.~~
- Once LLVM has been updated to 16, we need to test this using Arm Instruction Emulator or another tool.

cc #10