### PR TITLE
riscv: Support RMW when zaamo enabled (even when unsafe-assume-single-core disabled)

### DIFF
--- a/src/cfgs.rs
+++ b/src/cfgs.rs
@@ -496,6 +496,17 @@ mod atomic_cas_macros {
     macro_rules! cfg_no_atomic_cas {
         ($($tt:tt)*) => {};
     }
+    // private
+    macro_rules! cfg_has_atomic_cas_or_amo32 {
+        ($($tt:tt)*) => {
+            $($tt)*
+        };
+    }
+    macro_rules! cfg_has_atomic_cas_or_amo8 {
+        ($($tt:tt)*) => {
+            $($tt)*
+        };
+    }
 }
 #[cfg_attr(
     portable_atomic_no_cfg_target_has_atomic,
@@ -528,6 +539,73 @@ mod atomic_cas_macros {
         ($($tt:tt)*) => {
             $($tt)*
         };
+    }
+    // private
+    #[cfg_attr(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        cfg(not(any(target_feature = "zaamo", portable_atomic_target_feature = "zaamo")))
+    )]
+    macro_rules! cfg_has_atomic_cas_or_amo32 {
+        ($($tt:tt)*) => {};
+    }
+    #[cfg_attr(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        cfg(not(any(target_feature = "zaamo", portable_atomic_target_feature = "zaamo")))
+    )]
+    macro_rules! cfg_no_atomic_cas_or_amo32 {
+        ($($tt:tt)*) => {
+            $($tt)*
+        };
+    }
+    #[cfg(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        any(target_feature = "zaamo", portable_atomic_target_feature = "zaamo"),
+    ))]
+    macro_rules! cfg_has_atomic_cas_or_amo32 {
+        ($($tt:tt)*) => {
+            $($tt)*
+        };
+    }
+    #[cfg(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        any(target_feature = "zaamo", portable_atomic_target_feature = "zaamo"),
+    ))]
+    macro_rules! cfg_no_atomic_cas_or_amo32 {
+        ($($tt:tt)*) => {};
+    }
+    #[cfg_attr(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        cfg(not(any(target_feature = "zabha", portable_atomic_target_feature = "zabha")))
+    )]
+    #[cfg_attr(target_arch = "bpf", allow(unused_macros))]
+    macro_rules! cfg_has_atomic_cas_or_amo8 {
+        ($($tt:tt)*) => {};
+    }
+    #[cfg_attr(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        cfg(not(any(target_feature = "zabha", portable_atomic_target_feature = "zabha")))
+    )]
+    #[cfg_attr(target_arch = "bpf", allow(unused_macros))]
+    macro_rules! cfg_no_atomic_cas_or_amo8 {
+        ($($tt:tt)*) => {
+            $($tt)*
+        };
+    }
+    #[cfg(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        any(target_feature = "zabha", portable_atomic_target_feature = "zabha"),
+    ))]
+    macro_rules! cfg_has_atomic_cas_or_amo8 {
+        ($($tt:tt)*) => {
+            $($tt)*
+        };
+    }
+    #[cfg(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        any(target_feature = "zabha", portable_atomic_target_feature = "zabha"),
+    ))]
+    macro_rules! cfg_no_atomic_cas_or_amo8 {
+        ($($tt:tt)*) => {};
     }
 }
 

--- a/src/imp/float.rs
+++ b/src/imp/float.rs
@@ -90,7 +90,7 @@ macro_rules! atomic_float {
             }
         }
 
-        cfg_has_atomic_cas! {
+        cfg_has_atomic_cas_or_amo32! {
         impl $atomic_type {
             #[inline]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
@@ -98,6 +98,7 @@ macro_rules! atomic_float {
                 $float_type::from_bits(self.as_bits().swap(val.to_bits(), order))
             }
 
+            cfg_has_atomic_cas! {
             #[inline]
             #[cfg_attr(
                 any(all(debug_assertions, not(portable_atomic_no_track_caller)), miri),
@@ -185,7 +186,7 @@ macro_rules! atomic_float {
             pub(crate) fn fetch_min(&self, val: $float_type, order: Ordering) -> $float_type {
                 self.fetch_update_(order, |x| x.min(val))
             }
-
+            } // cfg_has_atomic_cas!
             #[inline]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
             pub(crate) fn fetch_neg(&self, order: Ordering) -> $float_type {
@@ -200,7 +201,7 @@ macro_rules! atomic_float {
                 $float_type::from_bits(self.as_bits().fetch_and(ABS_MASK, order))
             }
         }
-        } // cfg_has_atomic_cas!
+        } // cfg_has_atomic_cas_or_amo32!
     };
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -190,7 +190,7 @@ macro_rules! impl_default_no_fetch_ops {
             }
         }
     };
-    ($atomic_type:ident, $int_type:ident) => {
+    ($atomic_type:ident, $int_type:ty) => {
         impl $atomic_type {
             #[inline]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
@@ -221,7 +221,7 @@ macro_rules! impl_default_no_fetch_ops {
     };
 }
 macro_rules! impl_default_bit_opts {
-    ($atomic_type:ident, $int_type:ident) => {
+    ($atomic_type:ident, $int_type:ty) => {
         impl $atomic_type {
             #[inline]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -487,11 +487,17 @@ build() {
                                         CARGO_TARGET_DIR="${target_dir}/assume-single-core-zaamo" \
                                             RUSTFLAGS="${target_rustflags} --cfg portable_atomic_unsafe_assume_single_core -C target-feature=+zaamo" \
                                             x_cargo "${args[@]}" --exclude-features "critical-section" "$@"
+                                        CARGO_TARGET_DIR="${target_dir}/zaamo" \
+                                            RUSTFLAGS="${target_rustflags} -C target-feature=+zaamo" \
+                                            x_cargo "${args[@]}" --exclude-features "critical-section,require-cas" --exclude portable-atomic-util "$@"
                                         # Support for Zabha extension requires LLVM 19+.
                                         if [[ "${llvm_version}" -ge 19 ]]; then
                                             CARGO_TARGET_DIR="${target_dir}/assume-single-core-zabha" \
                                                 RUSTFLAGS="${target_rustflags} --cfg portable_atomic_unsafe_assume_single_core -C target-feature=+zaamo,+zabha" \
                                                 x_cargo "${args[@]}" --exclude-features "critical-section" "$@"
+                                            CARGO_TARGET_DIR="${target_dir}/zabha" \
+                                                RUSTFLAGS="${target_rustflags} -C target-feature=+zaamo,+zabha" \
+                                                x_cargo "${args[@]}" --exclude-features "critical-section,require-cas" --exclude portable-atomic-util "$@"
                                         fi
                                     fi
                                     ;;


### PR DESCRIPTION
Addresses https://github.com/taiki-e/portable-atomic/issues/123#issuecomment-2369371683

cc @romancardenas