### PR TITLE
Add require-cas feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ float = []
 # Use `std`.
 std = []
 
+# Emit compile error if atomic CAS is not available.
+require-cas = []
+
 # Note: serde and critical-section are public dependencies.
 [dependencies]
 # Implements serde::{Serialize,Deserialize} for atomic types.

--- a/portable-atomic-util/Cargo.toml
+++ b/portable-atomic-util/Cargo.toml
@@ -39,4 +39,5 @@ alloc = []
 # generic = []
 
 [dependencies]
-portable-atomic = { version = "1", path = "..", default-features = false }
+# TODO: use version 1.3 once portable-atomic with require-cas feature released.
+portable-atomic = { version = "1", path = "..", default-features = false, features = ["require-cas"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,8 +365,8 @@ compile_error!(
     ))
 )]
 compile_error!(
-    "cfg(portable_atomic_unsafe_assume_single_core) does not compatible with this target; \
-     if you need cfg(portable_atomic_unsafe_assume_single_core) support for this target, \
+    "cfg(portable_atomic_unsafe_assume_single_core) does not compatible with this target;\n\
+     if you need cfg(portable_atomic_unsafe_assume_single_core) support for this target,\n\
      please submit an issue at <https://github.com/taiki-e/portable-atomic>"
 );
 
@@ -400,6 +400,33 @@ compile_error!(
 #[cfg(all(portable_atomic_unsafe_assume_single_core, feature = "critical-section"))]
 compile_error!(
     "you may not enable feature `critical-section` and cfg(portable_atomic_unsafe_assume_single_core) at the same time"
+);
+
+#[cfg(feature = "require-cas")]
+#[cfg_attr(
+    portable_atomic_no_cfg_target_has_atomic,
+    cfg(not(any(
+        not(portable_atomic_no_atomic_cas),
+        portable_atomic_unsafe_assume_single_core,
+        feature = "critical-section",
+        target_arch = "avr",
+        target_arch = "msp430",
+    )))
+)]
+#[cfg_attr(
+    not(portable_atomic_no_cfg_target_has_atomic),
+    cfg(not(any(
+        target_has_atomic = "ptr",
+        portable_atomic_unsafe_assume_single_core,
+        feature = "critical-section",
+        target_arch = "avr",
+        target_arch = "msp430",
+    )))
+)]
+compile_error!(
+    "dependents require atomic CAS but not available on this target by default;\n\
+    consider using portable_atomic_unsafe_assume_single_core cfg or critical-section feature.\n\
+    see <https://docs.rs/portable-atomic/latest/portable_atomic/#optional-cfg> for more."
 );
 
 #[cfg(any(test, feature = "std"))]

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -427,9 +427,13 @@ build() {
                 else
                     echo "target '${target}' requires asm to implement atomic CAS (skipped build with --cfg portable_atomic_unsafe_assume_single_core)"
                 fi
-                # portable-atomic-util uses atomic CAS, so doesn't work on
-                # this target without portable_atomic_unsafe_assume_single_core cfg.
-                args+=(--exclude portable-atomic-util)
+                # portable-atomic-util crate and portable-atomic's require-cas feature require atomic CAS,
+                # so doesn't work on this target without portable_atomic_unsafe_assume_single_core cfg
+                # or critical-section feature.
+                args+=(
+                    --exclude portable-atomic-util
+                    --exclude-features require-cas
+                )
             fi
         fi
     fi


### PR DESCRIPTION
Provide better error message if dependents require atomic CAS but the end user forgets to use single-core cfg or critical-section feature.

Context: https://github.com/mvdnes/spin-rs/issues/151

cc @zesterer

### Example (with spin-rs)

Enable require-cas feature on spin (https://github.com/taiki-e/spin-rs/commit/990fa92e5f0e4c751f7f171fa2123ef39449c9c6)

```diff
- portable-atomic = { version = "1", optional = true, default-features = false }
+ # Enable require-cas feature to provide a better error message if the end user forgets to use cfg.
+ portable-atomic = { version = "1", optional = true, default-features = false, features = ["require-cas"] }
```

Then, when building spin without single-core cfg or CS feature, the following error message will be displayed.

```console
# without cfg
$ cargo build --target thumbv6m-none-eabi --no-default-features --features spin_mutex,portable_atomic
error: dependents require atomic CAS but not available on this target by default;
       consider using portable_atomic_unsafe_assume_single_core cfg or critical-section feature.
       see <https://docs.rs/portable-atomic/latest/portable_atomic/#optional-cfg> for more.
   --> /Users/taiki/.cargo/git/checkouts/portable-atomic-1ec81f4f47ac5a29/dd55758/src/lib.rs:426:1
    |
426 | / compile_error!(
427 | |     "dependents require atomic CAS but not available on this target by default;\n\
428 | |     consider using portable_atomic_unsafe_assume_single_core cfg or critical-section feature.\n\
429 | |     see <https://docs.rs/portable-atomic/latest/portable_atomic/#optional-cfg> for more."
430 | | );
    | |_^

error: could not compile `portable-atomic` (lib) due to previous error

# with cfg
$ RUSTFLAGS='--cfg portable_atomic_unsafe_assume_single_core' cargo build --target thumbv6m-none-eabi --no-default-features --features spin_mutex,portable_atomic
    Finished dev [unoptimized + debuginfo] target(s) in 0.96s
```

Maybe we can improve more on the error messages.