### PR TITLE
detect: Support run-time detection on powerpc64 AIX

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -50,6 +50,7 @@ fistp
 getauxval
 getisax
 getpid
+getsystemcfg
 gimli
 Halfword
 HWCAP
@@ -139,6 +140,7 @@ setb
 sete
 sifive
 signedness
+SIGTRAP
 simavr
 simio
 skiboot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,7 +549,7 @@ jobs:
 
       # {,no-}outline-atomics
       # portable_atomic_no_outline_atomics only affects x86_64, AArch64, Arm, powerpc64, and RISC-V Linux.
-      # outline-atomics is disabled by default on AArch64/powerpc64 musl with static linking
+      # outline-atomics is disabled by default on AArch64/powerpc64 musl with static linking, AArch64 illumos, and AIX.
       # powerpc64le- (little-endian) is skipped because it is pwr8 by default
       # RISC-V Linux is skipped because outline-atomics is currently disabled by default.
       - run: tools/test.sh -vv --tests ${TARGET:-} ${BUILD_STD:-} ${RELEASE:-}

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ RUSTFLAGS="--cfg portable_atomic_no_outline_atomics" cargo ...
   - Dynamic detection is currently only supported in x86_64, AArch64, Arm, RISC-V (disabled by default), Arm64EC, and powerpc64, otherwise it works the same as when this cfg is set.
   - If the required target features are enabled at compile-time, the atomic operations are inlined.
   - This is compatible with no-std (as with all features except `std`).
-  - On some targets, run-time detection is disabled by default mainly for incomplete build environments, and can be enabled by `--cfg portable_atomic_outline_atomics`. (When both cfg are enabled, `*_no_*` cfg is preferred.)
+  - On some targets, run-time detection is disabled by default mainly for compatibility with incomplete build environments or support for it is experimental, and can be enabled by `--cfg portable_atomic_outline_atomics`. (When both cfg are enabled, `*_no_*` cfg is preferred.)
   - Some AArch64 targets enable LLVM's `outline-atomics` target feature by default, so if you set this cfg, you may want to disable that as well. (portable-atomic's outline-atomics does not depend on the compiler-rt symbols, so even if you need to disable LLVM's outline-atomics, you may not need to disable portable-atomic's outline-atomics.)
 
   See also the [`atomic128` module's readme](https://github.com/taiki-e/portable-atomic/blob/HEAD/src/imp/atomic128/README.md).

--- a/src/imp/atomic128/mod.rs
+++ b/src/imp/atomic128/mod.rs
@@ -46,6 +46,11 @@ pub(super) mod aarch64;
                 target_os = "android",
                 target_os = "freebsd",
                 target_os = "openbsd",
+                all(
+                    target_os = "aix",
+                    not(portable_atomic_pre_llvm_20),
+                    any(test, portable_atomic_outline_atomics), // TODO(aix): currently disabled by default
+                ),
             ),
             not(any(miri, portable_atomic_sanitize_thread)),
         ),

--- a/src/imp/atomic128/powerpc64.rs
+++ b/src/imp/atomic128/powerpc64.rs
@@ -74,6 +74,19 @@ mod fallback;
 ))]
 #[path = "../detect/auxv.rs"]
 mod detect;
+#[cfg(not(portable_atomic_no_outline_atomics))]
+#[cfg(any(
+    test,
+    not(any(
+        target_feature = "quadword-atomics",
+        portable_atomic_target_feature = "quadword-atomics",
+    )),
+))]
+#[cfg(target_os = "aix")]
+#[cfg(not(portable_atomic_pre_llvm_20))] // SIGTRAP on LLVM 19
+#[cfg(any(test, portable_atomic_outline_atomics))] // TODO(aix): currently disabled by default
+#[path = "../detect/powerpc64_aix.rs"]
+mod detect;
 
 use core::{arch::asm, sync::atomic::Ordering};
 

--- a/src/imp/detect/README.md
+++ b/src/imp/detect/README.md
@@ -13,17 +13,18 @@ Here is the table of targets that support run-time CPU feature detection and the
 | aarch64     | netbsd               | sysctlbyname    | all      | Enabled by default |
 | aarch64     | openbsd              | sysctl          | all      | Enabled by default |
 | aarch64     | macos/ios/tvos/watchos/visionos | sysctlbyname | all | Currently only used in tests (see [aarch64_apple.rs](aarch64_apple.rs)). |
-| aarch64     | illumos              | getisax         | lse, lse2 | Disabled by default |
+| aarch64     | illumos              | getisax         | lse, lse2 | Disabled by default (experimental) |
 | aarch64/arm64ec | windows          | IsProcessorFeaturePresent | lse | Enabled by default |
 | aarch64     | fuchsia              | zx_system_get_features | lse | Enabled by default |
 | riscv32/riscv64 | linux/android    | riscv_hwprobe   | all      | Disabled by default |
 | powerpc64   | linux                | getauxval       | all      | Only enabled by default on `*-linux-{gnu,musl,ohos,uclibc}*` with dynamic linking enabled (musl is static linking by default). (dlsym is used by default if needed for compatibility with older versions) |
 | powerpc64   | freebsd              | elf_aux_info    | all      | Enabled by default (dlsym is used by default for compatibility with older versions) |
 | powerpc64   | openbsd              | elf_aux_info    | all      | Enabled by default (dlsym is used by default for compatibility with older versions) |
+| powerpc64   | aix                  | getsystemcfg    | all      | Requires LLVM 20+. Disabled by default (experimental) |
 
 Run-time detection is enabled by default on most targets and can be disabled with `--cfg portable_atomic_no_outline_atomics`.
 
-On some targets, run-time detection is disabled by default mainly for incomplete build environments, and can be enabled by `--cfg portable_atomic_outline_atomics`. (When both cfg are enabled, `*_no_*` cfg is preferred.)
+On some targets, run-time detection is disabled by default mainly for compatibility with incomplete build environments or support for it is experimental, and can be enabled by `--cfg portable_atomic_outline_atomics`. (When both cfg are enabled, `*_no_*` cfg is preferred.)
 
 For targets not included in the above table, run-time detection is always disabled and works the same as when `--cfg portable_atomic_no_outline_atomics` is set.
 

--- a/src/imp/detect/aarch64_illumos.rs
+++ b/src/imp/detect/aarch64_illumos.rs
@@ -6,7 +6,8 @@ Run-time CPU feature detection on AArch64 illumos by using getisax.
 As of nightly-2024-09-07, is_aarch64_feature_detected doesn't support run-time detection on illumos.
 https://github.com/rust-lang/stdarch/blob/d9466edb4c53cece8686ee6e17b028436ddf4151/crates/std_detect/src/detect/mod.rs
 
-Run-time detection on AArch64 illumos is currently disabled by default as AArch64 port is experimental.
+Run-time detection on AArch64 illumos is currently disabled by default as experimental
+because illumos AArch64 port is experimental and we cannot run tests on the VM or real machine.
 */
 
 include!("common.rs");

--- a/src/imp/detect/powerpc64_aix.rs
+++ b/src/imp/detect/powerpc64_aix.rs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/*
+Run-time CPU feature detection on PowerPC64 AIX by using getsystemcfg.
+
+Refs:
+- https://github.com/golang/go/blob/071aed2aaa0ed819582c5bff44b70d43c61f504a/src/internal/cpu/cpu_ppc64x_aix.go
+
+As of nightly-2024-09-07, is_powerpc_feature_detected doesn't support run-time detection on AIX.
+https://github.com/rust-lang/stdarch/blob/d9466edb4c53cece8686ee6e17b028436ddf4151/crates/std_detect/src/detect/mod.rs
+
+Run-time detection on PowerPC64 AIX is currently disabled by default as experimental
+because we cannot run tests on the VM or real machine.
+*/
+
+include!("common.rs");
+
+// libc requires Rust 1.63
+mod ffi {
+    pub(crate) use crate::utils::ffi::{c_int, c_ulong};
+
+    // TODO: use sys_const!
+    // https://github.com/rust-lang/libc/blob/0.2.158/src/unix/aix/mod.rs#L2058
+    // https://github.com/golang/go/blob/071aed2aaa0ed819582c5bff44b70d43c61f504a/src/internal/cpu/cpu_ppc64x_aix.go
+    pub(crate) const SC_IMPL: c_int = 2;
+    pub(crate) const POWER_8: c_ulong = 0x10000;
+    pub(crate) const POWER_9: c_ulong = 0x20000;
+    pub(crate) const POWER_10: c_ulong = 0x40000;
+
+    // TODO: use sys_fn!
+    extern "C" {
+        // https://www.ibm.com/docs/en/aix/7.3?topic=g-getsystemcfg-subroutine
+        // https://github.com/rust-lang/libc/blob/0.2.158/src/unix/aix/powerpc64.rs#L643
+        pub(crate) fn getsystemcfg(name: c_int) -> c_ulong;
+    }
+}
+
+#[cold]
+fn _detect(info: &mut CpuInfo) {
+    // SAFETY: calling getsystemcfg is safe.
+    let impl_ = unsafe { ffi::getsystemcfg(ffi::SC_IMPL) };
+    if impl_ == ffi::c_ulong::MAX {
+        return;
+    }
+    // Check both POWER_8 and later ISAs (which are superset of POWER_8) because
+    // AIX currently doesn't set POWER_8 when POWER_9 is set.
+    // https://github.com/golang/go/commit/51859ec2292d9c1d82a7054ec672ff551a0d7497
+    if impl_ & (ffi::POWER_8 | ffi::POWER_9 | ffi::POWER_10) != 0 {
+        info.set(CpuInfo::HAS_QUADWORD_ATOMICS);
+    }
+}
+
+#[allow(
+    clippy::alloc_instead_of_core,
+    clippy::std_instead_of_alloc,
+    clippy::std_instead_of_core,
+    clippy::undocumented_unsafe_blocks,
+    clippy::wildcard_imports
+)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Static assertions for FFI bindings.
+    // This checks that FFI bindings defined in this crate and FFI bindings defined
+    // in libc compatible signatures (or the same values if constants).
+    // Since this is static assertion, we can detect problems with
+    // `cargo check --tests --target <target>` run in CI (via TESTS=1 build.sh)
+    // without actually running tests on these platforms.
+    // See also https://github.com/taiki-e/test-helper/blob/HEAD/tools/codegen/src/ffi.rs.
+    // TODO: auto-generate this test
+    #[allow(
+        clippy::cast_possible_wrap,
+        clippy::cast_sign_loss,
+        clippy::cast_possible_truncation,
+        clippy::no_effect_underscore_binding
+    )]
+    const _: fn() = || {
+        let mut _getsystemcfg: unsafe extern "C" fn(ffi::c_int) -> ffi::c_ulong = ffi::getsystemcfg;
+        _getsystemcfg = libc::getsystemcfg;
+        static_assert!(ffi::SC_IMPL == libc::SC_IMPL);
+        static_assert!(ffi::POWER_8 == libc::POWER_8 as ffi::c_ulong);
+        static_assert!(ffi::POWER_9 == libc::POWER_9 as ffi::c_ulong);
+        // static_assert!(ffi::POWER_10 == libc::POWER_10 as ffi::c_ulong); // libc doesn't have this
+    };
+}

--- a/src/imp/fallback/mod.rs
+++ b/src/imp/fallback/mod.rs
@@ -42,6 +42,11 @@ type and the value type must be the same.
                 target_os = "android",
                 target_os = "freebsd",
                 target_os = "openbsd",
+                all(
+                    target_os = "aix",
+                    not(portable_atomic_pre_llvm_20),
+                    portable_atomic_outline_atomics, // TODO(aix): currently disabled by default
+                ),
             ),
             not(any(miri, portable_atomic_sanitize_thread)),
         ),

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -361,6 +361,11 @@ items! {
                         target_os = "android",
                         target_os = "freebsd",
                         target_os = "openbsd",
+                        all(
+                            target_os = "aix",
+                            not(portable_atomic_pre_llvm_20),
+                            portable_atomic_outline_atomics, // TODO(aix): currently disabled by default
+                        ),
                     ),
                     not(any(miri, portable_atomic_sanitize_thread)),
                 ),
@@ -471,6 +476,11 @@ pub(crate) use self::atomic128::riscv64::{AtomicI128, AtomicU128};
                 target_os = "android",
                 target_os = "freebsd",
                 target_os = "openbsd",
+                all(
+                    target_os = "aix",
+                    not(portable_atomic_pre_llvm_20),
+                    portable_atomic_outline_atomics, // TODO(aix): currently disabled by default
+                ),
             ),
             not(any(miri, portable_atomic_sanitize_thread)),
         ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ RUSTFLAGS="--cfg portable_atomic_no_outline_atomics" cargo ...
   - Dynamic detection is currently only supported in x86_64, AArch64, Arm, RISC-V (disabled by default), Arm64EC, and powerpc64, otherwise it works the same as when this cfg is set.
   - If the required target features are enabled at compile-time, the atomic operations are inlined.
   - This is compatible with no-std (as with all features except `std`).
-  - On some targets, run-time detection is disabled by default mainly for incomplete build environments, and can be enabled by `--cfg portable_atomic_outline_atomics`. (When both cfg are enabled, `*_no_*` cfg is preferred.)
+  - On some targets, run-time detection is disabled by default mainly for compatibility with incomplete build environments or support for it is experimental, and can be enabled by `--cfg portable_atomic_outline_atomics`. (When both cfg are enabled, `*_no_*` cfg is preferred.)
   - Some AArch64 targets enable LLVM's `outline-atomics` target feature by default, so if you set this cfg, you may want to disable that as well. (portable-atomic's outline-atomics does not depend on the compiler-rt symbols, so even if you need to disable LLVM's outline-atomics, you may not need to disable portable-atomic's outline-atomics.)
 
   See also the [`atomic128` module's readme](https://github.com/taiki-e/portable-atomic/blob/HEAD/src/imp/atomic128/README.md).

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -117,6 +117,7 @@ default_targets=(
   powerpc64-unknown-freebsd
   powerpc64le-unknown-freebsd
   powerpc64-unknown-openbsd
+  powerpc64-ibm-aix
 
   # s390x
   # rustc -Z unstable-options --print all-target-specs-json | jq -r '. | to_entries[] | if .value.arch == "s390x" then .key else empty end'
@@ -557,10 +558,10 @@ build() {
   # Check {,no-}outline-atomics
   case "${target}" in
     # portable_atomic_no_outline_atomics only affects x86_64, AArch64, Arm, powerpc64, and RISC-V Linux.
-    # outline-atomics is disabled by default on AArch64/powerpc64 musl with static linking
+    # outline-atomics is disabled by default on AArch64/powerpc64 musl with static linking, AArch64 illumos, and AIX.
     # powerpc64le- (little-endian) is skipped because it is pwr8 by default
     # RISC-V Linux is skipped because outline-atomics is currently disabled by default.
-    aarch64*-linux-musl* | powerpc64-*-linux-musl*) ;;
+    aarch64*-linux-musl* | aarch64*-illumos* | powerpc64-*-linux-musl* | powerpc64-*-aix) ;;
     x86_64* | aarch64* | arm* | thumb* | powerpc64-*)
       CARGO_TARGET_DIR="${target_dir}/no-outline-atomics" \
         RUSTFLAGS="${target_rustflags} --cfg portable_atomic_no_outline_atomics" \


### PR DESCRIPTION
Follow-up to #90 

Run-time detection on this platform is currently disabled by default as experimental because I don't yet have an environment where I can run tests.