### PR TITLE
aarch64: Use CASP instead of LDXP/STXP for store/RMW if available

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -4,4 +4,4 @@ status = [
     "test (aarch64-apple-darwin)",
     "valgrind (aarch64-unknown-linux-gnu)",
 ]
-timeout_sec = 7200
+timeout_sec = 10800

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-feature=+lse ${{ env.RANDOMIZE_LAYOUT }}
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-feature=+lse ${{ env.RANDOMIZE_LAYOUT }}
         if: startsWith(matrix.target, 'aarch64') && startsWith(matrix.rust, 'nightly') && !(contains(matrix.target, '-musl') || contains(matrix.target, '-android'))
-      # TODO: it seems qemu-user has not yet properly implemented FEAT_LSE2: https://github.com/taiki-e/portable-atomic/pull/11#issuecomment-1114044327
+      # TODO: As of QEMU 7.2, QEMU has not yet implemented FEAT_LSE2: https://linaro.atlassian.net/browse/QEMU-300
 
       # pwr7
       # powerpc64- (big-endian) is skipped because it is pre-pwr8 by default

--- a/build.rs
+++ b/build.rs
@@ -242,6 +242,8 @@ fn main() {
                 }
             }
             // lqarx and stqcx.
+            // Note: As of rustc 1.67, target_feature "quadword-atomics" is not available on rustc side:
+            // https://github.com/rust-lang/rust/blob/1.67.0/compiler/rustc_codegen_ssa/src/target_features.rs#L215
             target_feature_if("quadword-atomics", has_pwr8_features, &version, None, false);
         }
         _ => {}

--- a/src/imp/atomic128/README.md
+++ b/src/imp/atomic128/README.md
@@ -2,11 +2,13 @@
 
 The table of targets that support 128-bit atomics and the instructions used:
 
-| target_arch | load | store | CAS | note |
-| ----------- | ----- | ----- | ---- | ---- |
-| x86_64 | cmpxchg16b or vmovdqa | cmpxchg16b or vmovdqa | cmpxchg16b | cmpxchg16b target feature required. vmovdqa requires Intel or AMD CPU with AVX. <br> Both compile-time and run-time detection are supported for cmpxchg16b. vmovdqa is currently run-time detection only.  <br> Requires rustc 1.59+ when cmpxchg16b target feature is enabled at compile-time, otherwise requires nightly |
-| aarch64 | ldxp/stxp or casp or ldp | ldxp/stxp or stp | ldxp/stxp or casp | casp requires lse target feature, ldp/stp requires lse2 target feature. <br> Both compile-time and run-time detection are supported for lse. lse2 is currently compile-time detection only.  <br> Requires rustc 1.59+ |
-| powerpc64 | lq | stq | lqarx/stqcx. | Little endian or target CPU pwr8+. <br> Requires nightly |
-| s390x | lpq | stpq | cdsg | Requires nightly |
+| target_arch | load  | store | CAS  | RMW  | note |
+| ----------- | ----- | ----- | ---- | ---- | ---- |
+| x86_64 | cmpxchg16b or vmovdqa | cmpxchg16b or vmovdqa | cmpxchg16b | cmpxchg16b | cmpxchg16b target feature required. vmovdqa requires Intel or AMD CPU with AVX. <br> Both compile-time and run-time detection are supported for cmpxchg16b. vmovdqa is currently run-time detection only.  <br> Requires rustc 1.59+ when cmpxchg16b target feature is enabled at compile-time, otherwise requires nightly |
+| aarch64 | ldxp/stxp or casp or ldp | ldxp/stxp or casp or stp | ldxp/stxp or casp | ldxp/stxp or casp | casp requires lse target feature, ldp/stp requires lse2 target feature. <br> Both compile-time and run-time detection are supported for lse. lse2 is currently compile-time detection only.  <br> Requires rustc 1.59+ |
+| powerpc64 | lq | stq | lqarx/stqcx. | lqarx/stqcx. | Little endian or target CPU pwr8+. <br> Requires nightly |
+| s390x | lpq | stpq | cdsg | cdsg | Requires nightly |
 
 Run-time detections are enabled by default and can be disabled with `--cfg portable_atomic_no_outline_atomics`.
+
+See [aarch64.rs](aarch64.rs) module-level comments for more details on the instructions used on aarch64.

--- a/src/imp/atomic128/intrinsics.rs
+++ b/src/imp/atomic128/intrinsics.rs
@@ -308,6 +308,7 @@ where
 unsafe fn atomic_max(dst: *mut i128, val: i128, order: Ordering) -> i128 {
     // LLVM 15 doesn't support 128-bit atomic min/max for powerpc64.
     #[cfg(target_arch = "powerpc64")]
+    #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
     // SAFETY: the caller must uphold the safety contract for `atomic_max`
     unsafe {
         atomic_update(dst.cast(), order, |x| core::cmp::max(x as i128, val) as u128) as i128
@@ -335,6 +336,7 @@ unsafe fn atomic_max(dst: *mut i128, val: i128, order: Ordering) -> i128 {
 unsafe fn atomic_min(dst: *mut i128, val: i128, order: Ordering) -> i128 {
     // LLVM 15 doesn't support 128-bit atomic min/max for powerpc64.
     #[cfg(target_arch = "powerpc64")]
+    #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
     // SAFETY: the caller must uphold the safety contract for `atomic_min`
     unsafe {
         atomic_update(dst.cast(), order, |x| core::cmp::min(x as i128, val) as u128) as i128

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -344,6 +344,7 @@ build() {
                     CARGO_TARGET_DIR="${target_dir}/lse" \
                         RUSTFLAGS="${target_rustflags} -C target-feature=+lse" \
                         x_cargo "${args[@]}" "$@"
+                    # FEAT_LSE2 doesn't imply FEAT_LSE.
                     CARGO_TARGET_DIR="${target_dir}/lse2" \
                         RUSTFLAGS="${target_rustflags} -C target-feature=+lse,+lse2" \
                         x_cargo "${args[@]}" "$@"


### PR DESCRIPTION
Follow-up #20

In #20, we postponed this (https://github.com/taiki-e/portable-atomic/pull/20#issuecomment-1204208980), but LLVM 16+ adopted this (https://github.com/llvm/llvm-project/commit/10d34f5538e0d231a172608bdb7d08824771c7c7), so we'll follow LLVM's behavior.