### PR TITLE
aarch64: Enable run-time detection of FEAT_LRCPC3/FEAT_LSE128 in load/store

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -67,6 +67,8 @@ ldiapp
 ldsetp
 ldxp
 lghi
+libatomic
+libatomic's
 libcalls
 libelf
 libfdio

--- a/src/imp/atomic128/README.md
+++ b/src/imp/atomic128/README.md
@@ -7,7 +7,7 @@ Here is the table of targets that support 128-bit atomics and the instructions u
 | target_arch | load | store | CAS | RMW | note |
 | ----------- | ---- | ----- | --- | --- | ---- |
 | x86_64 | cmpxchg16b or vmovdqa | cmpxchg16b or vmovdqa | cmpxchg16b | cmpxchg16b | cmpxchg16b target feature required. vmovdqa requires Intel, AMD, or Zhaoxin CPU with AVX. <br> Both compile-time and run-time detection are supported for cmpxchg16b. vmovdqa is currently run-time detection only. <br> Requires rustc 1.59+ |
-| aarch64 | ldxp/stxp or casp or ldp/ldiapp | ldxp/stxp or casp or stp/stilp/swpp | ldxp/stxp or casp | ldxp/stxp or casp/swpp/ldclrp/ldsetp | casp requires lse target feature, ldp/stp requires lse2 target feature, ldiapp/stilp requires lse2 and rcpc3 target features, swpp/ldclrp/ldsetp requires lse128 target feature. <br> Both compile-time and run-time detection are supported for lse and lse2. Others are currently compile-time detection only. <br> Requires rustc 1.59+ |
+| aarch64 | ldxp/stxp or casp or ldp/ldiapp | ldxp/stxp or casp or stp/stilp/swpp | ldxp/stxp or casp | ldxp/stxp or casp/swpp/ldclrp/ldsetp | casp requires lse target feature, ldp/stp requires lse2 target feature, ldiapp/stilp requires lse2 and rcpc3 target features, swpp/ldclrp/ldsetp requires lse128 target feature. <br> Both compile-time and run-time detection are supported. <br> Requires rustc 1.59+ |
 | powerpc64 | lq | stq | lqarx/stqcx. | lqarx/stqcx. | Requires target-cpu pwr8+ (powerpc64le is pwr8 by default). Both compile-time and run-time detection are supported (run-time detection is currently disabled by default). <br> Requires nightly |
 | s390x | lpq | stpq | cdsg | cdsg | Requires nightly |
 

--- a/src/imp/atomic128/detect/aarch64_macos.rs
+++ b/src/imp/atomic128/detect/aarch64_macos.rs
@@ -7,7 +7,7 @@
 //
 // If macOS supporting FEAT_LSE128/FEAT_LRCPC3 becomes popular in the future, this module will
 // be used to support outline-atomics for FEAT_LSE128/FEAT_LRCPC3.
-// M4 is armv9.4-a but I don't know if it supports FEAT_LSE128/FEAT_LRCPC3.
+// M4 is armv9.2-a and it doesn't support FEAT_LSE128/FEAT_LRCPC3.
 //
 // Refs: https://developer.apple.com/documentation/kernel/1387446-sysctlbyname/determining_instruction_set_characteristics
 //
@@ -83,17 +83,13 @@ fn _detect(info: &mut CpuInfo) {
     if unsafe { sysctlbyname32(b"hw.optional.arm.FEAT_LSE2\0").unwrap_or(0) != 0 } {
         info.set(CpuInfo::HAS_LSE2);
     }
-    // we currently only use FEAT_LSE and FEAT_LSE2 in outline-atomics.
-    #[cfg(test)]
-    {
-        // SAFETY: we passed a valid C string.
-        if unsafe { sysctlbyname32(b"hw.optional.arm.FEAT_LSE128\0").unwrap_or(0) != 0 } {
-            info.set(CpuInfo::HAS_LSE128);
-        }
-        // SAFETY: we passed a valid C string.
-        if unsafe { sysctlbyname32(b"hw.optional.arm.FEAT_LRCPC3\0").unwrap_or(0) != 0 } {
-            info.set(CpuInfo::HAS_RCPC3);
-        }
+    // SAFETY: we passed a valid C string.
+    if unsafe { sysctlbyname32(b"hw.optional.arm.FEAT_LSE128\0").unwrap_or(0) != 0 } {
+        info.set(CpuInfo::HAS_LSE128);
+    }
+    // SAFETY: we passed a valid C string.
+    if unsafe { sysctlbyname32(b"hw.optional.arm.FEAT_LRCPC3\0").unwrap_or(0) != 0 } {
+        info.set(CpuInfo::HAS_RCPC3);
     }
 }
 

--- a/src/imp/atomic128/detect/auxv.rs
+++ b/src/imp/atomic128/detect/auxv.rs
@@ -102,7 +102,11 @@ mod os {
         // https://github.com/torvalds/linux/blob/v6.10/include/uapi/linux/auxvec.h
         #[cfg(any(test, target_arch = "aarch64"))]
         pub(crate) const AT_HWCAP: c_ulong = 16;
-        #[cfg(any(test, target_arch = "powerpc64"))]
+        #[cfg(any(
+            test,
+            all(target_arch = "aarch64", target_pointer_width = "64"),
+            target_arch = "powerpc64",
+        ))]
         pub(crate) const AT_HWCAP2: c_ulong = 26;
 
         // Defined in sys/system_properties.h.
@@ -227,11 +231,9 @@ mod arch {
     pub(super) const HWCAP_USCAT: ffi::c_ulong = 1 << 25;
     #[cfg(any(target_os = "linux", target_os = "android"))]
     #[cfg(target_pointer_width = "64")]
-    #[cfg(test)]
     pub(super) const HWCAP2_LRCPC3: ffi::c_ulong = 1 << 46;
     #[cfg(any(target_os = "linux", target_os = "android"))]
     #[cfg(target_pointer_width = "64")]
-    #[cfg(test)]
     pub(super) const HWCAP2_LSE128: ffi::c_ulong = 1 << 47;
 
     #[cold]
@@ -246,7 +248,6 @@ mod arch {
         }
         #[cfg(any(target_os = "linux", target_os = "android"))]
         #[cfg(target_pointer_width = "64")]
-        #[cfg(test)]
         {
             let hwcap2 = os::getauxval(ffi::AT_HWCAP2);
             if hwcap2 & HWCAP2_LRCPC3 != 0 {

--- a/src/imp/atomic128/detect/common.rs
+++ b/src/imp/atomic128/detect/common.rs
@@ -51,11 +51,9 @@ impl CpuInfo {
     const HAS_LSE: u32 = 1; // FEAT_LSE
     #[cfg_attr(not(test), allow(dead_code))]
     const HAS_LSE2: u32 = 2; // FEAT_LSE2
-    #[cfg(test)]
-    // This is currently only used in tests.
+    #[cfg_attr(not(test), allow(dead_code))]
     const HAS_LSE128: u32 = 3; // FEAT_LSE128
-    #[cfg(test)]
-    // This is currently only used in tests.
+    #[cfg_attr(not(test), allow(dead_code))]
     const HAS_RCPC3: u32 = 4; // FEAT_LRCPC3
 
     #[cfg(any(test, not(any(target_feature = "lse", portable_atomic_target_feature = "lse"))))]
@@ -69,12 +67,17 @@ impl CpuInfo {
     pub(crate) fn has_lse2(self) -> bool {
         self.test(CpuInfo::HAS_LSE2)
     }
-    #[cfg(test)]
+    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(any(
+        test,
+        not(any(target_feature = "lse128", portable_atomic_target_feature = "lse128")),
+    ))]
     #[inline]
     pub(crate) fn has_lse128(self) -> bool {
         self.test(CpuInfo::HAS_LSE128)
     }
-    #[cfg(test)]
+    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(any(test, not(any(target_feature = "rcpc3", portable_atomic_target_feature = "rcpc3"))))]
     #[inline]
     pub(crate) fn has_rcpc3(self) -> bool {
         self.test(CpuInfo::HAS_RCPC3)


### PR DESCRIPTION
- (new) If FEAT_LSE2 is not available at compile-time, we want to do run-time detection of FEAT_LSE2 (we are already doing this as it greatly improves performance: https://github.com/taiki-e/portable-atomic/pull/126), so we do run-time detection of FEAT_LRCPC3/FEAT_LSE128 at the same time.
- (as-is) If FEAT_LSE2 is available at compile-time, we don't do run-time detection of FEAT_LRCPC3/FEAT_LSE128 *for load/store* at this time, since FEAT_LRCPC3/FEAT_LSE128 is not yet available for most CPUs.
   (macOS that doesn't have any FEAT_LRCPC3/FEAT_LSE128-enabled CPUs as of M4 is only a platform that currently enables FEAT_LSE2 at compile-time by default.)
- (as-is) We don't do run-time detection of FEAT_LSE128 *for swap/fetch_and/fetch_or* at this time, because FEAT_LSE128 is not yet available for most CPUs, but since swpp/ldclrp/ldsetp is wait-free, it would make sense to do run-time detection in the future.


Also this documents the exact instruction selection per operation as comments.

Run-time detection of these features is usually supported on platforms that support run-time detection of FEAT_LSE2 and was implemented in this crate as a test-only implementation over 1 years ago (.e.g., https://github.com/taiki-e/portable-atomic/commit/f5daf34a4e7a71c6c0bd741e09eec9409147dd43, https://github.com/taiki-e/portable-atomic/commit/e12b4bd79edea40f58433856893f7449f59a1f8e)