### PR TITLE
Expose as_ptr

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Portable atomic types including support for 128-bit atomics, atomic float, etc.
 - Provide `AtomicF32` and `AtomicF64`. ([optional, requires the `float` feature](#optional-features-float))
 - Provide atomic load/store for targets where atomic is not available at all in the standard library. (RISC-V without A-extension, MSP430, AVR)
 - Provide atomic CAS for targets where atomic CAS is not available in the standard library. (thumbv6m, pre-v6 ARM, RISC-V without A-extension, MSP430, AVR, etc.) (always enabled for MSP430 and AVR, [optional](#optional-cfg-unsafe-assume-single-core) otherwise)
-- Provide stable equivalents of the standard library's atomic types' unstable APIs, such as [`AtomicPtr::fetch_*`](https://github.com/rust-lang/rust/issues/99108), [`AtomicBool::fetch_not`](https://github.com/rust-lang/rust/issues/98485).
+- Provide stable equivalents of the standard library's atomic types' unstable APIs, such as [`AtomicPtr::fetch_*`](https://github.com/rust-lang/rust/issues/99108), [`AtomicBool::fetch_not`](https://github.com/rust-lang/rust/issues/98485), [`Atomic*::as_ptr`](https://github.com/rust-lang/rust/issues/66893).
 - Make features that require newer compilers, such as [fetch_max](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_max), [fetch_min](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_min), [fetch_update](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicPtr.html#method.fetch_update), and [stronger CAS failure ordering](https://github.com/rust-lang/rust/pull/98383) available on Rust 1.34+.
 - Provide workaround for bugs in the standard library's atomic-related APIs, such as [rust-lang/rust#100650], `fence`/`compiler_fence` on MSP430 that cause LLVM error, etc.
 

--- a/bench/benches/imp/spinlock_fallback.rs
+++ b/bench/benches/imp/spinlock_fallback.rs
@@ -293,6 +293,11 @@ macro_rules! atomic_int {
             pub(crate) fn not(&self, order: Ordering) {
                 self.fetch_not(order);
             }
+
+            #[inline]
+            pub(crate) const fn as_ptr(&self) -> *mut $int_type {
+                self.v.get()
+            }
         }
     };
     (int, $atomic_type:ident, $int_type:ident, $align:literal) => {

--- a/build.rs
+++ b/build.rs
@@ -64,6 +64,10 @@ fn main() {
     if !version.probe(56, 2021, 8, 1) {
         println!("cargo:rustc-cfg=portable_atomic_no_core_unwind_safe");
     }
+    // const_raw_ptr_deref stabilized in Rust 1.58 (nightly-2021-11-15): https://github.com/rust-lang/rust/pull/89551
+    if !version.probe(58, 2021, 11, 14) {
+        println!("cargo:rustc-cfg=portable_atomic_no_const_raw_ptr_deref");
+    }
     // asm stabilized in Rust 1.59 (nightly-2021-12-16): https://github.com/rust-lang/rust/pull/91728
     let no_asm = !version.probe(59, 2021, 12, 15);
     let mut unstable_asm = false;

--- a/src/imp/atomic128/intrinsics.rs
+++ b/src/imp/atomic128/intrinsics.rs
@@ -592,6 +592,11 @@ macro_rules! atomic128 {
             pub(crate) fn not(&self, order: Ordering) {
                 self.fetch_not(order);
             }
+
+            #[inline]
+            pub(crate) const fn as_ptr(&self) -> *mut $int_type {
+                self.v.get()
+            }
         }
     };
     (uint, $atomic_type:ident, $int_type:ident, $atomic_max:ident, $atomic_min:ident) => {

--- a/src/imp/atomic128/macros.rs
+++ b/src/imp/atomic128/macros.rs
@@ -216,6 +216,11 @@ macro_rules! atomic128 {
             pub(crate) fn not(&self, order: Ordering) {
                 self.fetch_not(order);
             }
+
+            #[inline]
+            pub(crate) const fn as_ptr(&self) -> *mut $int_type {
+                self.v.get()
+            }
         }
     };
     (int, $atomic_type:ident, $int_type:ident) => {
@@ -432,6 +437,11 @@ macro_rules! atomic128 {
             #[inline]
             pub(crate) fn not(&self, order: Ordering) {
                 self.fetch_not(order);
+            }
+
+            #[inline]
+            pub(crate) const fn as_ptr(&self) -> *mut $int_type {
+                self.v.get()
             }
         }
     };

--- a/src/imp/core_atomic.rs
+++ b/src/imp/core_atomic.rs
@@ -42,12 +42,17 @@ impl AtomicBool {
         crate::utils::assert_store_ordering(order); // for track_caller (compiler can omit double check)
         self.inner.store(val, order);
     }
-    #[inline]
-    pub(crate) fn as_ptr(&self) -> *mut bool {
-        // SAFETY: Self is #[repr(C)] and internally UnsafeCell<u8>.
-        // See also https://github.com/rust-lang/rust/pull/66705 and
-        // https://github.com/rust-lang/rust/issues/66136#issuecomment-557867116.
-        unsafe { (*(self as *const Self as *const core::cell::UnsafeCell<u8>)).get() as *mut bool }
+    const_fn! {
+        const_if: #[cfg(not(portable_atomic_no_const_raw_ptr_deref))];
+        #[inline]
+        pub(crate) const fn as_ptr(&self) -> *mut bool {
+            // SAFETY: Self is #[repr(C)] and internally UnsafeCell<u8>.
+            // See also https://github.com/rust-lang/rust/pull/66705 and
+            // https://github.com/rust-lang/rust/issues/66136#issuecomment-557867116.
+            unsafe {
+                (*(self as *const Self as *const core::cell::UnsafeCell<u8>)).get() as *mut bool
+            }
+        }
     }
 }
 #[cfg_attr(portable_atomic_no_cfg_target_has_atomic, cfg(not(portable_atomic_no_atomic_cas)))]
@@ -130,12 +135,15 @@ impl<T> AtomicPtr<T> {
         crate::utils::assert_store_ordering(order); // for track_caller (compiler can omit double check)
         self.inner.store(ptr, order);
     }
-    #[inline]
-    pub(crate) fn as_ptr(&self) -> *mut *mut T {
-        // SAFETY: Self is #[repr(C)] and internally UnsafeCell<*mut T>.
-        // See also https://github.com/rust-lang/rust/pull/66705 and
-        // https://github.com/rust-lang/rust/issues/66136#issuecomment-557867116.
-        unsafe { (*(self as *const Self as *const core::cell::UnsafeCell<*mut T>)).get() }
+    const_fn! {
+        const_if: #[cfg(not(portable_atomic_no_const_raw_ptr_deref))];
+        #[inline]
+        pub(crate) const fn as_ptr(&self) -> *mut *mut T {
+            // SAFETY: Self is #[repr(C)] and internally UnsafeCell<*mut T>.
+            // See also https://github.com/rust-lang/rust/pull/66705 and
+            // https://github.com/rust-lang/rust/issues/66136#issuecomment-557867116.
+            unsafe { (*(self as *const Self as *const core::cell::UnsafeCell<*mut T>)).get() }
+        }
     }
 }
 #[cfg_attr(portable_atomic_no_cfg_target_has_atomic, cfg(not(portable_atomic_no_atomic_cas)))]
@@ -223,13 +231,16 @@ macro_rules! atomic_int {
                 crate::utils::assert_store_ordering(order); // for track_caller (compiler can omit double check)
                 self.inner.store(val, order);
             }
-            #[inline]
-            pub(crate) fn as_ptr(&self) -> *mut $int_type {
-                // SAFETY: Self is #[repr(C)] and internally UnsafeCell<$int_type>.
-                // See also https://github.com/rust-lang/rust/pull/66705 and
-                // https://github.com/rust-lang/rust/issues/66136#issuecomment-557867116.
-                unsafe {
-                    (*(self as *const Self as *const core::cell::UnsafeCell<$int_type>)).get()
+            const_fn! {
+                const_if: #[cfg(not(portable_atomic_no_const_raw_ptr_deref))];
+                #[inline]
+                pub(crate) const fn as_ptr(&self) -> *mut $int_type {
+                    // SAFETY: Self is #[repr(C)] and internally UnsafeCell<$int_type>.
+                    // See also https://github.com/rust-lang/rust/pull/66705 and
+                    // https://github.com/rust-lang/rust/issues/66136#issuecomment-557867116.
+                    unsafe {
+                        (*(self as *const Self as *const core::cell::UnsafeCell<$int_type>)).get()
+                    }
                 }
             }
         }

--- a/src/imp/fallback/imp.rs
+++ b/src/imp/fallback/imp.rs
@@ -316,6 +316,12 @@ macro_rules! atomic {
             pub(crate) fn not(&self, order: Ordering) {
                 self.fetch_not(order);
             }
+
+            #[cfg(any(test, not(portable_atomic_unstable_cmpxchg16b_target_feature)))]
+            #[inline]
+            pub(crate) const fn as_ptr(&self) -> *mut $int_type {
+                self.v.get()
+            }
         }
     };
     (int, $atomic_type:ident, $int_type:ident, $align:literal) => {

--- a/src/imp/fallback/utils.rs
+++ b/src/imp/fallback/utils.rs
@@ -96,7 +96,7 @@ const SPIN_LIMIT: u32 = 4;
 
 impl Backoff {
     #[inline]
-    pub(crate) fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self { step: 0 }
     }
 

--- a/src/imp/float.rs
+++ b/src/imp/float.rs
@@ -60,11 +60,14 @@ macro_rules! atomic_float {
                 self.as_bits().store(val.to_bits(), order)
             }
 
-            #[inline]
-            pub(crate) fn as_bits(&self) -> &crate::$atomic_int_type {
-                // SAFETY: $atomic_type and $atomic_int_type have the same layout,
-                // and there is no concurrent access to the value that does not go through this method.
-                unsafe { &*(self as *const $atomic_type as *const crate::$atomic_int_type) }
+            const_fn! {
+                const_if: #[cfg(not(portable_atomic_no_const_raw_ptr_deref))];
+                #[inline]
+                pub(crate) const fn as_bits(&self) -> &crate::$atomic_int_type {
+                    // SAFETY: $atomic_type and $atomic_int_type have the same layout,
+                    // and there is no concurrent access to the value that does not go through this method.
+                    unsafe { &*(self as *const $atomic_type as *const crate::$atomic_int_type) }
+                }
             }
 
             #[inline]

--- a/src/imp/float.rs
+++ b/src/imp/float.rs
@@ -66,6 +66,11 @@ macro_rules! atomic_float {
                 // and there is no concurrent access to the value that does not go through this method.
                 unsafe { &*(self as *const $atomic_type as *const crate::$atomic_int_type) }
             }
+
+            #[inline]
+            pub(crate) const fn as_ptr(&self) -> *mut $float_type {
+                self.v.get()
+            }
         }
 
         #[cfg_attr(

--- a/src/imp/interrupt/mod.rs
+++ b/src/imp/interrupt/mod.rs
@@ -265,6 +265,11 @@ impl AtomicBool {
             result != 0
         })
     }
+
+    #[inline]
+    pub(crate) const fn as_ptr(&self) -> *mut bool {
+        self.v.get() as *mut bool
+    }
 }
 
 #[cfg(not(all(target_arch = "msp430", not(feature = "critical-section"))))]
@@ -415,6 +420,11 @@ impl<T> AtomicPtr<T> {
     ) -> Result<*mut T, *mut T> {
         self.compare_exchange(current, new, success, failure)
     }
+
+    #[inline]
+    pub(crate) const fn as_ptr(&self) -> *mut *mut T {
+        self.p.get()
+    }
 }
 
 macro_rules! atomic_int {
@@ -454,6 +464,11 @@ macro_rules! atomic_int {
             #[inline]
             pub(crate) fn into_inner(self) -> $int_type {
                 self.v.into_inner()
+            }
+
+            #[inline]
+            pub(crate) const fn as_ptr(&self) -> *mut $int_type {
+                self.v.get()
             }
         }
     };

--- a/src/imp/riscv.rs
+++ b/src/imp/riscv.rs
@@ -71,6 +71,12 @@ impl AtomicBool {
             u8::atomic_store(self.v.get(), val as u8, order);
         }
     }
+
+    #[cfg(any(test, not(portable_atomic_unsafe_assume_single_core)))]
+    #[inline]
+    pub(crate) const fn as_ptr(&self) -> *mut bool {
+        self.v.get().cast::<bool>()
+    }
 }
 
 #[repr(transparent)]
@@ -136,6 +142,12 @@ impl<T> AtomicPtr<T> {
             usize::atomic_store(self.p.get().cast::<usize>(), ptr as usize, order);
         }
     }
+
+    #[cfg(any(test, not(portable_atomic_unsafe_assume_single_core)))]
+    #[inline]
+    pub(crate) const fn as_ptr(&self) -> *mut *mut T {
+        self.p.get()
+    }
 }
 
 macro_rules! atomic_int {
@@ -199,6 +211,12 @@ macro_rules! atomic_int {
                 unsafe {
                     $int_type::atomic_store(self.v.get(), val, order);
                 }
+            }
+
+            #[cfg(any(test, not(portable_atomic_unsafe_assume_single_core)))]
+            #[inline]
+            pub(crate) const fn as_ptr(&self) -> *mut $int_type {
+                self.v.get()
             }
         }
 

--- a/src/imp/x86.rs
+++ b/src/imp/x86.rs
@@ -41,16 +41,6 @@ macro_rules! atomic_int {
                     );
                 }
             }
-
-            #[inline]
-            pub(crate) fn as_ptr(&self) -> *mut $int_type {
-                // SAFETY: Self is #[repr(C)] and internally UnsafeCell<$int_type>.
-                // See also https://github.com/rust-lang/rust/pull/66705 and
-                // https://github.com/rust-lang/rust/issues/66136#issuecomment-557867116.
-                unsafe {
-                    (*(self as *const Self).cast::<core::cell::UnsafeCell<$int_type>>()).get()
-                }
-            }
         }
     };
     (int, $atomic_type:ident, $int_type:ident, $ptr_size:tt) => {

--- a/src/tests/helper.rs
+++ b/src/tests/helper.rs
@@ -52,6 +52,7 @@ macro_rules! __test_atomic_int_load_store {
             let mut a = <$atomic_type>::new(10);
             assert_eq!(*a.get_mut(), 10);
             *a.get_mut() = 5;
+            assert_eq!(a.as_ptr() as *const (), &a as *const _ as *const ());
             assert_eq!(a.into_inner(), 5);
         }
         #[test]
@@ -125,6 +126,7 @@ macro_rules! __test_atomic_float_load_store {
             let mut a = <$atomic_type>::new(10.0);
             assert_eq!(*a.get_mut(), 10.0);
             *a.get_mut() = 5.0;
+            assert_eq!(a.as_ptr() as *const (), &a as *const _ as *const ());
             assert_eq!(a.into_inner(), 5.0);
         }
         #[test]
@@ -158,6 +160,7 @@ macro_rules! __test_atomic_bool_load_store {
             let mut a = <$atomic_type>::new(false);
             assert_eq!(*a.get_mut(), false);
             *a.get_mut() = true;
+            assert_eq!(a.as_ptr() as *const (), &a as *const _ as *const ());
             assert_eq!(a.into_inner(), true);
         }
         #[test]
@@ -193,6 +196,7 @@ macro_rules! __test_atomic_ptr_load_store {
             let mut a = <$atomic_type>::new(ptr::null_mut());
             assert!(a.get_mut().is_null());
             *a.get_mut() = &mut v;
+            assert_eq!(a.as_ptr() as *const (), &a as *const _ as *const ());
             assert!(!a.into_inner().is_null());
         }
         #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -183,6 +183,20 @@ macro_rules! ifunc {
     }};
 }
 
+macro_rules! const_fn {
+    (
+        const_if: #[cfg($($cfg:tt)+)];
+        $(#[$($attr:tt)*])* $vis:vis const fn $($rest:tt)*
+    ) => {
+        #[cfg($($cfg)+)]
+        $(#[$($attr)*])*
+        $vis const fn $($rest)*
+        #[cfg(not($($cfg)+))]
+        $(#[$($attr)*])*
+        $vis fn $($rest)*
+    };
+}
+
 // We do not provide `nand` because it cannot be optimized on neither x86 nor MSP430.
 // https://godbolt.org/z/x88voWGov
 macro_rules! no_fetch_ops_impl {


### PR DESCRIPTION
> Returns a mutable pointer to the underlying {bool,pointer,integer,float}.
>
> Returning an `*mut` pointer from a shared reference to this atomic is safe because the atomic types work with interior mutability. Any use of the returned raw pointer requires an `unsafe` block and has to uphold the safety requirements:
> - If this atomic type is [lock-free](Self::is_lock_free), any concurrent operations on it must be atomic.
> - Otherwise, any concurrent operations on it must be compatible with operations performed by this atomic type.
>
> This is `const fn` on Rust 1.58+.