### PR TITLE
detect: Workaround Exynos 9810 bug on aarch64 Android

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -42,6 +42,7 @@ docsrs
 doctests
 DWCAS
 endianness
+exynos
 FIQs
 getauxval
 hartid


### PR DESCRIPTION
Samsung Exynos 9810 has a bug that big and little cores have different ISAs. And on older Android (pre-9), the kernel incorrectly reports that features available only on some cores are available on all cores.

See https://reviews.llvm.org/D114523 for details.

Our own run-time detection code has not been released yet and is not a problem, but portable-atomic < 1.1 may have been affected by this issue since rustc 1.69-nightly when is_aarch64_feature_detected supported run-time detection on Android. (https://github.com/rust-lang/stdarch/pull/1351, https://github.com/rust-lang/rust/pull/105784)

A patch on stdarch side: https://github.com/rust-lang/stdarch/pull/1378