### PR TITLE
Add bit_{set,clear,toggle} to Atomic{I,U}* and AtomicPtr

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -95,6 +95,7 @@ rcpc
 reentrancy
 sbcs
 seqlock
+setb
 sete
 sifive
 SIGILL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,7 @@ jobs:
           MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-retag-fields -Zmiri-disable-isolation
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -Z randomize-layout
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -Z randomize-layout
-          QUICKCHECK_TESTS: 20
+          QUICKCHECK_TESTS: 10
 
   san:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Add `Atomic{I,U}*::bit_{set,clear,toggle}` and `AtomicPtr::bit_{set,clear,toggle}`. ([#72](https://github.com/taiki-e/portable-atomic/pull/72))
+
+  They correspond to x86's `lock bt{s,r,c}`, and the implementation calls them on x86.
+
 - Add `AtomicU*::{fetch_neg,neg}` methods. Previously it was only available on `AtomicI*` and `AtomicF*`.
 
 - Add `as_ptr` method to all atomic types. ([#79](https://github.com/taiki-e/portable-atomic/pull/79))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 - Add `Atomic{I,U}*::bit_{set,clear,toggle}` and `AtomicPtr::bit_{set,clear,toggle}`. ([#72](https://github.com/taiki-e/portable-atomic/pull/72))
 
-  They correspond to x86's `lock bt{s,r,c}`, and the implementation calls them on x86.
+  They correspond to x86's `lock bt{s,r,c}`, and the implementation calls them on x86/x86_64.
 
 - Add `AtomicU*::{fetch_neg,neg}` methods. Previously it was only available on `AtomicI*` and `AtomicF*`.
 
@@ -58,13 +58,13 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
   `AtomicI*::neg` are equivalent to the corresponding `fetch_*` methods, but do not return the previous value. They are intended for optimization on platforms that have atomic instructions for the corresponding operation, such as x86's `lock neg`.
 
-  Currently, optimizations by these methods (`neg`) are only guaranteed for x86.
+  Currently, optimizations by these methods (`neg`) are only guaranteed for x86/x86_64.
 
 - Add `Atomic{I,U}*::{fetch_not,not}` methods. ([#54](https://github.com/taiki-e/portable-atomic/pull/54))
 
   `Atomic{I,U}*::not` are equivalent to the corresponding `fetch_*` methods, but do not return the previous value. They are intended for optimization on platforms that have atomic instructions for the corresponding operation, such as x86's `lock not`, MSP430's `inv`.
 
-  Currently, optimizations by these methods (`not`) are only guaranteed for x86 and MSP430.
+  Currently, optimizations by these methods (`not`) are only guaranteed for x86/x86_64 and MSP430.
 
   (Note: `AtomicBool` already has `fetch_not` and `not` methods.)
 
@@ -90,7 +90,7 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
   They are equivalent to the corresponding `fetch_*` methods, but do not return the previous value. They are intended for optimization on platforms that implement atomics using inline assembly, such as the MSP430.
 
-  Currently, optimizations by these methods (`add`,`sub`,`and`,`or`,`xor`) are only guaranteed for MSP430; on x86, LLVM can optimize in most cases, so cases, where this would improve things, should be rare.
+  Currently, optimizations by these methods (`add`,`sub`,`and`,`or`,`xor`) are only guaranteed for MSP430; on x86/x86_64, LLVM can optimize in most cases, so cases, where this would improve things, should be rare.
 
 - Various improvements to `portable_atomic_unsafe_assume_single_core` cfg. ([#44](https://github.com/taiki-e/portable-atomic/pull/44), [#40](https://github.com/taiki-e/portable-atomic/pull/40))
 

--- a/bench/benches/imp/spinlock_fallback.rs
+++ b/bench/benches/imp/spinlock_fallback.rs
@@ -85,6 +85,7 @@ macro_rules! atomic_int {
         unsafe impl Sync for $atomic_type {}
 
         no_fetch_ops_impl!($atomic_type, $int_type);
+        bit_opts_fetch_impl!($atomic_type, $int_type);
         impl $atomic_type {
             #[inline]
             pub(crate) const fn new(v: $int_type) -> Self {

--- a/build.rs
+++ b/build.rs
@@ -119,6 +119,9 @@ fn main() {
         println!("cargo:rustc-cfg=portable_atomic_no_atomic_load_store");
     }
 
+    if version.llvm >= 16 {
+        println!("cargo:rustc-cfg=portable_atomic_llvm16");
+    }
     if version.nightly {
         println!("cargo:rustc-cfg=portable_atomic_nightly");
 

--- a/src/imp/atomic128/intrinsics.rs
+++ b/src/imp/atomic128/intrinsics.rs
@@ -421,6 +421,7 @@ macro_rules! atomic128 {
         unsafe impl Sync for $atomic_type {}
 
         no_fetch_ops_impl!($atomic_type, $int_type);
+        bit_opts_fetch_impl!($atomic_type, $int_type);
         impl $atomic_type {
             #[inline]
             pub(crate) const fn new(v: $int_type) -> Self {

--- a/src/imp/atomic128/macros.rs
+++ b/src/imp/atomic128/macros.rs
@@ -11,6 +11,7 @@ macro_rules! atomic128 {
         unsafe impl Sync for $atomic_type {}
 
         no_fetch_ops_impl!($atomic_type, $int_type);
+        bit_opts_fetch_impl!($atomic_type, $int_type);
         impl $atomic_type {
             #[inline]
             pub(crate) const fn new(v: $int_type) -> Self {
@@ -254,6 +255,7 @@ macro_rules! atomic128 {
         unsafe impl Sync for $atomic_type {}
 
         no_fetch_ops_impl!($atomic_type, $int_type);
+        bit_opts_fetch_impl!($atomic_type, $int_type);
         impl $atomic_type {
             #[inline]
             pub(crate) const fn new(v: $int_type) -> Self {

--- a/src/imp/core_atomic.rs
+++ b/src/imp/core_atomic.rs
@@ -198,6 +198,17 @@ macro_rules! atomic_int {
         )]
         #[cfg_attr(not(portable_atomic_no_cfg_target_has_atomic), cfg(target_has_atomic = "ptr"))]
         no_fetch_ops_impl!($atomic_type, $int_type);
+        #[cfg(not(all(
+            not(any(miri, portable_atomic_sanitize_thread)),
+            any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
+            any(target_arch = "x86", target_arch = "x86_64"),
+        )))]
+        #[cfg_attr(
+            portable_atomic_no_cfg_target_has_atomic,
+            cfg(not(portable_atomic_no_atomic_cas))
+        )]
+        #[cfg_attr(not(portable_atomic_no_cfg_target_has_atomic), cfg(target_has_atomic = "ptr"))]
+        bit_opts_fetch_impl!($atomic_type, $int_type);
         impl $atomic_type {
             #[inline]
             pub(crate) const fn new(v: $int_type) -> Self {

--- a/src/imp/fallback/imp.rs
+++ b/src/imp/fallback/imp.rs
@@ -130,6 +130,7 @@ macro_rules! atomic {
         unsafe impl Sync for $atomic_type {}
 
         no_fetch_ops_impl!($atomic_type, $int_type);
+        bit_opts_fetch_impl!($atomic_type, $int_type);
         impl $atomic_type {
             #[inline]
             pub(crate) const fn new(v: $int_type) -> Self {

--- a/src/imp/interrupt/mod.rs
+++ b/src/imp/interrupt/mod.rs
@@ -515,6 +515,7 @@ macro_rules! atomic_int {
 
         #[cfg(not(all(target_arch = "msp430", not(feature = "critical-section"))))]
         no_fetch_ops_impl!($atomic_type, $int_type);
+        bit_opts_fetch_impl!($atomic_type, $int_type);
         #[cfg(not(all(target_arch = "msp430", not(feature = "critical-section"))))]
         impl $atomic_type {
             #[inline]
@@ -572,6 +573,7 @@ macro_rules! atomic_int {
         atomic_int!(base, $atomic_type, $int_type, $align);
         atomic_int!(cas, $atomic_type, $int_type);
         no_fetch_ops_impl!($atomic_type, $int_type);
+        bit_opts_fetch_impl!($atomic_type, $int_type);
         impl $atomic_type {
             #[inline]
             #[cfg_attr(all(debug_assertions, not(portable_atomic_no_track_caller)), track_caller)]

--- a/src/imp/x86.rs
+++ b/src/imp/x86.rs
@@ -1,4 +1,4 @@
-// Atomic operations implementation on x86.
+// Atomic operations implementation on x86/x86_64.
 //
 // Note: On Miri and ThreadSanitizer which do not support inline assembly, we don't use
 // this module and use CAS loop instead.

--- a/src/imp/x86.rs
+++ b/src/imp/x86.rs
@@ -7,7 +7,10 @@
 use core::arch::asm;
 use core::sync::atomic::Ordering;
 
-use super::core_atomic as imp;
+use super::core_atomic::{
+    AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicU16, AtomicU32, AtomicU64,
+    AtomicU8, AtomicUsize,
+};
 
 #[cfg(target_pointer_width = "32")]
 macro_rules! ptr_modifier {
@@ -24,7 +27,7 @@ macro_rules! ptr_modifier {
 
 macro_rules! atomic_int {
     ($atomic_type:ident, $int_type:ident, $ptr_size:tt) => {
-        impl imp::$atomic_type {
+        impl $atomic_type {
             #[inline]
             pub(crate) fn not(&self, _order: Ordering) {
                 let dst = self.as_ptr();
@@ -82,7 +85,7 @@ atomic_int!(AtomicIsize, isize, "qword");
 atomic_int!(AtomicUsize, usize, "qword");
 
 #[cfg(target_arch = "x86")]
-impl imp::AtomicI64 {
+impl AtomicI64 {
     #[inline]
     pub(crate) fn not(&self, order: Ordering) {
         self.fetch_not(order);
@@ -93,7 +96,7 @@ impl imp::AtomicI64 {
     }
 }
 #[cfg(target_arch = "x86")]
-impl imp::AtomicU64 {
+impl AtomicU64 {
     #[inline]
     pub(crate) fn not(&self, order: Ordering) {
         self.fetch_not(order);
@@ -103,3 +106,117 @@ impl imp::AtomicU64 {
         self.fetch_neg(order);
     }
 }
+
+macro_rules! atomic_bit_opts {
+    ($atomic_type:ident, $int_type:ident, $val_modifier:tt, $ptr_size:tt) => {
+        // LLVM 14 and older don't support generating `lock bt{s,r,c}`.
+        // https://godbolt.org/z/G1TMKza97
+        // LLVM 15 only supports generating `lock bt{s,r,c}` for immediate bit offsets.
+        // https://godbolt.org/z/dzzhr81z6
+        // LLVM 16 can generate `lock bt{s,r,c}` for both immediate and register bit offsets.
+        // https://github.com/taiki-e/portable-atomic/issues/48#issuecomment-1453473831
+        // So, use fetch_* based implementations on LLVM 16+, otherwise use asm based implementations.
+        #[cfg(portable_atomic_llvm16)]
+        bit_opts_fetch_impl!($atomic_type, $int_type);
+        #[cfg(not(portable_atomic_llvm16))]
+        impl $atomic_type {
+            // `<integer>::BITS` is not available on old nightly.
+            const BITS: u32 = (core::mem::size_of::<$int_type>() * 8) as u32;
+            #[inline]
+            pub(crate) fn bit_set(&self, bit: u32, _order: Ordering) -> bool {
+                let dst = self.as_ptr();
+                // SAFETY: any data races are prevented by atomic intrinsics and the raw
+                // pointer passed in is valid because we got it from a reference.
+                // the masking by the bit size of the type ensures that we do not shift
+                // out of bounds.
+                //
+                // https://www.felixcloutier.com/x86/bts
+                unsafe {
+                    let out: u8;
+                    // atomic RMW is always SeqCst.
+                    asm!(
+                        concat!("lock bts ", $ptr_size, " ptr [{dst", ptr_modifier!(), "}], {bit", $val_modifier, "}"),
+                        "setb {out}",
+                        dst = in(reg) dst,
+                        bit = in(reg) (bit & (Self::BITS - 1)) as $int_type,
+                        out = out(reg_byte) out,
+                        // Do not use `preserves_flags` because BTS modifies the CF flag.
+                        options(nostack),
+                    );
+                    out != 0
+                }
+            }
+            #[inline]
+            pub(crate) fn bit_clear(&self, bit: u32, _order: Ordering) -> bool {
+                let dst = self.as_ptr();
+                // SAFETY: any data races are prevented by atomic intrinsics and the raw
+                // pointer passed in is valid because we got it from a reference.
+                // the masking by the bit size of the type ensures that we do not shift
+                // out of bounds.
+                //
+                // https://www.felixcloutier.com/x86/btr
+                unsafe {
+                    let out: u8;
+                    // atomic RMW is always SeqCst.
+                    asm!(
+                        concat!("lock btr ", $ptr_size, " ptr [{dst", ptr_modifier!(), "}], {bit", $val_modifier, "}"),
+                        "setb {out}",
+                        dst = in(reg) dst,
+                        bit = in(reg) (bit & (Self::BITS - 1)) as $int_type,
+                        out = out(reg_byte) out,
+                        // Do not use `preserves_flags` because BTR modifies the CF flag.
+                        options(nostack),
+                    );
+                    out != 0
+                }
+            }
+            #[inline]
+            pub(crate) fn bit_toggle(&self, bit: u32, _order: Ordering) -> bool {
+                let dst = self.as_ptr();
+                // SAFETY: any data races are prevented by atomic intrinsics and the raw
+                // pointer passed in is valid because we got it from a reference.
+                // the masking by the bit size of the type ensures that we do not shift
+                // out of bounds.
+                //
+                // https://www.felixcloutier.com/x86/btc
+                unsafe {
+                    let out: u8;
+                    // atomic RMW is always SeqCst.
+                    asm!(
+                        concat!("lock btc ", $ptr_size, " ptr [{dst", ptr_modifier!(), "}], {bit", $val_modifier, "}"),
+                        "setb {out}",
+                        dst = in(reg) dst,
+                        bit = in(reg) (bit & (Self::BITS - 1)) as $int_type,
+                        out = out(reg_byte) out,
+                        // Do not use `preserves_flags` because BTC modifies the CF flag.
+                        options(nostack),
+                    );
+                    out != 0
+                }
+            }
+        }
+    };
+}
+
+bit_opts_fetch_impl!(AtomicI8, i8);
+bit_opts_fetch_impl!(AtomicU8, u8);
+atomic_bit_opts!(AtomicI16, i16, ":x", "word");
+atomic_bit_opts!(AtomicU16, u16, ":x", "word");
+atomic_bit_opts!(AtomicI32, i32, ":e", "dword");
+atomic_bit_opts!(AtomicU32, u32, ":e", "dword");
+#[cfg(target_arch = "x86_64")]
+atomic_bit_opts!(AtomicI64, i64, "", "qword");
+#[cfg(target_arch = "x86_64")]
+atomic_bit_opts!(AtomicU64, u64, "", "qword");
+#[cfg(target_arch = "x86")]
+bit_opts_fetch_impl!(AtomicI64, i64);
+#[cfg(target_arch = "x86")]
+bit_opts_fetch_impl!(AtomicU64, u64);
+#[cfg(target_pointer_width = "32")]
+atomic_bit_opts!(AtomicIsize, isize, ":e", "dword");
+#[cfg(target_pointer_width = "32")]
+atomic_bit_opts!(AtomicUsize, usize, ":e", "dword");
+#[cfg(target_pointer_width = "64")]
+atomic_bit_opts!(AtomicIsize, isize, "", "qword");
+#[cfg(target_pointer_width = "64")]
+atomic_bit_opts!(AtomicUsize, usize, "", "qword");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -882,10 +882,10 @@ impl AtomicBool {
     ///
     /// This function may generate more efficient code than `fetch_and` on some platforms.
     ///
-    /// - x86: `lock and` instead of `cmpxchg` loop
+    /// - x86/x86_64: `lock and` instead of `cmpxchg` loop
     /// - MSP430: `and` instead of disabling interrupts
     ///
-    /// Note: On x86, the use of either function should not usually
+    /// Note: On x86/x86_64, the use of either function should not usually
     /// affect the generated code, because LLVM can properly optimize the case
     /// where the result is unused.
     ///
@@ -1054,10 +1054,10 @@ impl AtomicBool {
     ///
     /// This function may generate more efficient code than `fetch_or` on some platforms.
     ///
-    /// - x86: `lock or` instead of `cmpxchg` loop
+    /// - x86/x86_64: `lock or` instead of `cmpxchg` loop
     /// - MSP430: `bis` instead of disabling interrupts
     ///
-    /// Note: On x86, the use of either function should not usually
+    /// Note: On x86/x86_64, the use of either function should not usually
     /// affect the generated code, because LLVM can properly optimize the case
     /// where the result is unused.
     ///
@@ -1171,10 +1171,10 @@ impl AtomicBool {
     ///
     /// This function may generate more efficient code than `fetch_xor` on some platforms.
     ///
-    /// - x86: `lock xor` instead of `cmpxchg` loop
+    /// - x86/x86_64: `lock xor` instead of `cmpxchg` loop
     /// - MSP430: `xor` instead of disabling interrupts
     ///
-    /// Note: On x86, the use of either function should not usually
+    /// Note: On x86/x86_64, the use of either function should not usually
     /// affect the generated code, because LLVM can properly optimize the case
     /// where the result is unused.
     ///
@@ -1284,10 +1284,10 @@ impl AtomicBool {
     ///
     /// This function may generate more efficient code than `fetch_not` on some platforms.
     ///
-    /// - x86: `lock xor` instead of `cmpxchg` loop
+    /// - x86/x86_64: `lock xor` instead of `cmpxchg` loop
     /// - MSP430: `xor` instead of disabling interrupts
     ///
-    /// Note: On x86, the use of either function should not usually
+    /// Note: On x86/x86_64, the use of either function should not usually
     /// affect the generated code, because LLVM can properly optimize the case
     /// where the result is unused.
     ///
@@ -2408,7 +2408,7 @@ impl<T> AtomicPtr<T> {
     /// [`Acquire`] makes the store part of this operation [`Relaxed`], and
     /// using [`Release`] makes the load part [`Relaxed`].
     ///
-    /// This corresponds to x86's `lock bts`, and the implementation calls them on x86.
+    /// This corresponds to x86's `lock bts`, and the implementation calls them on x86/x86_64.
     ///
     /// # Examples
     ///
@@ -2475,7 +2475,7 @@ impl<T> AtomicPtr<T> {
     /// [`Acquire`] makes the store part of this operation [`Relaxed`], and
     /// using [`Release`] makes the load part [`Relaxed`].
     ///
-    /// This corresponds to x86's `lock btr`, and the implementation calls them on x86.
+    /// This corresponds to x86's `lock btr`, and the implementation calls them on x86/x86_64.
     ///
     /// # Examples
     ///
@@ -2539,7 +2539,7 @@ impl<T> AtomicPtr<T> {
     /// [`Acquire`] makes the store part of this operation [`Relaxed`], and
     /// using [`Release`] makes the load part [`Relaxed`].
     ///
-    /// This corresponds to x86's `lock btc`, and the implementation calls them on x86.
+    /// This corresponds to x86's `lock btc`, and the implementation calls them on x86/x86_64.
     ///
     /// # Examples
     ///
@@ -3141,7 +3141,7 @@ using [`Release`] makes the load part [`Relaxed`].
 
 This function may generate more efficient code than `fetch_add` on some platforms.
 
-- MSP430: `add` instead of disabling interrupts (only {8,16}-bit atomics)
+- MSP430: `add` instead of disabling interrupts ({8,16}-bit atomics)
 
 # Examples
 
@@ -3237,7 +3237,7 @@ using [`Release`] makes the load part [`Relaxed`].
 
 This function may generate more efficient code than `fetch_sub` on some platforms.
 
-- MSP430: `sub` instead of disabling interrupts (only {8,16}-bit atomics)
+- MSP430: `sub` instead of disabling interrupts ({8,16}-bit atomics)
 
 # Examples
 
@@ -3337,10 +3337,10 @@ using [`Release`] makes the load part [`Relaxed`].
 
 This function may generate more efficient code than `fetch_and` on some platforms.
 
-- x86: `lock and` instead of `cmpxchg` loop (only {8,16,32}-bit atomics on x86, but additionally 64-bit atomics on x86_64)
-- MSP430: `and` instead of disabling interrupts (only {8,16}-bit atomics)
+- x86/x86_64: `lock and` instead of `cmpxchg` loop ({8,16,32}-bit atomics on x86, but additionally 64-bit atomics on x86_64)
+- MSP430: `and` instead of disabling interrupts ({8,16}-bit atomics)
 
-Note: On x86, the use of either function should not usually
+Note: On x86/x86_64, the use of either function should not usually
 affect the generated code, because LLVM can properly optimize the case
 where the result is unused.
 
@@ -3490,10 +3490,10 @@ using [`Release`] makes the load part [`Relaxed`].
 
 This function may generate more efficient code than `fetch_or` on some platforms.
 
-- x86: `lock or` instead of `cmpxchg` loop (only {8,16,32}-bit atomics on x86, but additionally 64-bit atomics on x86_64)
-- MSP430: `or` instead of disabling interrupts (only {8,16}-bit atomics)
+- x86/x86_64: `lock or` instead of `cmpxchg` loop ({8,16,32}-bit atomics on x86, but additionally 64-bit atomics on x86_64)
+- MSP430: `or` instead of disabling interrupts ({8,16}-bit atomics)
 
-Note: On x86, the use of either function should not usually
+Note: On x86/x86_64, the use of either function should not usually
 affect the generated code, because LLVM can properly optimize the case
 where the result is unused.
 
@@ -3595,10 +3595,10 @@ using [`Release`] makes the load part [`Relaxed`].
 
 This function may generate more efficient code than `fetch_xor` on some platforms.
 
-- x86: `lock xor` instead of `cmpxchg` loop (only {8,16,32}-bit atomics on x86, but additionally 64-bit atomics on x86_64)
-- MSP430: `xor` instead of disabling interrupts (only {8,16}-bit atomics)
+- x86/x86_64: `lock xor` instead of `cmpxchg` loop ({8,16,32}-bit atomics on x86, but additionally 64-bit atomics on x86_64)
+- MSP430: `xor` instead of disabling interrupts ({8,16}-bit atomics)
 
-Note: On x86, the use of either function should not usually
+Note: On x86/x86_64, the use of either function should not usually
 affect the generated code, because LLVM can properly optimize the case
 where the result is unused.
 
@@ -3854,7 +3854,7 @@ of this operation. All ordering modes are possible. Note that using
 [`Acquire`] makes the store part of this operation [`Relaxed`], and
 using [`Release`] makes the load part [`Relaxed`].
 
-This corresponds to x86's `lock bts`, and the implementation calls them on x86.
+This corresponds to x86's `lock bts`, and the implementation calls them on x86/x86_64.
 
 # Examples
 
@@ -3903,7 +3903,7 @@ of this operation. All ordering modes are possible. Note that using
 [`Acquire`] makes the store part of this operation [`Relaxed`], and
 using [`Release`] makes the load part [`Relaxed`].
 
-This corresponds to x86's `lock btr`, and the implementation calls them on x86.
+This corresponds to x86's `lock btr`, and the implementation calls them on x86/x86_64.
 
 # Examples
 
@@ -3950,7 +3950,7 @@ of this operation. All ordering modes are possible. Note that using
 [`Acquire`] makes the store part of this operation [`Relaxed`], and
 using [`Release`] makes the load part [`Relaxed`].
 
-This corresponds to x86's `lock btc`, and the implementation calls them on x86.
+This corresponds to x86's `lock btc`, and the implementation calls them on x86/x86_64.
 
 # Examples
 
@@ -4045,8 +4045,8 @@ using [`Release`] makes the load part [`Relaxed`].
 
 This function may generate more efficient code than `fetch_not` on some platforms.
 
-- x86: `lock not` instead of `cmpxchg` loop (only {8,16,32}-bit atomics on x86, but additionally 64-bit atomics on x86_64)
-- MSP430: `inv` instead of disabling interrupts (only {8,16}-bit atomics)
+- x86/x86_64: `lock not` instead of `cmpxchg` loop ({8,16,32}-bit atomics on x86, but additionally 64-bit atomics on x86_64)
+- MSP430: `inv` instead of disabling interrupts ({8,16}-bit atomics)
 
 # Examples
 
@@ -4142,7 +4142,7 @@ using [`Release`] makes the load part [`Relaxed`].
 
 This function may generate more efficient code than `fetch_neg` on some platforms.
 
-- x86: `lock neg` instead of `cmpxchg` loop (only {8,16,32}-bit atomics on x86, but additionally 64-bit atomics on x86_64)
+- x86/x86_64: `lock neg` instead of `cmpxchg` loop ({8,16,32}-bit atomics on x86, but additionally 64-bit atomics on x86_64)
 
 # Examples
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -242,6 +242,27 @@ macro_rules! no_fetch_ops_impl {
         }
     };
 }
+macro_rules! bit_opts_fetch_impl {
+    ($atomic_type:ident, $int_type:ident) => {
+        impl $atomic_type {
+            #[inline]
+            pub(crate) fn bit_set(&self, bit: u32, order: Ordering) -> bool {
+                let mask = (1 as $int_type).wrapping_shl(bit);
+                self.fetch_or(mask, order) & mask != 0
+            }
+            #[inline]
+            pub(crate) fn bit_clear(&self, bit: u32, order: Ordering) -> bool {
+                let mask = (1 as $int_type).wrapping_shl(bit);
+                self.fetch_and(!mask, order) & mask != 0
+            }
+            #[inline]
+            pub(crate) fn bit_toggle(&self, bit: u32, order: Ordering) -> bool {
+                let mask = (1 as $int_type).wrapping_shl(bit);
+                self.fetch_xor(mask, order) & mask != 0
+            }
+        }
+    };
+}
 
 pub(crate) struct NoRefUnwindSafe(UnsafeCell<()>);
 // SAFETY: this is a marker type and we'll never access the value.


### PR DESCRIPTION
They correspond to x86's `lock bt{s,r,c}`, and the implementation calls them on x86/x86_64.

> LLVM 14 and older don't support generating `lock bt{s,r,c}`.
> https://godbolt.org/z/G1TMKza97
> LLVM 15 only supports generating `lock bt{s,r,c}` for immediate bit offsets.
> https://godbolt.org/z/dzzhr81z6
> LLVM 16 can generate `lock bt{s,r,c}` for both immediate and register bit offsets.
> https://github.com/taiki-e/portable-atomic/issues/48#issuecomment-1453473831
> So, use fetch_* based implementations on LLVM 16+, otherwise use asm based implementations.


Closes #48