### PR TITLE
Implement cfg portable_atomic_critical_section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "portable-atomic"
-version = "1.7.0" #publish:version
+version = "1.7.1" #publish:version
 edition = "2018"
 rust-version = "1.34"
 license = "Apache-2.0 OR MIT"
@@ -80,6 +80,9 @@ serde = { version = "1.0.103", optional = true, default-features = false }
 #
 # See documentation for more: https://github.com/taiki-e/portable-atomic#optional-features-critical-section
 critical-section = { version = "1", optional = true }
+
+[target.'cfg(portable_atomic_critical_section)'.dependencies]
+critical-section = { version = "1" }
 
 [dev-dependencies]
 test-helper = { path = "tests/helper", features = ["std"] }

--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ RUSTFLAGS="--cfg portable_atomic_no_outline_atomics" cargo ...
 
   Originally, we were providing these as cfgs instead of features, but based on a strong request from the embedded ecosystem, we have agreed to provide them as features as well. See [#94](https://github.com/taiki-e/portable-atomic/pull/94) for more.
 
+- <a name="optional-cfg-portable-atomic"></a>**`--cfg portable_atomic_critical_section`**<br>
+  Since 1.7.1, this cfg is an alias of [`critical-section` feature](#optional-features-critical-section).
+
 - <a name="optional-cfg-no-outline-atomics"></a>**`--cfg portable_atomic_no_outline_atomics`**<br>
   Disable dynamic dispatching by run-time CPU feature detection.
 

--- a/build.rs
+++ b/build.rs
@@ -19,6 +19,8 @@ fn main() {
 
     #[cfg(feature = "unsafe-assume-single-core")]
     println!("cargo:rustc-cfg=portable_atomic_unsafe_assume_single_core");
+    #[cfg(feature = "critical-section")]
+    println!("cargo:rustc-cfg=portable_atomic_critical_section");
     #[cfg(feature = "s-mode")]
     println!("cargo:rustc-cfg=portable_atomic_s_mode");
     #[cfg(feature = "force-amo")]
@@ -53,7 +55,7 @@ fn main() {
         // Custom cfgs set by build script. Not public API.
         // grep -E 'cargo:rustc-cfg=' build.rs | grep -v '=//' | sed -E 's/^.*cargo:rustc-cfg=//; s/(=\\)?".*$//' | LC_ALL=C sort -u | tr '\n' ','
         println!(
-            "cargo:rustc-check-cfg=cfg(portable_atomic_disable_fiq,portable_atomic_force_amo,portable_atomic_ll_sc_rmw,portable_atomic_llvm_15,portable_atomic_llvm_16,portable_atomic_llvm_18,portable_atomic_new_atomic_intrinsics,portable_atomic_no_asm,portable_atomic_no_asm_maybe_uninit,portable_atomic_no_atomic_64,portable_atomic_no_atomic_cas,portable_atomic_no_atomic_load_store,portable_atomic_no_atomic_min_max,portable_atomic_no_cfg_target_has_atomic,portable_atomic_no_cmpxchg16b_intrinsic,portable_atomic_no_cmpxchg16b_target_feature,portable_atomic_no_const_raw_ptr_deref,portable_atomic_no_const_transmute,portable_atomic_no_core_unwind_safe,portable_atomic_no_stronger_failure_ordering,portable_atomic_no_track_caller,portable_atomic_no_unsafe_op_in_unsafe_fn,portable_atomic_s_mode,portable_atomic_sanitize_thread,portable_atomic_target_feature,portable_atomic_unsafe_assume_single_core,portable_atomic_unstable_asm,portable_atomic_unstable_asm_experimental_arch,portable_atomic_unstable_cfg_target_has_atomic,portable_atomic_unstable_isa_attribute)"
+            "cargo:rustc-check-cfg=cfg(portable_atomic_disable_fiq,portable_atomic_force_amo,portable_atomic_ll_sc_rmw,portable_atomic_llvm_15,portable_atomic_llvm_16,portable_atomic_llvm_18,portable_atomic_new_atomic_intrinsics,portable_atomic_no_asm,portable_atomic_no_asm_maybe_uninit,portable_atomic_no_atomic_64,portable_atomic_no_atomic_cas,portable_atomic_no_atomic_load_store,portable_atomic_no_atomic_min_max,portable_atomic_no_cfg_target_has_atomic,portable_atomic_no_cmpxchg16b_intrinsic,portable_atomic_no_cmpxchg16b_target_feature,portable_atomic_no_const_raw_ptr_deref,portable_atomic_no_const_transmute,portable_atomic_no_core_unwind_safe,portable_atomic_no_stronger_failure_ordering,portable_atomic_no_track_caller,portable_atomic_no_unsafe_op_in_unsafe_fn,portable_atomic_s_mode,portable_atomic_sanitize_thread,portable_atomic_target_feature,portable_atomic_unsafe_assume_single_core,portable_atomic_unstable_asm,portable_atomic_unstable_asm_experimental_arch,portable_atomic_unstable_cfg_target_has_atomic,portable_atomic_unstable_isa_attribute,portable_atomic_critical_section)"
         );
         // TODO: handle multi-line target_feature_fallback
         // grep -E 'target_feature_fallback\("' build.rs | sed -E 's/^.*target_feature_fallback\(//; s/",.*$/"/' | LC_ALL=C sort -u | tr '\n' ','

--- a/src/cfgs.rs
+++ b/src/cfgs.rs
@@ -9,7 +9,7 @@
         target_arch = "msp430",
         target_arch = "riscv32",
         target_arch = "riscv64",
-        feature = "critical-section",
+        portable_atomic_critical_section,
     )),
 )))]
 #[macro_use]
@@ -42,7 +42,7 @@ mod atomic_8_16_macros {
         target_arch = "msp430",
         target_arch = "riscv32",
         target_arch = "riscv64",
-        feature = "critical-section",
+        portable_atomic_critical_section,
     )),
 ))]
 #[macro_use]
@@ -78,7 +78,7 @@ mod atomic_8_16_macros {
             target_arch = "msp430",
             target_arch = "riscv32",
             target_arch = "riscv64",
-            feature = "critical-section",
+            portable_atomic_critical_section,
         )),
     )),
 ))]
@@ -104,7 +104,7 @@ mod atomic_32_macros {
             target_arch = "msp430",
             target_arch = "riscv32",
             target_arch = "riscv64",
-            feature = "critical-section",
+            portable_atomic_critical_section,
         )),
     )),
 )))]
@@ -130,7 +130,7 @@ mod atomic_32_macros {
             any(
                 not(portable_atomic_no_atomic_cas),
                 portable_atomic_unsafe_assume_single_core,
-                feature = "critical-section",
+                portable_atomic_critical_section,
                 target_arch = "avr",
                 target_arch = "msp430",
             ),
@@ -147,7 +147,7 @@ mod atomic_32_macros {
             any(
                 target_has_atomic = "ptr",
                 portable_atomic_unsafe_assume_single_core,
-                feature = "critical-section",
+                portable_atomic_critical_section,
                 target_arch = "avr",
                 target_arch = "msp430",
             ),
@@ -177,7 +177,7 @@ mod atomic_64_macros {
             any(
                 not(portable_atomic_no_atomic_cas),
                 portable_atomic_unsafe_assume_single_core,
-                feature = "critical-section",
+                portable_atomic_critical_section,
                 target_arch = "avr",
                 target_arch = "msp430",
             ),
@@ -194,7 +194,7 @@ mod atomic_64_macros {
             any(
                 target_has_atomic = "ptr",
                 portable_atomic_unsafe_assume_single_core,
-                feature = "critical-section",
+                portable_atomic_critical_section,
                 target_arch = "avr",
                 target_arch = "msp430",
             ),
@@ -278,7 +278,7 @@ mod atomic_64_macros {
     cfg(any(
         not(portable_atomic_no_atomic_cas),
         portable_atomic_unsafe_assume_single_core,
-        feature = "critical-section",
+        portable_atomic_critical_section,
         target_arch = "avr",
         target_arch = "msp430",
     ))
@@ -288,7 +288,7 @@ mod atomic_64_macros {
     cfg(any(
         target_has_atomic = "ptr",
         portable_atomic_unsafe_assume_single_core,
-        feature = "critical-section",
+        portable_atomic_critical_section,
         target_arch = "avr",
         target_arch = "msp430",
     ))
@@ -367,7 +367,7 @@ mod atomic_128_macros {
     cfg(not(any(
         not(portable_atomic_no_atomic_cas),
         portable_atomic_unsafe_assume_single_core,
-        feature = "critical-section",
+        portable_atomic_critical_section,
         target_arch = "avr",
         target_arch = "msp430",
     )))
@@ -377,7 +377,7 @@ mod atomic_128_macros {
     cfg(not(any(
         target_has_atomic = "ptr",
         portable_atomic_unsafe_assume_single_core,
-        feature = "critical-section",
+        portable_atomic_critical_section,
         target_arch = "avr",
         target_arch = "msp430",
     )))
@@ -401,7 +401,7 @@ mod atomic_128_macros {
     cfg(any(
         not(portable_atomic_no_atomic_cas),
         portable_atomic_unsafe_assume_single_core,
-        feature = "critical-section",
+        portable_atomic_critical_section,
         target_arch = "avr",
         target_arch = "msp430",
     ))
@@ -411,7 +411,7 @@ mod atomic_128_macros {
     cfg(any(
         target_has_atomic = "ptr",
         portable_atomic_unsafe_assume_single_core,
-        feature = "critical-section",
+        portable_atomic_critical_section,
         target_arch = "avr",
         target_arch = "msp430",
     ))
@@ -434,7 +434,7 @@ mod atomic_cas_macros {
     cfg(not(any(
         not(portable_atomic_no_atomic_cas),
         portable_atomic_unsafe_assume_single_core,
-        feature = "critical-section",
+        portable_atomic_critical_section,
         target_arch = "avr",
         target_arch = "msp430",
     )))
@@ -444,7 +444,7 @@ mod atomic_cas_macros {
     cfg(not(any(
         target_has_atomic = "ptr",
         portable_atomic_unsafe_assume_single_core,
-        feature = "critical-section",
+        portable_atomic_critical_section,
         target_arch = "avr",
         target_arch = "msp430",
     )))

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -6,7 +6,7 @@
 #[cfg(not(any(
     all(
         portable_atomic_no_atomic_load_store,
-        not(all(target_arch = "bpf", not(feature = "critical-section"))),
+        not(all(target_arch = "bpf", not(portable_atomic_critical_section))),
     ),
     portable_atomic_unsafe_assume_single_core,
     target_arch = "avr",
@@ -15,14 +15,14 @@
 #[cfg_attr(
     portable_atomic_no_cfg_target_has_atomic,
     cfg(not(all(
-        any(target_arch = "riscv32", target_arch = "riscv64", feature = "critical-section"),
+        any(target_arch = "riscv32", target_arch = "riscv64", portable_atomic_critical_section),
         portable_atomic_no_atomic_cas,
     )))
 )]
 #[cfg_attr(
     not(portable_atomic_no_cfg_target_has_atomic),
     cfg(not(all(
-        any(target_arch = "riscv32", target_arch = "riscv64", feature = "critical-section"),
+        any(target_arch = "riscv32", target_arch = "riscv64", portable_atomic_critical_section),
         not(target_has_atomic = "ptr"),
     )))
 )]
@@ -132,7 +132,7 @@ mod arm_linux;
 pub(crate) mod msp430;
 
 // atomic load/store for RISC-V without A-extension
-#[cfg(any(test, not(feature = "critical-section")))]
+#[cfg(any(test, not(portable_atomic_critical_section)))]
 #[cfg_attr(portable_atomic_no_cfg_target_has_atomic, cfg(any(test, portable_atomic_no_atomic_cas)))]
 #[cfg_attr(
     not(portable_atomic_no_cfg_target_has_atomic),
@@ -191,7 +191,7 @@ mod fallback;
 #[cfg(any(
     all(test, target_os = "none"),
     portable_atomic_unsafe_assume_single_core,
-    feature = "critical-section",
+    portable_atomic_critical_section,
     target_arch = "avr",
     target_arch = "msp430",
 ))]
@@ -207,7 +207,7 @@ mod fallback;
     target_arch = "riscv32",
     target_arch = "riscv64",
     target_arch = "xtensa",
-    feature = "critical-section",
+    portable_atomic_critical_section,
 ))]
 mod interrupt;
 
@@ -228,14 +228,14 @@ pub(crate) mod float;
 #[cfg_attr(
     portable_atomic_no_cfg_target_has_atomic,
     cfg(not(all(
-        any(target_arch = "riscv32", target_arch = "riscv64", feature = "critical-section"),
+        any(target_arch = "riscv32", target_arch = "riscv64", portable_atomic_critical_section),
         portable_atomic_no_atomic_cas,
     )))
 )]
 #[cfg_attr(
     not(portable_atomic_no_cfg_target_has_atomic),
     cfg(not(all(
-        any(target_arch = "riscv32", target_arch = "riscv64", feature = "critical-section"),
+        any(target_arch = "riscv32", target_arch = "riscv64", portable_atomic_critical_section),
         not(target_has_atomic = "ptr"),
     )))
 )]
@@ -264,12 +264,12 @@ items! {
 #[cfg(all(
     target_arch = "bpf",
     portable_atomic_no_atomic_load_store,
-    not(feature = "critical-section"),
+    not(portable_atomic_critical_section),
 ))]
 pub(crate) use self::core_atomic::{AtomicI64, AtomicIsize, AtomicPtr, AtomicU64, AtomicUsize};
 
 // RISC-V without A-extension & !(assume single core | critical section)
-#[cfg(not(any(portable_atomic_unsafe_assume_single_core, feature = "critical-section")))]
+#[cfg(not(any(portable_atomic_unsafe_assume_single_core, portable_atomic_critical_section)))]
 #[cfg_attr(portable_atomic_no_cfg_target_has_atomic, cfg(portable_atomic_no_atomic_cas))]
 #[cfg_attr(not(portable_atomic_no_cfg_target_has_atomic), cfg(not(target_has_atomic = "ptr")))]
 #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
@@ -285,7 +285,7 @@ items! {
 // no core atomic CAS & (assume single core | critical section) => critical section based fallback
 #[cfg(any(
     portable_atomic_unsafe_assume_single_core,
-    feature = "critical-section",
+    portable_atomic_critical_section,
     target_arch = "avr",
     target_arch = "msp430",
 ))]

--- a/src/imp/msp430.rs
+++ b/src/imp/msp430.rs
@@ -15,7 +15,7 @@
 
 #[cfg(not(portable_atomic_no_asm))]
 use core::arch::asm;
-#[cfg(any(test, not(feature = "critical-section")))]
+#[cfg(any(test, not(portable_atomic_critical_section)))]
 use core::cell::UnsafeCell;
 use core::sync::atomic::Ordering;
 
@@ -58,21 +58,21 @@ pub fn compiler_fence(order: Ordering) {
 
 macro_rules! atomic {
     (load_store, $([$($generics:tt)*])? $atomic_type:ident, $value_type:ty, $asm_suffix:tt) => {
-        #[cfg(any(test, not(feature = "critical-section")))]
+        #[cfg(any(test, not(portable_atomic_critical_section)))]
         #[repr(transparent)]
         pub(crate) struct $atomic_type $(<$($generics)*>)? {
             v: UnsafeCell<$value_type>,
         }
 
-        #[cfg(any(test, not(feature = "critical-section")))]
+        #[cfg(any(test, not(portable_atomic_critical_section)))]
         // Send is implicitly implemented for atomic integers, but not for atomic pointers.
         // SAFETY: any data races are prevented by atomic operations.
         unsafe impl $(<$($generics)*>)? Send for $atomic_type $(<$($generics)*>)? {}
-        #[cfg(any(test, not(feature = "critical-section")))]
+        #[cfg(any(test, not(portable_atomic_critical_section)))]
         // SAFETY: any data races are prevented by atomic operations.
         unsafe impl $(<$($generics)*>)? Sync for $atomic_type $(<$($generics)*>)? {}
 
-        #[cfg(any(test, not(feature = "critical-section")))]
+        #[cfg(any(test, not(portable_atomic_critical_section)))]
         impl $(<$($generics)*>)? $atomic_type $(<$($generics)*>)? {
             #[cfg(test)]
             #[inline]
@@ -150,7 +150,7 @@ macro_rules! atomic {
     };
     ($([$($generics:tt)*])? $atomic_type:ident, $value_type:ty, $asm_suffix:tt) => {
         atomic!(load_store, $([$($generics)*])? $atomic_type, $value_type, $asm_suffix);
-        #[cfg(any(test, not(feature = "critical-section")))]
+        #[cfg(any(test, not(portable_atomic_critical_section)))]
         impl $(<$($generics)*>)? $atomic_type $(<$($generics)*>)? {
             #[inline]
             pub(crate) fn add(&self, val: $value_type, _order: Ordering) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,9 @@ RUSTFLAGS="--cfg portable_atomic_no_outline_atomics" cargo ...
 
   Originally, we were providing these as cfgs instead of features, but based on a strong request from the embedded ecosystem, we have agreed to provide them as features as well. See [#94](https://github.com/taiki-e/portable-atomic/pull/94) for more.
 
+- <a name="optional-cfg-portable-atomic"></a>**`--cfg portable_atomic_critical_section`**<br>
+  Since 1.7.1, this cfg is an alias of [`critical-section` feature](#optional-features-critical-section).
+
 - <a name="optional-cfg-no-outline-atomics"></a>**`--cfg portable_atomic_no_outline_atomics`**<br>
   Disable dynamic dispatching by run-time CPU feature detection.
 
@@ -299,7 +302,7 @@ RUSTFLAGS="--cfg portable_atomic_no_outline_atomics" cargo ...
             target_arch = "msp430",
             target_arch = "riscv32",
             target_arch = "riscv64",
-            feature = "critical-section",
+            portable_atomic_critical_section,
         )),
     ),
     allow(unused_imports, unused_macros)
@@ -395,7 +398,7 @@ compile_error!(
     "cfg(portable_atomic_force_amo) may only be used together with cfg(portable_atomic_unsafe_assume_single_core)"
 );
 
-#[cfg(all(portable_atomic_unsafe_assume_single_core, feature = "critical-section"))]
+#[cfg(all(portable_atomic_unsafe_assume_single_core, portable_atomic_critical_section))]
 compile_error!(
     "you may not enable feature `critical-section` and cfg(portable_atomic_unsafe_assume_single_core) at the same time"
 );
@@ -406,7 +409,7 @@ compile_error!(
     cfg(not(any(
         not(portable_atomic_no_atomic_cas),
         portable_atomic_unsafe_assume_single_core,
-        feature = "critical-section",
+        portable_atomic_critical_section,
         target_arch = "avr",
         target_arch = "msp430",
     )))
@@ -416,7 +419,7 @@ compile_error!(
     cfg(not(any(
         target_has_atomic = "ptr",
         portable_atomic_unsafe_assume_single_core,
-        feature = "critical-section",
+        portable_atomic_critical_section,
         target_arch = "avr",
         target_arch = "msp430",
     )))


### PR DESCRIPTION
It is really hard to keep track if `critical-section` should be enabled with a complex project of many different dependencies with feature flags, which all require `critical-section` to be added. 

As such, the `critical-section` feature should get an alias called `portable_atomic_critical_section` cfg, just like how `unsafe-assume-single-core` feature has the alias `portable_atomic_unsafe_assume_single_core` cfg, to maintain feature parity.