### PR TITLE
util: Prevent weak counter overflow in Arc::downgrade

### DIFF
--- a/portable-atomic-util/CHANGELOG.md
+++ b/portable-atomic-util/CHANGELOG.md
@@ -10,6 +10,10 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Prevent weak counter overflow in `Arc::downgrade`. ([#83](https://github.com/taiki-e/portable-atomic/pull/83))
+
+  This fixes [a potential unsoundness recently found in the standard library's `Arc`](https://github.com/rust-lang/rust/issues/108706).
+
 ## [0.1.0] - 2023-01-15
 
 Initial release


### PR DESCRIPTION
This fixes a [potential unsoundness recently found in the standard library's `Arc`](https://github.com/rust-lang/rust/issues/108706).