### PR TITLE
aarch64: Support FEAT_LRCPC3/FEAT_LSE128 with pre-16 LLVM

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -64,8 +64,14 @@ kuser
 ldar
 ldaxp
 ldclrp
+ldclrpa
+ldclrpal
+ldclrpl
 ldiapp
 ldsetp
+ldsetpa
+ldsetpal
+ldsetpl
 ldxp
 lghi
 libatomic
@@ -149,6 +155,9 @@ subfe
 subfic
 subfze
 swpp
+swppa
+swppal
+swppl
 syscall
 sysctlbyname
 sysctlnode

--- a/build.rs
+++ b/build.rs
@@ -235,13 +235,8 @@ fn main() {
                 let is_macos = target_os == "macos";
                 let mut has_lse = is_macos;
                 target_feature_fallback("lse2", is_macos);
-                // LLVM supports FEAT_LRCPC3 and FEAT_LSE128 on LLVM 16+:
-                // https://github.com/llvm/llvm-project/commit/a6aaa969f7caec58a994142f8d855861cf3a1463
-                // https://github.com/llvm/llvm-project/commit/7fea6f2e0e606e5339c3359568f680eaf64aa306
-                if version.llvm >= 16 {
-                    has_lse |= target_feature_fallback("lse128", false);
-                    target_feature_fallback("rcpc3", false);
-                }
+                has_lse |= target_feature_fallback("lse128", false);
+                target_feature_fallback("rcpc3", false);
                 // aarch64_target_feature stabilized in Rust 1.61.
                 if needs_target_feature_fallback(&version, Some(61)) {
                     target_feature_fallback("lse", has_lse);

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -564,19 +564,16 @@ build() {
                         x_cargo "${args[@]}" "$@"
                     ;;
             esac
-            # Support for FEAT_LRCPC3 and FEAT_LSE128 requires LLVM 16+.
-            if [[ "${llvm_version}" -ge 16 ]]; then
-                CARGO_TARGET_DIR="${target_dir}/rcpc3" \
-                    RUSTFLAGS="${target_rustflags} -C target-feature=+lse,+lse2,+rcpc3" \
-                    x_cargo "${args[@]}" "$@"
-                # FEAT_LSE128 implies FEAT_LSE but not FEAT_LSE2.
-                CARGO_TARGET_DIR="${target_dir}/lse128" \
-                    RUSTFLAGS="${target_rustflags} -C target-feature=+lse2,+lse128" \
-                    x_cargo "${args[@]}" "$@"
-                CARGO_TARGET_DIR="${target_dir}/lse128-rcpc3" \
-                    RUSTFLAGS="${target_rustflags} -C target-feature=+lse2,+lse128,+rcpc3" \
-                    x_cargo "${args[@]}" "$@"
-            fi
+            CARGO_TARGET_DIR="${target_dir}/rcpc3" \
+                RUSTFLAGS="${target_rustflags} -C target-feature=+lse,+lse2,+rcpc3" \
+                x_cargo "${args[@]}" "$@"
+            # FEAT_LSE128 implies FEAT_LSE but not FEAT_LSE2.
+            CARGO_TARGET_DIR="${target_dir}/lse128" \
+                RUSTFLAGS="${target_rustflags} -C target-feature=+lse2,+lse128" \
+                x_cargo "${args[@]}" "$@"
+            CARGO_TARGET_DIR="${target_dir}/lse128-rcpc3" \
+                RUSTFLAGS="${target_rustflags} -C target-feature=+lse2,+lse128,+rcpc3" \
+                x_cargo "${args[@]}" "$@"
             ;;
         powerpc64-*)
             # powerpc64le- (little-endian) is skipped because it is pwr8 by default


### PR DESCRIPTION
LLVM supports FEAT_LRCPC3/FEAT_LSE128 instructions on LLVM 16+, so use .inst directive on old LLVM. https://github.com/llvm/llvm-project/commit/a6aaa969f7caec58a994142f8d855861cf3a1463 https://github.com/llvm/llvm-project/commit/7fea6f2e0e606e5339c3359568f680eaf64aa306

AAarch64 .inst directive is portable since LLVM 7: https://github.com/llvm/llvm-project/commit/3e3d39d07ea8bc210dfb256edc0ac5c66fb84474