### PR TITLE
Consider alignment when computing into_raw

### DIFF
--- a/portable-atomic-util/tests/arc.rs
+++ b/portable-atomic-util/tests/arc.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#![cfg(any(feature = "std", feature = "alloc"))]
+
+use portable_atomic_util::Arc;
+
+#[test]
+fn overaligned() {
+    #[repr(align(128))]
+    struct Aligned(u32);
+
+    let value = Arc::new(Aligned(128));
+    let ptr = Arc::into_raw(value);
+    // SAFETY: `ptr` should always be a valid `Aligned`.
+    assert_eq!(unsafe { (&*ptr).0 }, 128);
+    // SAFETY: `ptr` is a valid reference to an `Arc<Aligned>`.
+    let value = unsafe { Arc::from_raw(ptr) };
+    assert_eq!(value.0, 128);
+}

--- a/portable-atomic-util/tests/arc.rs
+++ b/portable-atomic-util/tests/arc.rs
@@ -5,7 +5,7 @@
 use portable_atomic_util::Arc;
 
 #[test]
-fn overaligned() {
+fn over_aligned() {
     #[repr(align(128))]
     struct Aligned(u32);
 


### PR DESCRIPTION
This commit fixes #137 by considering alignment when converting the raw
Arc pointer to and raw its raw representation.
