### PR TITLE
interrupt: Support Xtensa

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -69,6 +69,7 @@ libpthread
 libstd
 libtcl
 libtest
+linkall
 lqarx
 lrcpc
 lwsync
@@ -86,6 +87,7 @@ neoverse
 newrepo
 newtype
 nographic
+nostartfiles
 nostdinc
 opensbi
 osfmk
@@ -142,6 +144,7 @@ versatilepb
 virt
 vmlinux
 vmovdqa
+wokwi
 xadd
 xchg
 xgetbv

--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -46,6 +46,7 @@ dedup
 dlsym
 doctests
 DWCAS
+espup
 exynos
 FIQs
 getauxval
@@ -98,6 +99,7 @@ qword
 RAII
 rcpc
 reentrancy
+rsil
 sbcs
 seqlock
 setb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,7 @@ jobs:
       - run: espup install
       - run: tools/no-std.sh
       - run: tools/build.sh +esp xtensa-esp32-none-elf
-      # - run: tools/no-std.sh +esp xtensa-esp32-none-elf # TODO: run test with simulator on CI
+      - run: tools/no-std.sh +esp xtensa-esp32-none-elf
 
   miri:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,10 @@ jobs:
           persist-credentials: false
       - name: Install Rust
         run: rustup toolchain add nightly --no-self-update && rustup default nightly
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: espup
       - run: |
           set -euxo pipefail
           sudo apt-get -o Acquire::Retries=10 -qq update && sudo apt-get -o Acquire::Retries=10 -o Dpkg::Use-Pty=0 install -y --no-install-recommends \
@@ -266,7 +270,10 @@ jobs:
           sudo mv "opensbi-${OPENSBI_VERSION}-rv-bin/share/opensbi/ilp32/generic/firmware/fw_dynamic.bin" /usr/share/qemu/opensbi-riscv32-generic-fw_dynamic.bin
           sudo mv "opensbi-${OPENSBI_VERSION}-rv-bin/share/opensbi/ilp32/generic/firmware/fw_dynamic.elf" /usr/share/qemu/opensbi-riscv32-generic-fw_dynamic.elf
           rm -rf "opensbi-${OPENSBI_VERSION}-rv-bin"
+      - run: espup install
       - run: tools/no-std.sh
+      - run: tools/build.sh +esp xtensa-esp32-none-elf
+      # - run: tools/no-std.sh +esp xtensa-esp32-none-elf # TODO: run test with simulator on CI
 
   miri:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Support `portable_atomic_unsafe_assume_single_core` cfg on Xtensa targets without atomic CAS. ([#86](https://github.com/taiki-e/portable-atomic/pull/86))
+
 ## [1.2.0] - 2023-03-25
 
 - Make 64-bit atomics lock-free on ARM Linux/Android targets that do not have 64-bit atomics (e.g., armv5te-unknown-linux-gnueabi, arm-linux-androideabi, etc.) when the kernel version is 3.1 or later. ([#82](https://github.com/taiki-e/portable-atomic/pull/82))

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Portable atomic types including support for 128-bit atomics, atomic float, etc.
 - Provide `AtomicI128` and `AtomicU128`.
 - Provide `AtomicF32` and `AtomicF64`. ([optional, requires the `float` feature](#optional-features-float))
 - Provide atomic load/store for targets where atomic is not available at all in the standard library. (RISC-V without A-extension, MSP430, AVR)
-- Provide atomic CAS for targets where atomic CAS is not available in the standard library. (thumbv6m, pre-v6 ARM, RISC-V without A-extension, MSP430, AVR, etc.) (always enabled for MSP430 and AVR, [optional](#optional-cfg) otherwise)
+- Provide atomic CAS for targets where atomic CAS is not available in the standard library. (thumbv6m, pre-v6 ARM, RISC-V without A-extension, MSP430, AVR, Xtensa, etc.) (always enabled for MSP430 and AVR, [optional](#optional-cfg) otherwise)
 - Provide stable equivalents of the standard library's atomic types' unstable APIs, such as [`AtomicPtr::fetch_*`](https://github.com/rust-lang/rust/issues/99108), [`AtomicBool::fetch_not`](https://github.com/rust-lang/rust/issues/98485), [`Atomic*::as_ptr`](https://github.com/rust-lang/rust/issues/66893).
 - Make features that require newer compilers, such as [fetch_max](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_max), [fetch_min](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_min), [fetch_update](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicPtr.html#method.fetch_update), and [stronger CAS failure ordering](https://github.com/rust-lang/rust/pull/98383) available on Rust 1.34+.
 - Provide workaround for bugs in the standard library's atomic-related APIs, such as [rust-lang/rust#100650], `fence`/`compiler_fence` on MSP430 that cause LLVM error, etc.
@@ -136,7 +136,7 @@ RUSTFLAGS="--cfg portable_atomic_unsafe_assume_single_core" cargo ...
 
   This is intentionally not an optional feature. (If this is an optional feature, dependencies can implicitly enable the feature, resulting in the use of unsound code without the end-user being aware of it.)
 
-  ARMv6-M (thumbv6m), pre-v6 ARM (e.g., thumbv4t, thumbv5te), RISC-V without A-extension are currently supported.
+  ARMv6-M (thumbv6m), pre-v6 ARM (e.g., thumbv4t, thumbv5te), RISC-V without A-extension, and Xtensa are currently supported.
 
   Since all MSP430 and AVR are single-core, we always provide atomic CAS for them without this cfg.
 

--- a/src/imp/interrupt/README.md
+++ b/src/imp/interrupt/README.md
@@ -3,7 +3,7 @@
 This module is used to provide atomic CAS for targets where atomic CAS is not available in the standard library.
 
 - On MSP430 and AVR, they are always single-core, so this module is always used.
-- On ARMv6-M (thumbv6m), pre-v6 ARM (e.g., thumbv4t, thumbv5te), RISC-V without A-extension, they could be multi-core, so this module is used when `--cfg portable_atomic_unsafe_assume_single_core` is enabled.
+- On ARMv6-M (thumbv6m), pre-v6 ARM (e.g., thumbv4t, thumbv5te), RISC-V without A-extension, and Xtensa, they could be multi-core, so this module is used when `--cfg portable_atomic_unsafe_assume_single_core` is enabled.
 
 The implementation uses privileged instructions to disable interrupts, so it usually doesn't work on unprivileged mode.
 Enabling this cfg in an environment where privileged instructions are not available, or if the instructions used are not sufficient to disable interrupts in the system, it is also usually considered **unsound**, although the details are system-dependent.
@@ -19,6 +19,7 @@ For some targets, the implementation can be changed by explicitly enabling cfg.
 - On RISC-V (without A-extension) with `--cfg portable_atomic_s_mode`, this disables interrupts by modifying the SIE (Supervisor Interrupt Enable) bit of the `sstatus` register.
 - On MSP430, this disables interrupts by modifying the GIE (Global Interrupt Enable) bit of the status register (SR).
 - On AVR, this disables interrupts by modifying the I (Global Interrupt Enable) bit of the status register (SREG).
+- On Xtensa, this disables interrupts by modifying the PS special register.
 
 Some operations don't require disabling interrupts (loads and stores on targets except for AVR, but additionally on MSP430 `add`, `sub`, `and`, `or`, `xor`, `not`). However, when the `critical-section` feature is enabled, critical sections are taken for all atomic operations.
 

--- a/src/imp/interrupt/mod.rs
+++ b/src/imp/interrupt/mod.rs
@@ -60,6 +60,7 @@ use arch::atomic;
 #[cfg_attr(target_arch = "avr", path = "avr.rs")]
 #[cfg_attr(target_arch = "msp430", path = "msp430.rs")]
 #[cfg_attr(any(target_arch = "riscv32", target_arch = "riscv64"), path = "riscv.rs")]
+#[cfg_attr(target_arch = "xtensa", path = "xtensa.rs")]
 mod arch;
 
 use core::{cell::UnsafeCell, sync::atomic::Ordering};

--- a/src/imp/interrupt/xtensa.rs
+++ b/src/imp/interrupt/xtensa.rs
@@ -1,0 +1,42 @@
+// Refs:
+// - Xtensa Instruction Set Architecture (ISA) Reference Manual https://0x04.net/~mwk/doc/xtensa.pdf
+// - Linux kernel's Xtensa atomic implementation https://github.com/torvalds/linux/blob/v6.1/arch/xtensa/include/asm/atomic.h
+
+#[cfg(not(portable_atomic_no_asm))]
+use core::arch::asm;
+
+pub(super) use core::sync::atomic;
+
+pub(super) type State = u32;
+
+/// Disables interrupts and returns the previous interrupt state.
+#[inline]
+pub(super) fn disable() -> State {
+    let r: u32;
+    // SAFETY: reading the PS special register and disabling all interrupts is safe.
+    // (see module-level comments of interrupt/mod.rs on the safety of using privileged instructions)
+    unsafe {
+        // Do not use `nomem` and `readonly` because prevent subsequent memory accesses from being reordered before interrupts are disabled.
+        // Interrupt level 15 to disable all interrupts.
+        // SYNC after RSIL is not required.
+        asm!("rsil {0}, 15", out(reg) r, options(nostack));
+    }
+    r
+}
+
+/// Restores the previous interrupt state.
+#[inline]
+pub(super) unsafe fn restore(r: State) {
+    // SAFETY: the caller must guarantee that the state was retrieved by the previous `disable`,
+    // and we've checked that interrupts were enabled before disabling interrupts.
+    unsafe {
+        // Do not use `nomem` and `readonly` because prevent preceding memory accesses from being reordered after interrupts are enabled.
+        // SYNC after WSR is required to guarantee that subsequent RSIL read the written value.
+        asm!(
+            "wsr.ps {0}",
+            "rsync",
+            in(reg) r,
+            options(nostack),
+        );
+    }
+}

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -166,6 +166,7 @@ mod fallback;
     target_arch = "msp430",
     target_arch = "riscv32",
     target_arch = "riscv64",
+    target_arch = "xtensa",
 ))]
 mod interrupt;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ Portable atomic types including support for 128-bit atomics, atomic float, etc.
 - Provide `AtomicI128` and `AtomicU128`.
 - Provide `AtomicF32` and `AtomicF64`. ([optional, requires the `float` feature](#optional-features-float))
 - Provide atomic load/store for targets where atomic is not available at all in the standard library. (RISC-V without A-extension, MSP430, AVR)
-- Provide atomic CAS for targets where atomic CAS is not available in the standard library. (thumbv6m, pre-v6 ARM, RISC-V without A-extension, MSP430, AVR, etc.) (always enabled for MSP430 and AVR, [optional](#optional-cfg) otherwise)
+- Provide atomic CAS for targets where atomic CAS is not available in the standard library. (thumbv6m, pre-v6 ARM, RISC-V without A-extension, MSP430, AVR, Xtensa, etc.) (always enabled for MSP430 and AVR, [optional](#optional-cfg) otherwise)
 - Provide stable equivalents of the standard library's atomic types' unstable APIs, such as [`AtomicPtr::fetch_*`](https://github.com/rust-lang/rust/issues/99108), [`AtomicBool::fetch_not`](https://github.com/rust-lang/rust/issues/98485), [`Atomic*::as_ptr`](https://github.com/rust-lang/rust/issues/66893).
 - Make features that require newer compilers, such as [fetch_max](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_max), [fetch_min](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.fetch_min), [fetch_update](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicPtr.html#method.fetch_update), and [stronger CAS failure ordering](https://github.com/rust-lang/rust/pull/98383) available on Rust 1.34+.
 - Provide workaround for bugs in the standard library's atomic-related APIs, such as [rust-lang/rust#100650], `fence`/`compiler_fence` on MSP430 that cause LLVM error, etc.
@@ -128,7 +128,7 @@ RUSTFLAGS="--cfg portable_atomic_unsafe_assume_single_core" cargo ...
 
   This is intentionally not an optional feature. (If this is an optional feature, dependencies can implicitly enable the feature, resulting in the use of unsound code without the end-user being aware of it.)
 
-  ARMv6-M (thumbv6m), pre-v6 ARM (e.g., thumbv4t, thumbv5te), RISC-V without A-extension are currently supported.
+  ARMv6-M (thumbv6m), pre-v6 ARM (e.g., thumbv4t, thumbv5te), RISC-V without A-extension, and Xtensa are currently supported.
 
   Since all MSP430 and AVR are single-core, we always provide atomic CAS for them without this cfg.
 
@@ -213,7 +213,7 @@ RUSTFLAGS="--cfg portable_atomic_unsafe_assume_single_core" cargo ...
     clippy::unreadable_literal,
 )]
 // asm_experimental_arch
-// AVR and MSP430 are tier 3 platforms and require nightly anyway.
+// AVR, MSP430, and Xtensa are tier 3 platforms and require nightly anyway.
 // On tier 2 platforms (powerpc64 and s390x), we use cfg set by build script to
 // determine whether this feature is available or not.
 #![cfg_attr(
@@ -222,6 +222,7 @@ RUSTFLAGS="--cfg portable_atomic_unsafe_assume_single_core" cargo ...
         any(
             target_arch = "avr",
             target_arch = "msp430",
+            all(target_arch = "xtensa", portable_atomic_unsafe_assume_single_core),
             all(
                 portable_atomic_unstable_asm_experimental_arch,
                 target_arch = "powerpc64",
@@ -338,6 +339,7 @@ compile_error!(
             target_arch = "msp430",
             target_arch = "riscv32",
             target_arch = "riscv64",
+            target_arch = "xtensa",
         )),
     ))
 )]
@@ -351,6 +353,7 @@ compile_error!(
             target_arch = "msp430",
             target_arch = "riscv32",
             target_arch = "riscv64",
+            target_arch = "xtensa",
         )),
     ))
 )]

--- a/tests/api-test/src/helper.rs
+++ b/tests/api-test/src/helper.rs
@@ -139,7 +139,10 @@ macro_rules! __test_atomic_int {
                 assert_eq!(a.load(Ordering::Relaxed), 0b100001);
             }
         }
+        // TODO: wrong result or compiler segfault
+        #[cfg(not(target_arch = "xtensa"))]
         __run_test!(fetch_nand);
+        #[cfg(not(target_arch = "xtensa"))]
         fn fetch_nand() {
             for &order in &test_helper::SWAP_ORDERINGS {
                 let a = <$atomic_type>::new(0x13);
@@ -179,7 +182,10 @@ macro_rules! __test_atomic_int {
                 assert_eq!(a.load(Ordering::Relaxed), 0b011110);
             }
         }
+        // TODO: compiler bug "Undefined temporary symbol .LBB<num>"
+        #[cfg(not(target_arch = "xtensa"))]
         __run_test!(fetch_max);
+        #[cfg(not(target_arch = "xtensa"))]
         fn fetch_max() {
             for &order in &test_helper::SWAP_ORDERINGS {
                 let a = <$atomic_type>::new(23);
@@ -194,7 +200,10 @@ macro_rules! __test_atomic_int {
                 assert_eq!(a.load(Ordering::Relaxed), 1);
             }
         }
+        // TODO: compiler bug "Undefined temporary symbol .LBB<num>"
+        #[cfg(not(target_arch = "xtensa"))]
         __run_test!(fetch_min);
+        #[cfg(not(target_arch = "xtensa"))]
         fn fetch_min() {
             for &order in &test_helper::SWAP_ORDERINGS {
                 let a = <$atomic_type>::new(23);
@@ -384,7 +393,10 @@ macro_rules! __test_atomic_float {
                 assert_eq!(a.load(Ordering::Relaxed), $float_type::MIN - 1.0);
             }
         }
+        // TODO: undefined reference to `f{max,min}{,f}' (fixed in https://github.com/rust-lang/compiler-builtins/pull/517)
+        #[cfg(not(target_arch = "xtensa"))]
         __run_test!(fetch_max);
+        #[cfg(not(target_arch = "xtensa"))]
         fn fetch_max() {
             for &order in &test_helper::SWAP_ORDERINGS {
                 let a = <$atomic_type>::new(23.0);
@@ -399,7 +411,10 @@ macro_rules! __test_atomic_float {
                 assert_eq!(a.load(Ordering::Relaxed), 1.0);
             }
         }
+        // TODO: undefined reference to `f{max,min}{,f}' (fixed in https://github.com/rust-lang/compiler-builtins/pull/517)
+        #[cfg(not(target_arch = "xtensa"))]
         __run_test!(fetch_min);
+        #[cfg(not(target_arch = "xtensa"))]
         fn fetch_min() {
             for &order in &test_helper::SWAP_ORDERINGS {
                 let a = <$atomic_type>::new(23.0);

--- a/tests/xtensa/.cargo/config.toml
+++ b/tests/xtensa/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target-dir = "../../target"
+
+[target.xtensa-esp32-none-elf]
+runner = "wokwi-server --chip esp32"

--- a/tests/xtensa/Cargo.toml
+++ b/tests/xtensa/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "xtensa-test"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[workspace]
+resolver = "2"
+
+[dependencies]
+portable-atomic = { path = "../..", features = ["float"] }
+test-helper = { path = "../helper" }
+
+paste = "1"
+
+[target.xtensa-esp32-none-elf.dependencies]
+esp-println = { version = "0.4", default-features = false, features = ["uart", "esp32"] }
+esp32-hal = "0.11"
+xtensa-lx-rt = { version = "0.15", features = ["esp32"] }
+
+[profile.dev]
+opt-level = 'z'
+
+[profile.release]
+opt-level = 'z'

--- a/tests/xtensa/build.rs
+++ b/tests/xtensa/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=memory.x");
+}

--- a/tests/xtensa/src/main.rs
+++ b/tests/xtensa/src/main.rs
@@ -1,0 +1,105 @@
+#![no_main]
+#![no_std]
+#![warn(rust_2018_idioms, single_use_lifetimes, unsafe_op_in_unsafe_fn)]
+#![feature(panic_info_message)]
+#![allow(clippy::empty_loop)] // this test crate is #![no_std]
+
+#[macro_use]
+#[path = "../../api-test/src/helper.rs"]
+mod helper;
+
+use core::sync::atomic::Ordering;
+
+use portable_atomic::*;
+
+use esp32_hal as _;
+use esp_println::{print, println};
+
+#[xtensa_lx_rt::entry]
+fn main() -> ! {
+    macro_rules! test_atomic_int {
+        ($int_type:ident) => {
+            paste::paste! {
+                fn [<test_atomic_ $int_type>]() {
+                    __test_atomic_int!([<Atomic $int_type:camel>], $int_type);
+                }
+                print!("test test_atomic_{} ... ", stringify!($int_type));
+                [<test_atomic_ $int_type>]();
+                println!("ok");
+            }
+        };
+    }
+    macro_rules! test_atomic_float {
+        ($float_type:ident) => {
+            paste::paste! {
+                fn [<test_atomic_ $float_type>]() {
+                    __test_atomic_float!([<Atomic $float_type:camel>], $float_type);
+                }
+                print!("test test_atomic_{} ... ", stringify!($float_type));
+                [<test_atomic_ $float_type>]();
+                println!("ok");
+            }
+        };
+    }
+    macro_rules! test_atomic_bool {
+        () => {
+            fn test_atomic_bool() {
+                __test_atomic_bool!(AtomicBool);
+            }
+            print!("test test_atomic_bool ... ");
+            test_atomic_bool();
+            println!("ok");
+        };
+    }
+    macro_rules! test_atomic_ptr {
+        () => {
+            fn test_atomic_ptr() {
+                __test_atomic_ptr!(AtomicPtr<u8>);
+            }
+            print!("test test_atomic_ptr ... ");
+            test_atomic_ptr();
+            println!("ok");
+        };
+    }
+
+    for &order in &test_helper::FENCE_ORDERINGS {
+        fence(order);
+        compiler_fence(order);
+    }
+    hint::spin_loop();
+    test_atomic_bool!();
+    test_atomic_ptr!();
+    test_atomic_int!(isize);
+    test_atomic_int!(usize);
+    test_atomic_int!(i8);
+    test_atomic_int!(u8);
+    test_atomic_int!(i16);
+    test_atomic_int!(u16);
+    test_atomic_int!(i32);
+    test_atomic_int!(u32);
+    test_atomic_int!(i64);
+    test_atomic_int!(u64);
+    test_atomic_int!(i128);
+    test_atomic_int!(u128);
+    test_atomic_float!(f32);
+    test_atomic_float!(f64);
+
+    loop {}
+}
+
+#[inline(never)]
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
+    if let Some(m) = info.message() {
+        print!("panicked at '{m:?}'");
+    } else {
+        print!("panic occurred (no message)");
+    }
+    if let Some(l) = info.location() {
+        println!(", {l}");
+    } else {
+        println!(" (no location info)");
+    }
+
+    loop {}
+}

--- a/tools/no-std.sh
+++ b/tools/no-std.sh
@@ -117,6 +117,12 @@ run() {
                 subcmd=build
             fi
             ;;
+        xtensa*)
+            # TODO: run test with simulator on CI
+            if ! type -P wokwi-server &>/dev/null; then
+                subcmd=build
+            fi
+            ;;
     esac
     args+=("${subcmd}" "${target_flags[@]}")
     if grep <<<"${rustup_target_list}" -Eq "^${target}( |$)"; then
@@ -164,6 +170,11 @@ run() {
             ;;
         avr*)
             test_dir=tests/avr
+            ;;
+        xtensa*)
+            test_dir=tests/xtensa
+            linker=linkall.x
+            target_rustflags+=" -C link-arg=-Wl,-T${linker} -C link-arg=-nostartfiles"
             ;;
         *) bail "unrecognized target '${target}'" ;;
     esac


### PR DESCRIPTION
This adds `portable_atomic_unsafe_assume_single_core` support for Xtensa targets without atomic CAS.