### PR TITLE
feat: Implement AsRef and Borrow on Arc

### DIFF
--- a/portable-atomic-util/src/arc.rs
+++ b/portable-atomic-util/src/arc.rs
@@ -8,6 +8,7 @@ use portable_atomic::{
 use alloc::boxed::Box;
 
 use core::{
+    borrow::Borrow,
     fmt,
     hash::Hash,
     marker::PhantomData,
@@ -598,6 +599,18 @@ impl<T: ?Sized> Deref for Arc<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
+        &self.inner().value
+    }
+}
+
+impl<T: ?Sized> AsRef<T> for Arc<T> {
+    fn as_ref(&self) -> &T {
+        &self.inner().value
+    }
+}
+
+impl<T: ?Sized> Borrow<T> for Arc<T> {
+    fn borrow(&self) -> &T {
         &self.inner().value
     }
 }


### PR DESCRIPTION
Forgot to add this when I was writing #41. Should hopefully improve symmetry between `std::sync::Arc` and `portable_atomic_util::Arc`.