### PR TITLE
riscv: Support 128-bit atomics for RV64 and 64-bit atomics for RV32 (Zacas extension)

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -3,6 +3,7 @@ adde
 alcgr
 algr
 allnoconfig
+amocas
 aosp
 aqrl
 armasm
@@ -31,6 +32,7 @@ cpsid
 cpsie
 CPSR
 cpuid
+cpus
 cputable
 csel
 cset
@@ -192,4 +194,5 @@ xsave
 xsub
 zaamo
 zabha
+zacas
 Zhaoxin

--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -46,6 +46,8 @@ DWCAS
 elems
 espup
 exynos
+fild
+fistp
 getauxval
 getisax
 getpid
@@ -70,6 +72,7 @@ ldclrpa
 ldclrpal
 ldclrpl
 ldiapp
+ldrexd
 ldsetp
 ldsetpa
 ldsetpal
@@ -101,6 +104,8 @@ minu
 mipsn
 miscompiles
 mmfr
+movlps
+movq
 mpidr
 mstatus
 mvfr
@@ -150,6 +155,7 @@ stilp
 stlxp
 stpq
 stqcx
+strexd
 stxp
 subarch
 subc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,8 +259,6 @@ jobs:
             target: riscv64gc-unknown-linux-gnu
           - rust: '1.59' # LLVM 13
             target: riscv64gc-unknown-linux-gnu
-          - rust: '1.73' # LLVM 17 (oldest version we can use experimental-zacas on this target)
-            target: riscv64gc-unknown-linux-gnu
           - rust: stable
             target: riscv64gc-unknown-linux-gnu
           - rust: nightly
@@ -317,6 +315,9 @@ jobs:
       # TODO: LLVM bug: Undefined temporary symbol error when building std.
       - run: printf 'RELEASE=--release\n' >>"${GITHUB_ENV}"
         if: startsWith(matrix.target, 'mips-') || startsWith(matrix.target, 'mipsel-')
+      # for serde
+      - run: printf '%s\n' "RUSTFLAGS=${RUSTFLAGS} --cfg no_diagnostic_namespace" >>"${GITHUB_ENV}"
+        if: matrix.rust == 'nightly-2024-02-13'
 
       - run: tools/test.sh -vv ${TARGET:-} ${DOCTEST_XCOMPILE:-} ${BUILD_STD:-} ${RELEASE:-}
       # We test doctest only once with the default build conditions because doctest is slow. Both api-test
@@ -388,21 +389,21 @@ jobs:
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-cpu=pwr8
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-cpu=pwr8
         if: startsWith(matrix.target, 'powerpc64-')
-      # riscv64 +zabha
+      # riscv +zabha
       - run: tools/test.sh -vv --tests ${TARGET:-} ${BUILD_STD:-} ${RELEASE:-}
         env:
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-feature=+zabha
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-feature=+zabha
           QEMU_CPU: max
         # TODO: cranelift doesn't support cfg(target_feature): https://github.com/rust-lang/rustc_codegen_cranelift/issues/1400
-        if: startsWith(matrix.target, 'riscv64') && !contains(matrix.flags, 'codegen-backend=cranelift')
-      # riscv64 +experimental-zacas
+        if: startsWith(matrix.target, 'riscv') && !contains(matrix.flags, 'codegen-backend=cranelift')
+      # riscv +experimental-zacas
       - run: tools/test.sh -vv --tests ${TARGET:-} ${BUILD_STD:-} ${RELEASE:-}
         env:
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-feature=+experimental-zacas
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-feature=+experimental-zacas
         # TODO: cranelift doesn't support cfg(target_feature): https://github.com/rust-lang/rustc_codegen_cranelift/issues/1400
-        if: startsWith(matrix.target, 'riscv64') && !contains(matrix.flags, 'codegen-backend=cranelift')
+        if: startsWith(matrix.target, 'riscv') && !contains(matrix.flags, 'codegen-backend=cranelift')
       # s390x z196 (arch9)
       - run: tools/test.sh -vv --tests ${TARGET:-} ${BUILD_STD:-} ${RELEASE:-}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,8 @@ jobs:
             target: riscv64gc-unknown-linux-gnu
           - rust: '1.59' # LLVM 13
             target: riscv64gc-unknown-linux-gnu
+          - rust: '1.73' # LLVM 17 (oldest version we can use experimental-zacas on this target)
+            target: riscv64gc-unknown-linux-gnu
           - rust: stable
             target: riscv64gc-unknown-linux-gnu
           - rust: nightly
@@ -386,6 +388,21 @@ jobs:
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-cpu=pwr8
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-cpu=pwr8
         if: startsWith(matrix.target, 'powerpc64-')
+      # riscv64 +zabha
+      - run: tools/test.sh -vv --tests ${TARGET:-} ${BUILD_STD:-} ${RELEASE:-}
+        env:
+          RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-feature=+zabha
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-feature=+zabha
+          QEMU_CPU: max
+        # TODO: cranelift doesn't support cfg(target_feature): https://github.com/rust-lang/rustc_codegen_cranelift/issues/1400
+        if: startsWith(matrix.target, 'riscv64') && !contains(matrix.flags, 'codegen-backend=cranelift')
+      # riscv64 +experimental-zacas
+      - run: tools/test.sh -vv --tests ${TARGET:-} ${BUILD_STD:-} ${RELEASE:-}
+        env:
+          RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-feature=+experimental-zacas
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-feature=+experimental-zacas
+        # TODO: cranelift doesn't support cfg(target_feature): https://github.com/rust-lang/rustc_codegen_cranelift/issues/1400
+        if: startsWith(matrix.target, 'riscv64') && !contains(matrix.flags, 'codegen-backend=cranelift')
       # s390x z196 (arch9)
       - run: tools/test.sh -vv --tests ${TARGET:-} ${BUILD_STD:-} ${RELEASE:-}
         env:

--- a/src/cfgs.rs
+++ b/src/cfgs.rs
@@ -154,6 +154,36 @@ mod atomic_32_macros {
         ),
         target_has_atomic = "64",
         not(any(target_pointer_width = "16", target_pointer_width = "32")),
+        all(
+            target_arch = "riscv32",
+            not(any(miri, portable_atomic_sanitize_thread)),
+            not(portable_atomic_no_asm),
+            any(
+                target_feature = "experimental-zacas",
+                portable_atomic_target_feature = "experimental-zacas",
+                // TODO(riscv)
+                // all(
+                //     feature = "fallback",
+                //     not(portable_atomic_no_outline_atomics),
+                //     any(test, portable_atomic_outline_atomics), // TODO(riscv): currently disabled by default
+                //     any(
+                //         all(
+                //             target_os = "linux",
+                //             any(
+                //                 target_env = "gnu",
+                //                 all(
+                //                     any(target_env = "musl", target_env = "ohos"),
+                //                     not(target_feature = "crt-static"),
+                //                 ),
+                //                 portable_atomic_outline_atomics,
+                //             ),
+                //         ),
+                //         target_os = "android",
+                //     ),
+                //     not(any(miri, portable_atomic_sanitize_thread)),
+                // ),
+            ),
+        ),
     ))
 )]
 #[macro_use]
@@ -201,6 +231,36 @@ mod atomic_64_macros {
         ),
         target_has_atomic = "64",
         not(any(target_pointer_width = "16", target_pointer_width = "32")),
+        all(
+            target_arch = "riscv32",
+            not(any(miri, portable_atomic_sanitize_thread)),
+            not(portable_atomic_no_asm),
+            any(
+                target_feature = "experimental-zacas",
+                portable_atomic_target_feature = "experimental-zacas",
+                // TODO(riscv)
+                // all(
+                //     feature = "fallback",
+                //     not(portable_atomic_no_outline_atomics),
+                //     any(test, portable_atomic_outline_atomics), // TODO(riscv): currently disabled by default
+                //     any(
+                //         all(
+                //             target_os = "linux",
+                //             any(
+                //                 target_env = "gnu",
+                //                 all(
+                //                     any(target_env = "musl", target_env = "ohos"),
+                //                     not(target_feature = "crt-static"),
+                //                 ),
+                //                 portable_atomic_outline_atomics,
+                //             ),
+                //         ),
+                //         target_os = "android",
+                //     ),
+                //     not(any(miri, portable_atomic_sanitize_thread)),
+                // ),
+            ),
+        ),
     )))
 )]
 #[macro_use]
@@ -247,11 +307,11 @@ mod atomic_64_macros {
             any(
                 target_feature = "experimental-zacas",
                 portable_atomic_target_feature = "experimental-zacas",
-                // TODO(riscv64)
+                // TODO(riscv)
                 // all(
                 //     feature = "fallback",
                 //     not(portable_atomic_no_outline_atomics),
-                //     any(test, portable_atomic_outline_atomics), // TODO(riscv64): currently disabled by default
+                //     any(test, portable_atomic_outline_atomics), // TODO(riscv): currently disabled by default
                 //     any(
                 //         all(
                 //             target_os = "linux",
@@ -366,11 +426,11 @@ mod atomic_128_macros {
             any(
                 target_feature = "experimental-zacas",
                 portable_atomic_target_feature = "experimental-zacas",
-                // TODO(riscv64)
+                // TODO(riscv)
                 // all(
                 //     feature = "fallback",
                 //     not(portable_atomic_no_outline_atomics),
-                //     any(test, portable_atomic_outline_atomics), // TODO(riscv64): currently disabled by default
+                //     any(test, portable_atomic_outline_atomics), // TODO(riscv): currently disabled by default
                 //     any(
                 //         all(
                 //             target_os = "linux",

--- a/src/cfgs.rs
+++ b/src/cfgs.rs
@@ -242,6 +242,35 @@ mod atomic_64_macros {
             ),
         ),
         all(
+            target_arch = "riscv64",
+            not(portable_atomic_no_asm),
+            any(
+                target_feature = "experimental-zacas",
+                portable_atomic_target_feature = "experimental-zacas",
+                // TODO(riscv64)
+                // all(
+                //     feature = "fallback",
+                //     not(portable_atomic_no_outline_atomics),
+                //     any(test, portable_atomic_outline_atomics), // TODO(riscv64): currently disabled by default
+                //     any(
+                //         all(
+                //             target_os = "linux",
+                //             any(
+                //                 target_env = "gnu",
+                //                 all(
+                //                     any(target_env = "musl", target_env = "ohos"),
+                //                     not(target_feature = "crt-static"),
+                //                 ),
+                //                 portable_atomic_outline_atomics,
+                //             ),
+                //         ),
+                //         target_os = "android",
+                //     ),
+                //     not(any(miri, portable_atomic_sanitize_thread)),
+                // ),
+            ),
+        ),
+        all(
             target_arch = "powerpc64",
             portable_atomic_unstable_asm_experimental_arch,
             any(
@@ -329,6 +358,35 @@ mod atomic_128_macros {
                     not(portable_atomic_no_outline_atomics),
                     not(any(target_env = "sgx", miri)),
                 ),
+            ),
+        ),
+        all(
+            target_arch = "riscv64",
+            not(portable_atomic_no_asm),
+            any(
+                target_feature = "experimental-zacas",
+                portable_atomic_target_feature = "experimental-zacas",
+                // TODO(riscv64)
+                // all(
+                //     feature = "fallback",
+                //     not(portable_atomic_no_outline_atomics),
+                //     any(test, portable_atomic_outline_atomics), // TODO(riscv64): currently disabled by default
+                //     any(
+                //         all(
+                //             target_os = "linux",
+                //             any(
+                //                 target_env = "gnu",
+                //                 all(
+                //                     any(target_env = "musl", target_env = "ohos"),
+                //                     not(target_feature = "crt-static"),
+                //                 ),
+                //                 portable_atomic_outline_atomics,
+                //             ),
+                //         ),
+                //         target_os = "android",
+                //     ),
+                //     not(any(miri, portable_atomic_sanitize_thread)),
+                // ),
             ),
         ),
         all(

--- a/src/imp/atomic128/README.md
+++ b/src/imp/atomic128/README.md
@@ -10,6 +10,7 @@ Here is the table of targets that support 128-bit atomics and the instructions u
 | ----------- | ---- | ----- | --- | --- | ---- |
 | x86_64 | cmpxchg16b or vmovdqa | cmpxchg16b or vmovdqa | cmpxchg16b | cmpxchg16b | cmpxchg16b target feature required. vmovdqa requires Intel, AMD, or Zhaoxin CPU with AVX. <br> Both compile-time and run-time detection are supported for cmpxchg16b. vmovdqa is currently run-time detection only. <br> Requires rustc 1.59+ |
 | aarch64 | ldxp/stxp or casp or ldp/ldiapp | ldxp/stxp or casp or stp/stilp/swpp | ldxp/stxp or casp | ldxp/stxp or casp/swpp/ldclrp/ldsetp | casp requires lse target feature, ldp/stp requires lse2 target feature, ldiapp/stilp requires lse2 and rcpc3 target features, swpp/ldclrp/ldsetp requires lse128 target feature. <br> Both compile-time and run-time detection are supported. <br> Requires rustc 1.59+ |
+| riscv64 | amocas.q | amocas.q | amocas.q | amocas.q | Experimental. Requires experimental-zacas target feature. Currently compile-time detection only due to LLVM marking it as experimental. <br> Requires 1.82+ (LLVM 19+) |
 | powerpc64 | lq | stq | lqarx/stqcx. | lqarx/stqcx. | Requires target-cpu pwr8+ (powerpc64le is pwr8 by default). Both compile-time and run-time detection are supported (run-time detection is currently disabled by default). <br> Requires nightly |
 | s390x | lpq | stpq | cdsg | cdsg | Requires nightly |
 
@@ -19,7 +20,7 @@ See [aarch64.rs](aarch64.rs) module-level comments for more details on the instr
 
 ## Comparison with core::intrinsics::atomic_\* (core::sync::atomic::Atomic{I,U}128)
 
-This directory has target-specific implementations with inline assembly ([aarch64.rs](aarch64.rs), [x86_64.rs](x86_64.rs), [powerpc64.rs](powerpc64.rs), [s390x.rs](s390x.rs)) and an implementation without inline assembly ([intrinsics.rs](intrinsics.rs)). The latter currently always needs nightly compilers and is only used for Miri and ThreadSanitizer, which do not support inline assembly.
+This directory has target-specific implementations with inline assembly ([aarch64.rs](aarch64.rs), [x86_64.rs](x86_64.rs), [powerpc64.rs](powerpc64.rs), [riscv64.rs](riscv64.rs), [s390x.rs](s390x.rs)) and an implementation without inline assembly ([intrinsics.rs](intrinsics.rs)). The latter currently always needs nightly compilers and is only used for Miri and ThreadSanitizer, which do not support inline assembly.
 
 Implementations with inline assembly generate assemblies almost equivalent to the `core::intrinsics::atomic_*` (used in `core::sync::atomic::Atomic{I,U}128`) for many operations, but some operations may or may not generate more efficient code. For example:
 
@@ -47,6 +48,7 @@ Here is the table of targets that support run-time CPU feature detection and the
 | aarch64     | macos/ios/tvos/watchos/visionos | sysctlbyname    | all      | Currently only used in tests (see detect/aarch64_apple.rs). |
 | aarch64     | windows              | IsProcessorFeaturePresent | lse | Enabled by default |
 | aarch64     | fuchsia              | zx_system_get_features | lse | Enabled by default |
+| riscv64     | linux                | riscv_hwprobe   | all      | Currently only used in tests due to LLVM marking zacas as experimental |
 | powerpc64   | linux                | getauxval       | all      | Disabled by default |
 | powerpc64   | freebsd              | elf_aux_info    | all      | Disabled by default |
 | powerpc64   | openbsd              | elf_aux_info    | all      | Disabled by default |

--- a/src/imp/atomic128/macros.rs
+++ b/src/imp/atomic128/macros.rs
@@ -261,7 +261,12 @@ macro_rules! atomic128 {
     };
 }
 
-#[cfg(any(target_arch = "powerpc64", target_arch = "s390x", target_arch = "x86_64"))]
+#[cfg(any(
+    target_arch = "powerpc64",
+    target_arch = "riscv64",
+    target_arch = "s390x",
+    target_arch = "x86_64",
+))]
 #[allow(unused_macros)] // also used by intrinsics.rs
 macro_rules! atomic_rmw_by_atomic_update {
     () => {

--- a/src/imp/atomic128/riscv64.rs
+++ b/src/imp/atomic128/riscv64.rs
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/*
+Atomic{I,U}128 implementation on riscv64 using amocas.q (DWCAS).
+
+Note: On Miri and ThreadSanitizer which do not support inline assembly, we don't use
+this module and use intrinsics.rs instead.
+
+Refs:
+- RISC-V Instruction Set Manual
+  https://github.com/riscv/riscv-isa-manual/tree/riscv-isa-release-8b9dc50-2024-08-30
+  "Zacas" Extension for Atomic Compare-and-Swap (CAS) Instructions
+  https://github.com/riscv/riscv-isa-manual/blob/riscv-isa-release-8b9dc50-2024-08-30/src/zacas.adoc
+- RISC-V Atomics ABI Specification
+  https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/draft-20240829-13bfa9f54634cb60d86b9b333e109f077805b4b3/riscv-atomic.adoc
+
+Generated asm:
+- riscv64 (+experimental-zacas) https://godbolt.org/z/5Kc17T1W8
+*/
+
+// TODO: 64-bit atomic using amocas.d for riscv32
+
+include!("macros.rs");
+
+// TODO
+// #[cfg(not(any(target_feature = "experimental-zacas", portable_atomic_target_feature = "experimental-zacas")))]
+// #[path = "../fallback/outline_atomics.rs"]
+// mod fallback;
+
+// On musl with static linking, it seems that libc is not always available.
+// See detect/auxv.rs for more.
+#[cfg(test)] // TODO
+#[cfg(not(portable_atomic_no_outline_atomics))]
+#[cfg(any(test, portable_atomic_outline_atomics))] // TODO(riscv64): currently disabled by default
+#[cfg(any(
+    test,
+    not(any(
+        target_feature = "experimental-zacas",
+        portable_atomic_target_feature = "experimental-zacas"
+    ))
+))]
+#[cfg(any(
+    all(
+        target_os = "linux",
+        any(
+            target_env = "gnu",
+            all(any(target_env = "musl", target_env = "ohos"), not(target_feature = "crt-static")),
+            portable_atomic_outline_atomics,
+        ),
+    ),
+    target_os = "android",
+))]
+#[path = "../detect/riscv_linux.rs"]
+mod detect;
+
+use core::{arch::asm, sync::atomic::Ordering};
+
+use crate::utils::{Pair, U128};
+
+// https://github.com/riscv-non-isa/riscv-asm-manual/blob/ad0de8c004e29c9a7ac33cfd054f4d4f9392f2fb/src/asm-manual.adoc#arch
+#[cfg(any(
+    target_feature = "experimental-zacas",
+    portable_atomic_target_feature = "experimental-zacas"
+))]
+macro_rules! start_zacas {
+    () => {
+        // zacas available, no-op
+        ""
+    };
+}
+#[cfg(any(
+    target_feature = "experimental-zacas",
+    portable_atomic_target_feature = "experimental-zacas"
+))]
+macro_rules! end_zacas {
+    () => {
+        // zacas available, no-op
+        ""
+    };
+}
+#[cfg(not(any(
+    target_feature = "experimental-zacas",
+    portable_atomic_target_feature = "experimental-zacas"
+)))]
+macro_rules! start_zacas {
+    () => {
+        ".option push\n.option arch, +experimental-zacas"
+    };
+}
+#[cfg(not(any(
+    target_feature = "experimental-zacas",
+    portable_atomic_target_feature = "experimental-zacas"
+)))]
+macro_rules! end_zacas {
+    () => {
+        ".option pop"
+    };
+}
+
+macro_rules! atomic_rmw_amocas_order {
+    ($op:ident, $order:ident) => {
+        atomic_rmw_amocas_order!($op, $order, failure = $order)
+    };
+    ($op:ident, $order:ident, failure = $failure:ident) => {
+        match $order {
+            Ordering::Relaxed => $op!("", ""),
+            Ordering::Acquire => $op!("", ".aq"),
+            Ordering::Release => $op!("", ".rl"),
+            Ordering::AcqRel => $op!("", ".aqrl"),
+            Ordering::SeqCst if $failure == Ordering::SeqCst => $op!("fence rw,rw", ".aqrl"),
+            Ordering::SeqCst => $op!("", ".aqrl"),
+            _ => unreachable!(),
+        }
+    };
+}
+
+#[inline]
+unsafe fn atomic_load(src: *mut u128, order: Ordering) -> u128 {
+    debug_assert!(src as usize % 16 == 0);
+
+    // SAFETY: the caller must uphold the safety contract.
+    unsafe {
+        let (out_lo, out_hi);
+        macro_rules! load {
+            ($fence:tt, $asm_order:tt) => {
+                asm!(
+                    start_zacas!(),
+                    $fence,
+                    concat!("amocas.q", $asm_order, " a2, a2, 0({src})"),
+                    end_zacas!(),
+                    src = in(reg) ptr_reg!(src),
+                    inout("a2") 0_u64 => out_lo,
+                    inout("a3") 0_u64 => out_hi,
+                    options(nostack, preserves_flags),
+                )
+            };
+        }
+        atomic_rmw_amocas_order!(load, order);
+        U128 { pair: Pair { lo: out_lo, hi: out_hi } }.whole
+    }
+}
+
+#[inline]
+unsafe fn atomic_store(dst: *mut u128, val: u128, order: Ordering) {
+    // SAFETY: the caller must uphold the safety contract.
+    unsafe {
+        atomic_swap(dst, val, order);
+    }
+}
+
+#[inline]
+unsafe fn atomic_compare_exchange(
+    dst: *mut u128,
+    old: u128,
+    new: u128,
+    success: Ordering,
+    failure: Ordering,
+) -> Result<u128, u128> {
+    debug_assert!(dst as usize % 16 == 0);
+    let order = crate::utils::upgrade_success_ordering(success, failure);
+
+    // SAFETY: the caller must uphold the safety contract.
+    let prev = unsafe {
+        let old = U128 { whole: old };
+        let new = U128 { whole: new };
+        let (prev_lo, prev_hi);
+        macro_rules! cmpxchg {
+            ($fence:tt, $asm_order:tt) => {
+                asm!(
+                    start_zacas!(),
+                    $fence,
+                    concat!("amocas.q", $asm_order, " a4, a2, 0({dst})"),
+                    end_zacas!(),
+                    dst = in(reg) ptr_reg!(dst),
+                    // must be allocated to even/odd register pair
+                    inout("a4") old.pair.lo => prev_lo,
+                    inout("a5") old.pair.hi => prev_hi,
+                    // must be allocated to even/odd register pair
+                    in("a2") new.pair.lo,
+                    in("a3") new.pair.hi,
+                    options(nostack, preserves_flags),
+                )
+            };
+        }
+        atomic_rmw_amocas_order!(cmpxchg, order, failure = failure);
+        U128 { pair: Pair { lo: prev_lo, hi: prev_hi } }.whole
+    };
+    if prev == old {
+        Ok(prev)
+    } else {
+        Err(prev)
+    }
+}
+
+// amocas is always strong.
+use atomic_compare_exchange as atomic_compare_exchange_weak;
+
+// 128-bit atomic load by two 64-bit atomic loads. (see arm_linux.rs for more)
+#[inline]
+unsafe fn byte_wise_atomic_load(src: *const u128) -> u128 {
+    // SAFETY: the caller must uphold the safety contract.
+    unsafe {
+        let (out_lo, out_hi);
+        asm!(
+            "ld {out_lo}, ({src})",
+            "ld {out_hi}, 8({src})",
+            src = in(reg) ptr_reg!(src),
+            out_lo = out(reg) out_lo,
+            out_hi = out(reg) out_hi,
+            options(pure, nostack, preserves_flags, readonly),
+        );
+        U128 { pair: Pair { lo: out_lo, hi: out_hi } }.whole
+    }
+}
+
+#[inline(always)]
+unsafe fn atomic_update<F>(dst: *mut u128, order: Ordering, mut f: F) -> u128
+where
+    F: FnMut(u128) -> u128,
+{
+    // SAFETY: the caller must uphold the safety contract.
+    unsafe {
+        let mut prev = byte_wise_atomic_load(dst);
+        loop {
+            let next = f(prev);
+            match atomic_compare_exchange_weak(dst, prev, next, order, Ordering::Relaxed) {
+                Ok(x) => return x,
+                Err(x) => prev = x,
+            }
+        }
+    }
+}
+
+atomic_rmw_by_atomic_update!();
+
+#[inline]
+fn is_lock_free() -> bool {
+    #[cfg(any(
+        target_feature = "experimental-zacas",
+        portable_atomic_target_feature = "experimental-zacas"
+    ))]
+    {
+        // zacas is available at compile-time.
+        true
+    }
+    #[cfg(not(any(
+        target_feature = "experimental-zacas",
+        portable_atomic_target_feature = "experimental-zacas"
+    )))]
+    {
+        detect::detect().has_zacas()
+    }
+}
+const IS_ALWAYS_LOCK_FREE: bool = cfg!(any(
+    target_feature = "experimental-zacas",
+    portable_atomic_target_feature = "experimental-zacas"
+));
+
+atomic128!(AtomicI128, i128, atomic_max, atomic_min);
+atomic128!(AtomicU128, u128, atomic_umax, atomic_umin);
+
+#[allow(clippy::undocumented_unsafe_blocks, clippy::wildcard_imports)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_atomic_int!(i128);
+    test_atomic_int!(u128);
+
+    // load/store/swap implementation is not affected by signedness, so it is
+    // enough to test only unsigned types.
+    stress_test!(u128);
+}

--- a/src/imp/atomic64/README.md
+++ b/src/imp/atomic64/README.md
@@ -1,3 +1,34 @@
 # Implementation of 64-bit atomics on 32-bit architectures
 
 (See the [`atomic128` module](../atomic128) for 128-bit atomics on 64-bit architectures.)
+
+## 64-bit atomics instructions
+
+Here is the table of targets that support 64-bit atomics and the instructions used:
+
+| target_arch | load | store | CAS | RMW | note |
+| ----------- | ---- | ----- | --- | --- | ---- |
+| x86 | cmpxchg8b or fild or movlps or movq | cmpxchg8b or fistp or movlps | cmpxchg8b | cmpxchg8b | provided by `core::sync::atomic` |
+| arm | ldrexd | ldrexd/strexd | ldrexd/strexd | ldrexd/strexd | provided by `core::sync::atomic` for Armv6+, otherwise provided by us for Linux/Android using kuser_cmpxchg64 (see arm_linux.rs for more) |
+| riscv32 | amocas.d | amocas.d | amocas.d | amocas.d | Experimental. Requires experimental-zacas target feature. Currently compile-time detection only due to LLVM marking it as experimental. <br> Requires 1.82+ (LLVM 19+) |
+
+If `core::sync::atomic` provides 64-bit atomics, we use them.
+On compiler versions or platforms where these are not supported, the fallback implementation is used.
+
+## Run-time CPU feature detection
+
+[detect](../detect) module has run-time CPU feature detection implementations.
+
+Here is the table of targets that support run-time CPU feature detection and the instruction or API used:
+
+| target_arch | target_os/target_env | instruction/API | features | note |
+| ----------- | -------------------- | --------------- | -------- | ---- |
+| riscv32     | linux                | riscv_hwprobe   | all      | Currently only used in tests due to LLVM marking zacas as experimental |
+
+Run-time detection is enabled by default on most targets and can be disabled with `--cfg portable_atomic_no_outline_atomics`.
+
+On some targets, run-time detection is disabled by default mainly for compatibility with older versions of operating systems or incomplete build environments, and can be enabled by `--cfg portable_atomic_outline_atomics`. (When both cfg are enabled, `*_no_*` cfg is preferred.)
+
+For targets not included in the above table, run-time detection is always disabled and works the same as when `--cfg portable_atomic_no_outline_atomics` is set.
+
+See also [docs on `portable_atomic_no_outline_atomics`](https://github.com/taiki-e/portable-atomic/blob/HEAD/README.md#optional-cfg-no-outline-atomics) in the top-level readme.

--- a/src/imp/atomic64/macros.rs
+++ b/src/imp/atomic64/macros.rs
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+macro_rules! atomic64 {
+    ($atomic_type:ident, $int_type:ident, $atomic_max:ident, $atomic_min:ident) => {
+        #[repr(C, align(8))]
+        pub(crate) struct $atomic_type {
+            v: core::cell::UnsafeCell<$int_type>,
+        }
+
+        // Send is implicitly implemented.
+        // SAFETY: any data races are prevented by atomic intrinsics, the kernel user helper, or the lock.
+        unsafe impl Sync for $atomic_type {}
+
+        impl_default_no_fetch_ops!($atomic_type, $int_type);
+        impl_default_bit_opts!($atomic_type, $int_type);
+        impl $atomic_type {
+            #[inline]
+            pub(crate) const fn new(v: $int_type) -> Self {
+                Self { v: core::cell::UnsafeCell::new(v) }
+            }
+
+            #[inline]
+            pub(crate) fn is_lock_free() -> bool {
+                is_lock_free()
+            }
+            pub(crate) const IS_ALWAYS_LOCK_FREE: bool = IS_ALWAYS_LOCK_FREE;
+
+            #[inline]
+            pub(crate) fn get_mut(&mut self) -> &mut $int_type {
+                // SAFETY: the mutable reference guarantees unique ownership.
+                // (UnsafeCell::get_mut requires Rust 1.50)
+                unsafe { &mut *self.v.get() }
+            }
+
+            #[inline]
+            #[cfg_attr(all(debug_assertions, not(portable_atomic_no_track_caller)), track_caller)]
+            pub(crate) fn load(&self, order: Ordering) -> $int_type {
+                crate::utils::assert_load_ordering(order);
+                #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+                // SAFETY: any data races are prevented by atomic intrinsics, the kernel user helper, or the lock
+                // and the raw pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    atomic_load(self.v.get().cast::<u64>(), order) as $int_type
+                }
+            }
+
+            #[inline]
+            #[cfg_attr(all(debug_assertions, not(portable_atomic_no_track_caller)), track_caller)]
+            pub(crate) fn store(&self, val: $int_type, order: Ordering) {
+                crate::utils::assert_store_ordering(order);
+                #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+                // SAFETY: any data races are prevented by atomic intrinsics, the kernel user helper, or the lock
+                // and the raw pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    atomic_store(self.v.get().cast::<u64>(), val as u64, order)
+                }
+            }
+
+            #[inline]
+            pub(crate) fn swap(&self, val: $int_type, order: Ordering) -> $int_type {
+                #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+                // SAFETY: any data races are prevented by atomic intrinsics, the kernel user helper, or the lock
+                // and the raw pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    atomic_swap(self.v.get().cast::<u64>(), val as u64, order) as $int_type
+                }
+            }
+
+            #[inline]
+            #[cfg_attr(all(debug_assertions, not(portable_atomic_no_track_caller)), track_caller)]
+            pub(crate) fn compare_exchange(
+                &self,
+                current: $int_type,
+                new: $int_type,
+                success: Ordering,
+                failure: Ordering,
+            ) -> Result<$int_type, $int_type> {
+                crate::utils::assert_compare_exchange_ordering(success, failure);
+                #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+                // SAFETY: any data races are prevented by atomic intrinsics, the kernel user helper, or the lock
+                // and the raw pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    match atomic_compare_exchange(
+                        self.v.get().cast::<u64>(),
+                        current as u64,
+                        new as u64,
+                        success,
+                        failure,
+                    ) {
+                        Ok(v) => Ok(v as $int_type),
+                        Err(v) => Err(v as $int_type),
+                    }
+                }
+            }
+
+            #[inline]
+            #[cfg_attr(all(debug_assertions, not(portable_atomic_no_track_caller)), track_caller)]
+            pub(crate) fn compare_exchange_weak(
+                &self,
+                current: $int_type,
+                new: $int_type,
+                success: Ordering,
+                failure: Ordering,
+            ) -> Result<$int_type, $int_type> {
+                crate::utils::assert_compare_exchange_ordering(success, failure);
+                #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+                // SAFETY: any data races are prevented by atomic intrinsics, the kernel user helper, or the lock
+                // and the raw pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    match atomic_compare_exchange_weak(
+                        self.v.get().cast::<u64>(),
+                        current as u64,
+                        new as u64,
+                        success,
+                        failure,
+                    ) {
+                        Ok(v) => Ok(v as $int_type),
+                        Err(v) => Err(v as $int_type),
+                    }
+                }
+            }
+
+            #[inline]
+            pub(crate) fn fetch_add(&self, val: $int_type, order: Ordering) -> $int_type {
+                #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+                // SAFETY: any data races are prevented by atomic intrinsics, the kernel user helper, or the lock
+                // and the raw pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    atomic_add(self.v.get().cast::<u64>(), val as u64, order) as $int_type
+                }
+            }
+
+            #[inline]
+            pub(crate) fn fetch_sub(&self, val: $int_type, order: Ordering) -> $int_type {
+                #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+                // SAFETY: any data races are prevented by atomic intrinsics, the kernel user helper, or the lock
+                // and the raw pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    atomic_sub(self.v.get().cast::<u64>(), val as u64, order) as $int_type
+                }
+            }
+
+            #[inline]
+            pub(crate) fn fetch_and(&self, val: $int_type, order: Ordering) -> $int_type {
+                #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+                // SAFETY: any data races are prevented by atomic intrinsics, the kernel user helper, or the lock
+                // and the raw pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    atomic_and(self.v.get().cast::<u64>(), val as u64, order) as $int_type
+                }
+            }
+
+            #[inline]
+            pub(crate) fn fetch_nand(&self, val: $int_type, order: Ordering) -> $int_type {
+                #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+                // SAFETY: any data races are prevented by atomic intrinsics, the kernel user helper, or the lock
+                // and the raw pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    atomic_nand(self.v.get().cast::<u64>(), val as u64, order) as $int_type
+                }
+            }
+
+            #[inline]
+            pub(crate) fn fetch_or(&self, val: $int_type, order: Ordering) -> $int_type {
+                #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+                // SAFETY: any data races are prevented by atomic intrinsics, the kernel user helper, or the lock
+                // and the raw pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    atomic_or(self.v.get().cast::<u64>(), val as u64, order) as $int_type
+                }
+            }
+
+            #[inline]
+            pub(crate) fn fetch_xor(&self, val: $int_type, order: Ordering) -> $int_type {
+                #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+                // SAFETY: any data races are prevented by atomic intrinsics, the kernel user helper, or the lock
+                // and the raw pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    atomic_xor(self.v.get().cast::<u64>(), val as u64, order) as $int_type
+                }
+            }
+
+            #[inline]
+            pub(crate) fn fetch_max(&self, val: $int_type, order: Ordering) -> $int_type {
+                #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+                // SAFETY: any data races are prevented by atomic intrinsics, the kernel user helper, or the lock
+                // and the raw pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    $atomic_max(self.v.get().cast::<u64>(), val as u64, order) as $int_type
+                }
+            }
+
+            #[inline]
+            pub(crate) fn fetch_min(&self, val: $int_type, order: Ordering) -> $int_type {
+                #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+                // SAFETY: any data races are prevented by atomic intrinsics, the kernel user helper, or the lock
+                // and the raw pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    $atomic_min(self.v.get().cast::<u64>(), val as u64, order) as $int_type
+                }
+            }
+
+            #[inline]
+            pub(crate) fn fetch_not(&self, order: Ordering) -> $int_type {
+                #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+                // SAFETY: any data races are prevented by atomic intrinsics, the kernel user helper, or the lock
+                // and the raw pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    atomic_not(self.v.get().cast::<u64>(), order) as $int_type
+                }
+            }
+            #[inline]
+            pub(crate) fn not(&self, order: Ordering) {
+                self.fetch_not(order);
+            }
+
+            #[inline]
+            pub(crate) fn fetch_neg(&self, order: Ordering) -> $int_type {
+                #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+                // SAFETY: any data races are prevented by atomic intrinsics, the kernel user helper, or the lock
+                // and the raw pointer passed in is valid because we got it from a reference.
+                unsafe {
+                    atomic_neg(self.v.get().cast::<u64>(), order) as $int_type
+                }
+            }
+            #[inline]
+            pub(crate) fn neg(&self, order: Ordering) {
+                self.fetch_neg(order);
+            }
+
+            #[inline]
+            pub(crate) const fn as_ptr(&self) -> *mut $int_type {
+                self.v.get()
+            }
+        }
+    };
+}
+
+#[cfg(target_arch = "riscv32")]
+macro_rules! atomic_rmw_by_atomic_update {
+    () => {
+        #[inline]
+        #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+        unsafe fn atomic_swap(dst: *mut u64, val: u64, order: Ordering) -> u64 {
+            // SAFETY: the caller must uphold the safety contract.
+            unsafe { atomic_update(dst, order, |_| val) }
+        }
+        #[inline]
+        #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+        unsafe fn atomic_add(dst: *mut u64, val: u64, order: Ordering) -> u64 {
+            // SAFETY: the caller must uphold the safety contract.
+            unsafe { atomic_update(dst, order, |x| x.wrapping_add(val)) }
+        }
+        #[inline]
+        #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+        unsafe fn atomic_sub(dst: *mut u64, val: u64, order: Ordering) -> u64 {
+            // SAFETY: the caller must uphold the safety contract.
+            unsafe { atomic_update(dst, order, |x| x.wrapping_sub(val)) }
+        }
+        #[inline]
+        #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+        unsafe fn atomic_and(dst: *mut u64, val: u64, order: Ordering) -> u64 {
+            // SAFETY: the caller must uphold the safety contract.
+            unsafe { atomic_update(dst, order, |x| x & val) }
+        }
+        #[inline]
+        #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+        unsafe fn atomic_nand(dst: *mut u64, val: u64, order: Ordering) -> u64 {
+            // SAFETY: the caller must uphold the safety contract.
+            unsafe { atomic_update(dst, order, |x| !(x & val)) }
+        }
+        #[inline]
+        #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+        unsafe fn atomic_or(dst: *mut u64, val: u64, order: Ordering) -> u64 {
+            // SAFETY: the caller must uphold the safety contract.
+            unsafe { atomic_update(dst, order, |x| x | val) }
+        }
+        #[inline]
+        #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+        unsafe fn atomic_xor(dst: *mut u64, val: u64, order: Ordering) -> u64 {
+            // SAFETY: the caller must uphold the safety contract.
+            unsafe { atomic_update(dst, order, |x| x ^ val) }
+        }
+        #[inline]
+        #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+        unsafe fn atomic_not(dst: *mut u64, order: Ordering) -> u64 {
+            // SAFETY: the caller must uphold the safety contract.
+            unsafe { atomic_update(dst, order, |x| !x) }
+        }
+        #[inline]
+        #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+        unsafe fn atomic_neg(dst: *mut u64, order: Ordering) -> u64 {
+            // SAFETY: the caller must uphold the safety contract.
+            unsafe { atomic_update(dst, order, u64::wrapping_neg) }
+        }
+        atomic_rmw_by_atomic_update!(cmp);
+    };
+    (cmp) => {
+        #[inline]
+        #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+        unsafe fn atomic_max(dst: *mut u64, val: u64, order: Ordering) -> u64 {
+            #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+            // SAFETY: the caller must uphold the safety contract.
+            unsafe {
+                atomic_update(dst, order, |x| core::cmp::max(x as i64, val as i64) as u64)
+            }
+        }
+        #[inline]
+        #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+        unsafe fn atomic_umax(dst: *mut u64, val: u64, order: Ordering) -> u64 {
+            // SAFETY: the caller must uphold the safety contract.
+            unsafe { atomic_update(dst, order, |x| core::cmp::max(x, val)) }
+        }
+        #[inline]
+        #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+        unsafe fn atomic_min(dst: *mut u64, val: u64, order: Ordering) -> u64 {
+            #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+            // SAFETY: the caller must uphold the safety contract.
+            unsafe {
+                atomic_update(dst, order, |x| core::cmp::min(x as i64, val as i64) as u64)
+            }
+        }
+        #[inline]
+        #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+        unsafe fn atomic_umin(dst: *mut u64, val: u64, order: Ordering) -> u64 {
+            // SAFETY: the caller must uphold the safety contract.
+            unsafe { atomic_update(dst, order, |x| core::cmp::min(x, val)) }
+        }
+    };
+}

--- a/src/imp/detect/common.rs
+++ b/src/imp/detect/common.rs
@@ -106,7 +106,7 @@ flags! {
     HAS_QUADWORD_ATOMICS(1, has_quadword_atomics, "quadword-atomics", any(target_feature = "quadword-atomics", portable_atomic_target_feature = "quadword-atomics")),
 }
 
-#[cfg(target_arch = "riscv64")]
+#[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
 flags! {
     // amocas.{w,d,q}
     HAS_ZACAS(1, has_zacas, "zacas", any(target_feature = "experimental-zacas", portable_atomic_target_feature = "experimental-zacas")),
@@ -321,7 +321,7 @@ mod tests_common {
             }
         }
     }
-    #[cfg(target_arch = "riscv64")]
+    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
     #[test]
     #[cfg_attr(portable_atomic_test_outline_atomics_detect_false, ignore)]
     fn test_detect() {

--- a/src/imp/detect/riscv_linux.rs
+++ b/src/imp/detect/riscv_linux.rs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/*
+Run-time CPU feature detection on RISC-V Linux/Android by using riscv_hwprobe.
+
+On RISC-V, detection using auxv only supports single-letter extensions.
+So, we use riscv_hwprobe that supports multi-letter extensions.
+
+Refs: https://github.com/torvalds/linux/blob/v6.11/Documentation/arch/riscv/hwprobe.rst
+*/
+
+include!("common.rs");
+
+use core::ptr;
+
+// core::ffi::c_* (except c_void) requires Rust 1.64, libc will soon require Rust 1.47
+#[allow(non_camel_case_types, non_upper_case_globals)]
+mod ffi {
+    pub(crate) use super::c_types::{c_long, c_size_t, c_uint, c_ulong};
+
+    // https://github.com/torvalds/linux/blob/v6.11/arch/riscv/include/uapi/asm/hwprobe.h
+    #[derive(Copy, Clone)]
+    #[repr(C)]
+    pub(crate) struct riscv_hwprobe {
+        pub(crate) key: i64,
+        pub(crate) value: u64,
+    }
+
+    pub(crate) const __NR_riscv_hwprobe: c_long = 258;
+
+    // https://github.com/torvalds/linux/blob/v6.11/arch/riscv/include/uapi/asm/hwprobe.h
+    pub(crate) const RISCV_HWPROBE_KEY_IMA_EXT_0: i64 = 4;
+    // Linux 6.8+
+    // https://github.com/torvalds/linux/commit/154a3706122978eeb34d8223d49285ed4f3c61fa
+    pub(crate) const RISCV_HWPROBE_EXT_ZACAS: u64 = 1 << 34;
+
+    extern "C" {
+        // https://man7.org/linux/man-pages/man2/syscall.2.html
+        pub(crate) fn syscall(number: c_long, ...) -> c_long;
+    }
+
+    // https://github.com/torvalds/linux/blob/v6.11/Documentation/arch/riscv/hwprobe.rst
+    pub(crate) unsafe fn __riscv_hwprobe(
+        pairs: *mut riscv_hwprobe,
+        pair_count: c_size_t,
+        cpu_set_size: c_size_t,
+        cpus: *mut c_ulong,
+        flags: c_uint,
+    ) -> c_long {
+        // SAFETY: the caller must uphold the safety contract.
+        unsafe { syscall(__NR_riscv_hwprobe, pairs, pair_count, cpu_set_size, cpus, flags) }
+    }
+}
+
+// syscall returns an unsupported error if riscv_hwprobe is not supported,
+// so we can safely use this function on older versions of Linux.
+fn riscv_hwprobe(out: &mut ffi::riscv_hwprobe) -> bool {
+    // SAFETY: We've passed the valid pointer and length,
+    // passing null ptr for cpus is safe because cpu_set_size is zero.
+    unsafe { ffi::__riscv_hwprobe(out, 1, 0, ptr::null_mut(), 0) == 0 }
+}
+
+#[cold]
+fn _detect(info: &mut CpuInfo) {
+    let mut out = ffi::riscv_hwprobe { key: ffi::RISCV_HWPROBE_KEY_IMA_EXT_0, value: 0 };
+    if riscv_hwprobe(&mut out) && out.key != -1 {
+        let value = out.value;
+        if value & ffi::RISCV_HWPROBE_EXT_ZACAS != 0 {
+            info.set(CpuInfo::HAS_ZACAS);
+        }
+    }
+}
+
+#[allow(
+    clippy::alloc_instead_of_core,
+    clippy::std_instead_of_alloc,
+    clippy::std_instead_of_core,
+    clippy::undocumented_unsafe_blocks,
+    clippy::wildcard_imports
+)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Static assertions for FFI bindings.
+    // This checks that FFI bindings defined in this crate, FFI bindings defined
+    // in libc, and FFI bindings generated for the platform's latest header file
+    // using bindgen have compatible signatures (or the same values if constants).
+    // Since this is static assertion, we can detect problems with
+    // `cargo check --tests --target <target>` run in CI (via TESTS=1 build.sh)
+    // without actually running tests on these platforms.
+    // See also tools/codegen/src/ffi.rs.
+    // TODO(codegen): auto-generate this test
+    #[allow(
+        clippy::cast_possible_wrap,
+        clippy::cast_sign_loss,
+        clippy::no_effect_underscore_binding
+    )]
+    const _: fn() = || {
+        use std::mem;
+        use test_helper::sys;
+        // TODO: syscall
+        // static_assert!(ffi::__NR_riscv_hwprobe == libc::__NR_riscv_hwprobe); // libc doesn't have this
+        static_assert!(ffi::__NR_riscv_hwprobe == sys::__NR_riscv_hwprobe as ffi::c_long);
+        // static_assert!(ffi::RISCV_HWPROBE_KEY_IMA_EXT_0 == libc::RISCV_HWPROBE_KEY_IMA_EXT_0); // libc doesn't have this
+        static_assert!(ffi::RISCV_HWPROBE_KEY_IMA_EXT_0 == sys::RISCV_HWPROBE_KEY_IMA_EXT_0 as i64);
+        // static_assert!(ffi::RISCV_HWPROBE_EXT_ZACAS == libc::RISCV_HWPROBE_EXT_ZACAS); // libc doesn't have this
+        static_assert!(ffi::RISCV_HWPROBE_EXT_ZACAS == sys::RISCV_HWPROBE_EXT_ZACAS);
+        // libc doesn't have this
+        // static_assert!(
+        //     mem::size_of::<ffi::riscv_hwprobe>()
+        //         == mem::size_of::<libc::riscv_hwprobe>()
+        // );
+        static_assert!(
+            mem::size_of::<ffi::riscv_hwprobe>() == mem::size_of::<sys::riscv_hwprobe>()
+        );
+        let ffi: ffi::riscv_hwprobe = unsafe { mem::zeroed() };
+        let _ = sys::riscv_hwprobe { key: ffi.key, value: ffi.value };
+    };
+}

--- a/src/imp/fallback/mod.rs
+++ b/src/imp/fallback/mod.rs
@@ -375,7 +375,21 @@ macro_rules! atomic {
 #[cfg_attr(portable_atomic_no_cfg_target_has_atomic, cfg(any(test, portable_atomic_no_atomic_64)))]
 #[cfg_attr(
     not(portable_atomic_no_cfg_target_has_atomic),
-    cfg(any(test, not(target_has_atomic = "64")))
+    cfg(any(
+        test,
+        not(any(
+            target_has_atomic = "64",
+            all(
+                target_arch = "riscv32",
+                not(any(miri, portable_atomic_sanitize_thread)),
+                not(portable_atomic_no_asm),
+                any(
+                    target_feature = "experimental-zacas",
+                    portable_atomic_target_feature = "experimental-zacas",
+                ),
+            ),
+        ))
+    ))
 )]
 cfg_no_fast_atomic_64! {
     atomic!(AtomicI64, i64, 8);

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -64,6 +64,41 @@ mod aarch64;
 #[cfg_attr(not(any(miri, portable_atomic_sanitize_thread)), path = "atomic128/x86_64.rs")]
 mod x86_64;
 
+// riscv64 128-bit atomics
+#[cfg(all(
+    target_arch = "riscv64",
+    not(portable_atomic_no_asm),
+    any(
+        target_feature = "experimental-zacas",
+        portable_atomic_target_feature = "experimental-zacas",
+        // TODO(riscv64)
+        // all(
+        //     feature = "fallback",
+        //     not(portable_atomic_no_outline_atomics),
+        //     any(test, portable_atomic_outline_atomics), // TODO(riscv64): currently disabled by default
+        //     any(
+        //         all(
+        //             target_os = "linux",
+        //             any(
+        //                 target_env = "gnu",
+        //                 all(
+        //                     any(target_env = "musl", target_env = "ohos"),
+        //                     not(target_feature = "crt-static"),
+        //                 ),
+        //                 portable_atomic_outline_atomics,
+        //             ),
+        //         ),
+        //         target_os = "android",
+        //     ),
+        //     not(any(miri, portable_atomic_sanitize_thread)),
+        // ),
+    ),
+))]
+// Use intrinsics.rs on Miri and Sanitizer that do not support inline assembly.
+#[cfg_attr(any(miri, portable_atomic_sanitize_thread), path = "atomic128/intrinsics.rs")]
+#[cfg_attr(not(any(miri, portable_atomic_sanitize_thread)), path = "atomic128/riscv64.rs")]
+mod riscv64;
+
 // powerpc64 128-bit atomics
 #[cfg(all(
     target_arch = "powerpc64",
@@ -178,6 +213,14 @@ mod x86;
             target_arch = "x86_64",
             any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
             any(target_feature = "cmpxchg16b", portable_atomic_target_feature = "cmpxchg16b"),
+        ),
+        all(
+            target_arch = "riscv64",
+            not(portable_atomic_no_asm),
+            any(
+                target_feature = "experimental-zacas",
+                portable_atomic_target_feature = "experimental-zacas",
+            ),
         ),
         all(
             target_arch = "powerpc64",
@@ -357,6 +400,35 @@ items! {
             ),
         ),
         all(
+            target_arch = "riscv64",
+            not(portable_atomic_no_asm),
+            any(
+                target_feature = "experimental-zacas",
+                portable_atomic_target_feature = "experimental-zacas",
+                // TODO(riscv64)
+                // all(
+                //     feature = "fallback",
+                //     not(portable_atomic_no_outline_atomics),
+                //     any(test, portable_atomic_outline_atomics), // TODO(riscv64): currently disabled by default
+                //     any(
+                //         all(
+                //             target_os = "linux",
+                //             any(
+                //                 target_env = "gnu",
+                //                 all(
+                //                     any(target_env = "musl", target_env = "ohos"),
+                //                     not(target_feature = "crt-static"),
+                //                 ),
+                //                 portable_atomic_outline_atomics,
+                //             ),
+                //         ),
+                //         target_os = "android",
+                //     ),
+                //     not(any(miri, portable_atomic_sanitize_thread)),
+                // ),
+            ),
+        ),
+        all(
             target_arch = "powerpc64",
             portable_atomic_unstable_asm_experimental_arch,
             any(
@@ -429,6 +501,37 @@ pub(crate) use self::aarch64::{AtomicI128, AtomicU128};
     ),
 ))]
 pub(crate) use self::x86_64::{AtomicI128, AtomicU128};
+// riscv64 & zacas
+#[cfg(all(
+    target_arch = "riscv64",
+    not(portable_atomic_no_asm),
+    any(
+        target_feature = "experimental-zacas",
+        portable_atomic_target_feature = "experimental-zacas",
+        // TODO(riscv64)
+        // all(
+        //     feature = "fallback",
+        //     not(portable_atomic_no_outline_atomics),
+        //     any(test, portable_atomic_outline_atomics), // TODO(riscv64): currently disabled by default
+        //     any(
+        //         all(
+        //             target_os = "linux",
+        //             any(
+        //                 target_env = "gnu",
+        //                 all(
+        //                     any(target_env = "musl", target_env = "ohos"),
+        //                     not(target_feature = "crt-static"),
+        //                 ),
+        //                 portable_atomic_outline_atomics,
+        //             ),
+        //         ),
+        //         target_os = "android",
+        //     ),
+        //     not(any(miri, portable_atomic_sanitize_thread)),
+        // ),
+    ),
+))]
+pub(crate) use self::riscv64::{AtomicI128, AtomicU128};
 // powerpc64 & (pwr8 | outline-atomics)
 #[cfg(all(
     target_arch = "powerpc64",

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -71,11 +71,11 @@ mod x86_64;
     any(
         target_feature = "experimental-zacas",
         portable_atomic_target_feature = "experimental-zacas",
-        // TODO(riscv64)
+        // TODO(riscv)
         // all(
         //     feature = "fallback",
         //     not(portable_atomic_no_outline_atomics),
-        //     any(test, portable_atomic_outline_atomics), // TODO(riscv64): currently disabled by default
+        //     any(test, portable_atomic_outline_atomics), // TODO(riscv): currently disabled by default
         //     any(
         //         all(
         //             target_os = "linux",
@@ -163,6 +163,40 @@ mod s390x;
 #[cfg_attr(not(portable_atomic_no_cfg_target_has_atomic), cfg(not(target_has_atomic = "64")))]
 #[path = "atomic64/arm_linux.rs"]
 mod arm_linux;
+
+// riscv32 64-bit atomics
+#[cfg(all(
+    target_arch = "riscv32",
+    not(any(miri, portable_atomic_sanitize_thread)),
+    not(portable_atomic_no_asm),
+    any(
+        target_feature = "experimental-zacas",
+        portable_atomic_target_feature = "experimental-zacas",
+        // TODO(riscv)
+        // all(
+        //     feature = "fallback",
+        //     not(portable_atomic_no_outline_atomics),
+        //     any(test, portable_atomic_outline_atomics), // TODO(riscv): currently disabled by default
+        //     any(
+        //         all(
+        //             target_os = "linux",
+        //             any(
+        //                 target_env = "gnu",
+        //                 all(
+        //                     any(target_env = "musl", target_env = "ohos"),
+        //                     not(target_feature = "crt-static"),
+        //                 ),
+        //                 portable_atomic_outline_atomics,
+        //             ),
+        //         ),
+        //         target_os = "android",
+        //     ),
+        //     not(any(miri, portable_atomic_sanitize_thread)),
+        // ),
+    ),
+))]
+#[path = "atomic64/riscv32.rs"]
+mod riscv32;
 
 // MSP430 atomics
 #[cfg(target_arch = "msp430")]
@@ -366,13 +400,45 @@ items! {
 #[cfg_attr(portable_atomic_no_cfg_target_has_atomic, cfg(not(portable_atomic_no_atomic_cas)))]
 #[cfg_attr(not(portable_atomic_no_cfg_target_has_atomic), cfg(target_has_atomic = "ptr"))]
 items! {
-    #[cfg(not(all(
-        target_arch = "arm",
-        not(any(miri, portable_atomic_sanitize_thread)),
-        any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
-        any(target_os = "linux", target_os = "android"),
-        not(any(target_feature = "v6", portable_atomic_target_feature = "v6")),
-        not(portable_atomic_no_outline_atomics),
+    #[cfg(not(any(
+        all(
+            target_arch = "arm",
+            not(any(miri, portable_atomic_sanitize_thread)),
+            any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
+            any(target_os = "linux", target_os = "android"),
+            not(any(target_feature = "v6", portable_atomic_target_feature = "v6")),
+            not(portable_atomic_no_outline_atomics),
+        ),
+        all(
+            target_arch = "riscv32",
+            not(any(miri, portable_atomic_sanitize_thread)),
+            not(portable_atomic_no_asm),
+            any(
+                target_feature = "experimental-zacas",
+                portable_atomic_target_feature = "experimental-zacas",
+                // TODO(riscv)
+                // all(
+                //     feature = "fallback",
+                //     not(portable_atomic_no_outline_atomics),
+                //     any(test, portable_atomic_outline_atomics), // TODO(riscv): currently disabled by default
+                //     any(
+                //         all(
+                //             target_os = "linux",
+                //             any(
+                //                 target_env = "gnu",
+                //                 all(
+                //                     any(target_env = "musl", target_env = "ohos"),
+                //                     not(target_feature = "crt-static"),
+                //                 ),
+                //                 portable_atomic_outline_atomics,
+                //             ),
+                //         ),
+                //         target_os = "android",
+                //     ),
+                //     not(any(miri, portable_atomic_sanitize_thread)),
+                // ),
+            ),
+        ),
     )))]
     #[cfg_attr(portable_atomic_no_cfg_target_has_atomic, cfg(portable_atomic_no_atomic_64))]
     #[cfg_attr(not(portable_atomic_no_cfg_target_has_atomic), cfg(not(target_has_atomic = "64")))]
@@ -405,11 +471,11 @@ items! {
             any(
                 target_feature = "experimental-zacas",
                 portable_atomic_target_feature = "experimental-zacas",
-                // TODO(riscv64)
+                // TODO(riscv)
                 // all(
                 //     feature = "fallback",
                 //     not(portable_atomic_no_outline_atomics),
-                //     any(test, portable_atomic_outline_atomics), // TODO(riscv64): currently disabled by default
+                //     any(test, portable_atomic_outline_atomics), // TODO(riscv): currently disabled by default
                 //     any(
                 //         all(
                 //             target_os = "linux",
@@ -477,6 +543,37 @@ items! {
 #[cfg_attr(portable_atomic_no_cfg_target_has_atomic, cfg(portable_atomic_no_atomic_64))]
 #[cfg_attr(not(portable_atomic_no_cfg_target_has_atomic), cfg(not(target_has_atomic = "64")))]
 pub(crate) use self::arm_linux::{AtomicI64, AtomicU64};
+#[cfg(all(
+    target_arch = "riscv32",
+    not(any(miri, portable_atomic_sanitize_thread)),
+    not(portable_atomic_no_asm),
+    any(
+        target_feature = "experimental-zacas",
+        portable_atomic_target_feature = "experimental-zacas",
+        // TODO(riscv)
+        // all(
+        //     feature = "fallback",
+        //     not(portable_atomic_no_outline_atomics),
+        //     any(test, portable_atomic_outline_atomics), // TODO(riscv): currently disabled by default
+        //     any(
+        //         all(
+        //             target_os = "linux",
+        //             any(
+        //                 target_env = "gnu",
+        //                 all(
+        //                     any(target_env = "musl", target_env = "ohos"),
+        //                     not(target_feature = "crt-static"),
+        //                 ),
+        //                 portable_atomic_outline_atomics,
+        //             ),
+        //         ),
+        //         target_os = "android",
+        //     ),
+        //     not(any(miri, portable_atomic_sanitize_thread)),
+        // ),
+    ),
+))]
+pub(crate) use self::riscv32::{AtomicI64, AtomicU64};
 
 // 128-bit atomics (platform-specific)
 // AArch64
@@ -508,11 +605,11 @@ pub(crate) use self::x86_64::{AtomicI128, AtomicU128};
     any(
         target_feature = "experimental-zacas",
         portable_atomic_target_feature = "experimental-zacas",
-        // TODO(riscv64)
+        // TODO(riscv)
         // all(
         //     feature = "fallback",
         //     not(portable_atomic_no_outline_atomics),
-        //     any(test, portable_atomic_outline_atomics), // TODO(riscv64): currently disabled by default
+        //     any(test, portable_atomic_outline_atomics), // TODO(riscv): currently disabled by default
         //     any(
         //         all(
         //             target_os = "linux",

--- a/src/imp/riscv.rs
+++ b/src/imp/riscv.rs
@@ -26,6 +26,8 @@ Generated asm:
 - riscv32imac https://godbolt.org/z/aG9157dhW
 */
 
+// TODO: Zacas extension
+
 #[cfg(not(portable_atomic_no_asm))]
 use core::arch::asm;
 use core::{cell::UnsafeCell, sync::atomic::Ordering};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,14 +275,24 @@ RUSTFLAGS="--cfg portable_atomic_no_outline_atomics" cargo ...
 // fallback and causing memory ordering problems to be missed by these checkers.
 #![cfg_attr(
     all(
-        any(target_arch = "aarch64", target_arch = "powerpc64", target_arch = "s390x"),
+        any(
+            target_arch = "aarch64",
+            target_arch = "powerpc64",
+            target_arch = "riscv64",
+            target_arch = "s390x",
+        ),
         any(miri, portable_atomic_sanitize_thread),
     ),
     allow(internal_features)
 )]
 #![cfg_attr(
     all(
-        any(target_arch = "aarch64", target_arch = "powerpc64", target_arch = "s390x"),
+        any(
+            target_arch = "aarch64",
+            target_arch = "powerpc64",
+            target_arch = "riscv64",
+            target_arch = "s390x",
+        ),
         any(miri, portable_atomic_sanitize_thread),
     ),
     feature(core_intrinsics)

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -118,6 +118,14 @@ fn test_is_lock_free() {
             any(target_feature = "cmpxchg16b", portable_atomic_target_feature = "cmpxchg16b"),
         ),
         all(
+            target_arch = "riscv64",
+            not(portable_atomic_no_asm),
+            any(
+                target_feature = "experimental-zacas",
+                portable_atomic_target_feature = "experimental-zacas",
+            ),
+        ),
+        all(
             target_arch = "powerpc64",
             portable_atomic_unstable_asm_experimental_arch,
             any(

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -79,7 +79,23 @@ fn test_is_lock_free() {
     assert!(AtomicU32::is_lock_free());
     #[cfg(not(portable_atomic_no_cfg_target_has_atomic))]
     {
-        if cfg!(all(
+        if cfg!(any(
+            target_has_atomic = "64",
+            all(
+                target_arch = "riscv32",
+                not(any(miri, portable_atomic_sanitize_thread)),
+                not(portable_atomic_no_asm),
+                any(
+                    target_feature = "experimental-zacas",
+                    portable_atomic_target_feature = "experimental-zacas",
+                ),
+            ),
+        )) {
+            assert!(AtomicI64::is_always_lock_free());
+            assert!(AtomicI64::is_lock_free());
+            assert!(AtomicU64::is_always_lock_free());
+            assert!(AtomicU64::is_lock_free());
+        } else if cfg!(all(
             feature = "fallback",
             target_arch = "arm",
             not(any(miri, portable_atomic_sanitize_thread)),
@@ -93,11 +109,6 @@ fn test_is_lock_free() {
             assert!(!AtomicI64::is_always_lock_free());
             assert!(AtomicI64::is_lock_free());
             assert!(!AtomicU64::is_always_lock_free());
-            assert!(AtomicU64::is_lock_free());
-        } else if cfg!(target_has_atomic = "64") {
-            assert!(AtomicI64::is_always_lock_free());
-            assert!(AtomicI64::is_lock_free());
-            assert!(AtomicU64::is_always_lock_free());
             assert!(AtomicU64::is_lock_free());
         } else {
             assert!(!AtomicI64::is_always_lock_free());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -344,6 +344,7 @@ pub(crate) fn zero_extend64_ptr(v: *mut ()) -> core::mem::MaybeUninit<u64> {
 #[cfg(any(
     target_arch = "aarch64",
     target_arch = "powerpc64",
+    target_arch = "riscv64",
     target_arch = "s390x",
     target_arch = "x86_64",
 ))]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -359,7 +359,7 @@ pub(crate) union U128 {
     pub(crate) pair: Pair<u64>,
 }
 #[allow(dead_code)]
-#[cfg(target_arch = "arm")]
+#[cfg(any(target_arch = "arm", target_arch = "riscv32"))]
 /// A 64-bit value represented as a pair of 32-bit values.
 ///
 /// This type is `#[repr(C)]`, both fields have the same in-memory representation

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -587,6 +587,17 @@ build() {
                 RUSTFLAGS="${target_rustflags} -C target-cpu=pwr7" \
                 x_cargo "${args[@]}" "$@"
             ;;
+        riscv64*)
+            case "${target}" in
+                # TODO(riscv64): support CAS in riscv.rs when zacas enabled
+                riscv??i-* | riscv??im-* | riscv??imc-*) ;;
+                *)
+                    CARGO_TARGET_DIR="${target_dir}/zacas" \
+                        RUSTFLAGS="${target_rustflags} -C target-feature=+experimental-zacas" \
+                        x_cargo "${args[@]}" "$@"
+                    ;;
+            esac
+            ;;
         s390x*)
             CARGO_TARGET_DIR="${target_dir}/z196" \
                 RUSTFLAGS="${target_rustflags} -C target-cpu=z196" \

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -587,9 +587,9 @@ build() {
                 RUSTFLAGS="${target_rustflags} -C target-cpu=pwr7" \
                 x_cargo "${args[@]}" "$@"
             ;;
-        riscv64*)
+        riscv*)
             case "${target}" in
-                # TODO(riscv64): support CAS in riscv.rs when zacas enabled
+                # TODO(riscv): support CAS in riscv.rs when zacas enabled
                 riscv??i-* | riscv??im-* | riscv??imc-*) ;;
                 *)
                     CARGO_TARGET_DIR="${target_dir}/zacas" \


### PR DESCRIPTION
This supports 128-bit atomics for riscv64 and 64-bit atomics for riscv32 with [Zacas extension](https://github.com/riscv/riscv-isa-manual/blob/riscv-isa-release-8b9dc50-2024-08-30/src/zacas.adoc) (ratified more than half a year ago) enabled.

Note:
- Currently Zacas extension support is marked as experimental in LLVM: so `-C target-feature=+experimental-zacas` instead of `-C target-feature=+zacas` is needed for now.
  - As the name indicates, support for this extension on our part at this time will also be somewhat experimental.
  - ~~Perhaps we cannot merge this PR until LLVM marks this as non-experimental.~~
    - Now marked as experimental on our end too. And now only enabled for LLVM 19 because it is more experimental in LLVM 17/18 and "experimental-zacas" feature may no longer exist when it is marked as non-experimental in LLVM 20.
- The core part of runtime CPU feature detection has already been implemented for Linux/Android and tested for Linux on QEMU, but is test-only until zacas is marked as non-experimental by LLVM.
- Zacas extension provides DWCAS, but there is no DW load/store instruction in the ratified atomic-related extensions AFAIK, so a load/store implementation at this time would not be very efficient.

FYI @ibraheemdev