### PR TITLE
aarch64: Support outline atomics on old nightly

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -89,10 +89,6 @@ fn main() {
         }
         println!("cargo:rustc-cfg=portable_atomic_no_asm");
     }
-    // aarch64_target_feature stabilized in Rust 1.61 (nightly-2022-03-16): https://github.com/rust-lang/rust/pull/90621
-    if !version.probe(61, 2022, 3, 15) {
-        println!("cargo:rustc-cfg=portable_atomic_no_aarch64_target_feature");
-    }
     // https://github.com/rust-lang/rust/pull/98383 merged in Rust 1.64 (nightly-2022-07-19).
     if !version.probe(64, 2022, 7, 18) {
         println!("cargo:rustc-cfg=portable_atomic_no_stronger_failure_ordering");
@@ -176,6 +172,19 @@ fn main() {
             }
         }
         "aarch64" => {
+            // aarch64_target_feature stabilized in Rust 1.61 (nightly-2022-03-16): https://github.com/rust-lang/rust/pull/90621
+            if !version.probe(61, 2022, 3, 15) {
+                if version.nightly && is_allowed_feature("aarch64_target_feature") {
+                    // The part of this feature we use has not been changed since 1.27
+                    // (https://github.com/rust-lang/rust/commit/1217d70465edb2079880347fea4baaac56895f51)
+                    // until it was stabilized in nightly-2022-03-16, so it can be safely enabled in
+                    // nightly, which is older than nightly-2022-03-16.
+                    println!("cargo:rustc-cfg=portable_atomic_unstable_aarch64_target_feature");
+                } else {
+                    println!("cargo:rustc-cfg=portable_atomic_no_aarch64_target_feature");
+                }
+            }
+
             // aarch64 macos always support FEAT_LSE and FEAT_LSE2 because it is armv8.6: https://github.com/rust-lang/rust/blob/1.67.0/compiler/rustc_target/src/spec/aarch64_apple_darwin.rs#L7
             let is_macos = target_os == "macos";
             // aarch64_target_feature stabilized in Rust 1.61.

--- a/src/imp/atomic128/aarch64.rs
+++ b/src/imp/atomic128/aarch64.rs
@@ -350,9 +350,12 @@ unsafe fn atomic_compare_exchange(
 #[cfg(any(
     target_feature = "lse",
     portable_atomic_target_feature = "lse",
-    not(portable_atomic_no_aarch64_target_feature),
+    all(not(portable_atomic_no_aarch64_target_feature), not(portable_atomic_no_outline_atomics)),
 ))]
-#[cfg_attr(not(portable_atomic_no_aarch64_target_feature), target_feature(enable = "lse"))]
+#[cfg_attr(
+    not(any(target_feature = "lse", portable_atomic_target_feature = "lse",)),
+    target_feature(enable = "lse")
+)]
 #[inline]
 unsafe fn _atomic_compare_exchange_casp(
     dst: *mut u128,

--- a/src/imp/atomic128/detect/aarch64_std.rs
+++ b/src/imp/atomic128/detect/aarch64_std.rs
@@ -31,7 +31,7 @@ pub(crate) fn has_lse() -> bool {
             // Note: std may not be available on tier 3 such as aarch64 FreeBSD/OpenBSD.
             any(
                 feature = "std",
-                target_os = "linux",
+                all(target_os = "linux", any(target_env = "gnu", target_env = "musl")),
                 target_os = "android",
                 target_os = "windows",
                 // target_os = "freebsd",

--- a/src/imp/atomic128/detect/aarch64_std.rs
+++ b/src/imp/atomic128/detect/aarch64_std.rs
@@ -25,7 +25,10 @@ pub(crate) fn has_lse() -> bool {
     #[allow(unreachable_code)]
     {
         #[cfg(all(
-            not(portable_atomic_no_aarch64_target_feature),
+            not(any(
+                portable_atomic_no_aarch64_target_feature,
+                portable_atomic_unstable_aarch64_target_feature
+            )),
             // https://github.com/rust-lang/stdarch/blob/a0c30f3e3c75adcd6ee7efc94014ebcead61c507/crates/std_detect/src/detect/mod.rs
             // It is fine to use std for targets that we know can be linked to std.
             // Note: std may not be available on tier 3 such as aarch64 FreeBSD/OpenBSD.

--- a/src/imp/atomic128/detect/common.rs
+++ b/src/imp/atomic128/detect/common.rs
@@ -249,7 +249,10 @@ mod tests_aarch64_common {
             #[cfg(any(
                 target_feature = "lse",
                 portable_atomic_target_feature = "lse",
-                not(portable_atomic_no_aarch64_target_feature),
+                all(
+                    not(portable_atomic_no_aarch64_target_feature),
+                    not(portable_atomic_no_outline_atomics)
+                ),
             ))]
             unsafe {
                 use core::{cell::UnsafeCell, sync::atomic::Ordering};
@@ -265,7 +268,10 @@ mod tests_aarch64_common {
             }
         } else {
             assert!(!detect().test(CpuInfo::HAS_LSE));
-            #[cfg(not(portable_atomic_no_aarch64_target_feature))]
+            #[cfg(not(any(
+                portable_atomic_no_aarch64_target_feature,
+                portable_atomic_unstable_aarch64_target_feature
+            )))]
             {
                 assert!(!std::arch::is_aarch64_feature_detected!("lse"));
             }
@@ -281,7 +287,10 @@ mod tests_aarch64_common {
             }
         } else {
             assert!(!detect().test(CpuInfo::HAS_LSE2));
-            // #[cfg(not(portable_atomic_no_aarch64_target_feature))]
+            // #[cfg(not(any(
+            //     portable_atomic_no_aarch64_target_feature,
+            //     portable_atomic_unstable_aarch64_target_feature
+            // )))]
             // {
             //     assert!(!std::arch::is_aarch64_feature_detected!("lse2"));
             // }
@@ -295,7 +304,10 @@ mod tests_aarch64_common {
             assert!(detect().test(CpuInfo::HAS_LSE128));
         } else {
             assert!(!detect().test(CpuInfo::HAS_LSE128));
-            // #[cfg(not(portable_atomic_no_aarch64_target_feature))]
+            // #[cfg(not(any(
+            //     portable_atomic_no_aarch64_target_feature,
+            //     portable_atomic_unstable_aarch64_target_feature
+            // )))]
             // {
             //     assert!(!std::arch::is_aarch64_feature_detected!("lse128"));
             // }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,10 +230,19 @@ See also [the `atomic128` module's readme](https://github.com/taiki-e/portable-a
 // These features are already stabilized or have already been removed from compilers,
 // and can safely be enabled for old nightly as long as version detection works.
 // - cfg(target_has_atomic)
+// - #[target_feature(enable = "lse")] on AArch64
 // - asm! on ARM, AArch64, RISC-V, x86_64
 // - llvm_asm! on AVR (tier 3) and MSP430 (tier 3)
 // - #[instruction_set] on non-Linux pre-v6 ARM (tier 3)
 #![cfg_attr(portable_atomic_unstable_cfg_target_has_atomic, feature(cfg_target_has_atomic))]
+#![cfg_attr(
+    all(
+        target_arch = "aarch64",
+        portable_atomic_unstable_aarch64_target_feature,
+        not(portable_atomic_no_outline_atomics),
+    ),
+    feature(aarch64_target_feature)
+)]
 #![cfg_attr(
     all(
         portable_atomic_unstable_asm,

--- a/target-specs/aarch64-unknown-linux-uclibc.json
+++ b/target-specs/aarch64-unknown-linux-uclibc.json
@@ -1,0 +1,18 @@
+{
+  "arch": "aarch64",
+  "crt-static-respected": true,
+  "data-layout": "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
+  "dynamic-linking": true,
+  "env": "uclibc",
+  "has-rpath": true,
+  "has-thread-local": true,
+  "llvm-target": "aarch64-unknown-linux-uclibc",
+  "max-atomic-width": 128,
+  "os": "linux",
+  "position-independent-executables": true,
+  "relro-level": "full",
+  "supported-split-debuginfo": ["packed", "unpacked", "off"],
+  "target-family": ["unix"],
+  "target-mcount": "\u0001_mcount",
+  "target-pointer-width": "64"
+}


### PR DESCRIPTION
Similar to https://github.com/taiki-e/portable-atomic/commit/3f5d42f70485fd022c2e4a847c81737e3651bbde.

This also supports building for aarch64 linux-uclibc.