### PR TITLE
tests: Test MSP430 using mspdebug

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -73,6 +73,7 @@ ldiapp
 ldrexd
 ldsetp
 ldxp
+lgcc
 lghi
 libatomic
 libatomic's
@@ -83,6 +84,7 @@ libstd
 libtcl
 libtest
 linkall
+lmul
 locgr
 locgre
 lqarx
@@ -91,6 +93,7 @@ lwsync
 machdep
 MAXNAME
 maxu
+mcpu
 mfcr
 mfence
 mgba
@@ -101,6 +104,7 @@ mmfr
 movlps
 movq
 mpidr
+mspdebug
 mstatus
 mvfr
 negs
@@ -132,6 +136,7 @@ sete
 sifive
 signedness
 simavr
+simio
 skiboot
 slbgr
 slgr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,10 +577,12 @@ jobs:
             "$@"
           }
           retry sudo apt-get -o Acquire::Retries=10 -qq update
+          # TODO: only install Armv4TE/AVR/MSP430-specific packages for nightly toolchains
           retry sudo apt-get -o Acquire::Retries=10 -o Dpkg::Use-Pty=0 install -y --no-install-recommends \
             avr-libc \
             gcc-avr \
             libelf-dev \
+            mspdebug \
             qemu-system-arm \
             qemu-system-misc \
             simavr
@@ -591,6 +593,10 @@ jobs:
           sudo mv -- "opensbi-${OPENSBI_VERSION}-rv-bin/share/opensbi/ilp32/generic/firmware/fw_dynamic.bin" /usr/share/qemu/opensbi-riscv32-generic-fw_dynamic.bin
           sudo mv -- "opensbi-${OPENSBI_VERSION}-rv-bin/share/opensbi/ilp32/generic/firmware/fw_dynamic.elf" /usr/share/qemu/opensbi-riscv32-generic-fw_dynamic.elf
           rm -rf -- "opensbi-${OPENSBI_VERSION}-rv-bin"
+          mkdir -p -- "${HOME}"/msp430-gcc
+          retry curl --proto '=https' --tlsv1.2 -fsSL --retry 10 --retry-connrefused https://dr-download.ti.com/software-development/ide-configuration-compiler-or-debugger/MD-LlCjWuAbzH/9.3.1.2/msp430-gcc-9.3.1.11_linux64.tar.bz2 \
+            | tar xjf - --strip-components 1 -C "${HOME}"/msp430-gcc
+          printf '%s\n' "${HOME}"/msp430-gcc/bin >>"${GITHUB_PATH}"
       - uses: taiki-e/github-actions/install-rust@main
         with:
           toolchain: ${{ matrix.rust }}

--- a/tests/msp430/.cargo/config.toml
+++ b/tests/msp430/.cargo/config.toml
@@ -1,0 +1,6 @@
+[build]
+target-dir = "../../target"
+
+[target.'cfg(all(target_arch = "msp430", target_os = "none"))']
+# Not in PATH (handled in tools/no-std.sh).
+# runner = "mspdebug-test-runner.sh"

--- a/tests/msp430/Cargo.toml
+++ b/tests/msp430/Cargo.toml
@@ -1,0 +1,59 @@
+[package]
+name = "msp430-test"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[features]
+default = ["bool", "ptr", "isize", "usize", "i8", "u8"]
+# NB: Sync feature list with tools/no-std.sh
+bool = []
+ptr = []
+isize = []
+usize = []
+i8 = []
+u8 = []
+i16 = []
+u16 = []
+i32 = []
+u32 = []
+i64 = []
+u64 = []
+i128 = []
+u128 = []
+f32 = ["portable-atomic/float"]
+f64 = ["portable-atomic/float"]
+
+[dependencies]
+portable-atomic = { path = "../.." }
+
+msp430-rt = "0.4"
+msp430f5529 = { git = "https://github.com/cr1901/msp430f5529", rev = "23946ef9bb0365caabd2c30ad14c2c9ab2d425c7", features = ["rt"] }
+paste = "1"
+ufmt = "0.2"
+
+[workspace]
+resolver = "2"
+
+[lints.rust]
+rust_2018_idioms = "warn"
+single_use_lifetimes = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(target_arch,values("xtensa"))',
+    'cfg(qemu)',
+] }
+# unsafe_op_in_unsafe_fn = "warn" # Set at crate-level instead since https://github.com/rust-lang/rust/pull/100081 is not available on MSRV
+[lints.clippy]
+lint_groups_priority = { level = "allow", priority = 1 } # https://github.com/rust-lang/rust-clippy/issues/12920
+
+[profile.dev]
+codegen-units = 1
+lto = true
+opt-level = "s"
+panic = "abort"
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "s"
+panic = "abort"

--- a/tests/msp430/build.rs
+++ b/tests/msp430/build.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=memory.x");
+}

--- a/tests/msp430/memory.x
+++ b/tests/msp430/memory.x
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: Apache-2.0 OR MIT */
+/* Adapted from https://github.com/cr1901/msp430f5529-quickstart/blob/7de729ece0aeb37d9462ac832d3aa5f6686bbbc5/memory.x. */
+
+MEMORY
+{
+  /* These values are correct for the msp430f5529 device. You will need to
+     modify these values if using a different device. Room must be reserved
+     for interrupt vectors plus reset vector and the end of the first 64kB
+     of address space. */
+  RAM : ORIGIN = 0x2200, LENGTH = 0x2000
+  ROM : ORIGIN = 0x4400, LENGTH = 0xBB80
+  VECTORS : ORIGIN = 0xFF80, LENGTH = 0x80
+}
+
+/* Stack begins at the end of RAM:
+   _stack_start = ORIGIN(RAM) + LENGTH(RAM); */
+
+/* TODO: Code (and data?) above 64kB mark, which is supported even without
+   using MSP430X mode. */

--- a/tests/msp430/src/main.rs
+++ b/tests/msp430/src/main.rs
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#![no_main]
+#![no_std]
+#![warn(unsafe_op_in_unsafe_fn)]
+
+#[macro_use]
+#[path = "../../api-test/src/helper.rs"]
+mod helper;
+
+use msp430f5529 as _;
+use portable_atomic::*;
+
+macro_rules! print {
+    ($($tt:tt)*) => {
+        let _ = ufmt::uwrite!(simio::Console, $($tt)*);
+    };
+}
+macro_rules! println {
+    ($($tt:tt)*) => {
+        let _ = ufmt::uwriteln!(simio::Console, $($tt)*);
+    };
+}
+
+#[msp430_rt::entry]
+fn main() -> ! {
+    #[allow(unused_macros)]
+    macro_rules! test_atomic_int {
+        ($int_type:ident) => {
+            paste::paste! {
+                fn [<test_atomic_ $int_type>]() {
+                    __test_atomic_int!([<Atomic $int_type:camel>], $int_type);
+                }
+                print!("{}", concat!("test test_atomic_", stringify!($int_type), " ... "));
+                [<test_atomic_ $int_type>]();
+                println!("ok");
+            }
+        };
+    }
+    #[allow(unused_macros)]
+    macro_rules! test_atomic_float {
+        ($float_type:ident) => {
+            paste::paste! {
+                fn [<test_atomic_ $float_type>]() {
+                    __test_atomic_float!([<Atomic $float_type:camel>], $float_type);
+                }
+                print!("{}", concat!("test test_atomic_", stringify!($float_type), " ... "));
+                [<test_atomic_ $float_type>]();
+                println!("ok");
+            }
+        };
+    }
+    #[cfg(feature = "bool")]
+    macro_rules! test_atomic_bool {
+        () => {
+            fn test_atomic_bool() {
+                __test_atomic_bool!(AtomicBool);
+            }
+            print!("test test_atomic_bool ... ");
+            test_atomic_bool();
+            println!("ok");
+        };
+    }
+    #[cfg(feature = "ptr")]
+    macro_rules! test_atomic_ptr {
+        () => {
+            fn test_atomic_ptr() {
+                __test_atomic_ptr!(AtomicPtr<u8>);
+            }
+            print!("test test_atomic_ptr ... ");
+            test_atomic_ptr();
+            println!("ok");
+        };
+    }
+
+    println!("starting tests...");
+
+    #[cfg(not(any(
+        feature = "bool",
+        feature = "ptr",
+        feature = "isize",
+        feature = "usize",
+        feature = "i8",
+        feature = "u8",
+        feature = "i16",
+        feature = "u16",
+        feature = "i32",
+        feature = "u32",
+        feature = "i64",
+        feature = "u64",
+        feature = "i128",
+        feature = "u128",
+        feature = "f32",
+        feature = "f64",
+    )))]
+    {
+        // misc
+        for order in helper::FENCE_ORDERINGS {
+            fence(order);
+            compiler_fence(order);
+        }
+        hint::spin_loop();
+    }
+    #[cfg(feature = "bool")]
+    test_atomic_bool!();
+    #[cfg(feature = "ptr")]
+    test_atomic_ptr!();
+    #[cfg(feature = "isize")]
+    test_atomic_int!(isize);
+    #[cfg(feature = "usize")]
+    test_atomic_int!(usize);
+    #[cfg(feature = "i8")]
+    test_atomic_int!(i8);
+    #[cfg(feature = "u8")]
+    test_atomic_int!(u8);
+    #[cfg(feature = "i16")]
+    test_atomic_int!(i16);
+    #[cfg(feature = "u16")]
+    test_atomic_int!(u16);
+    #[cfg(feature = "i32")]
+    test_atomic_int!(i32);
+    #[cfg(feature = "u32")]
+    test_atomic_int!(u32);
+    #[cfg(feature = "i64")]
+    test_atomic_int!(i64);
+    #[cfg(feature = "u64")]
+    test_atomic_int!(u64);
+    #[cfg(feature = "i128")]
+    test_atomic_int!(i128);
+    #[cfg(feature = "u128")]
+    test_atomic_int!(u128);
+    #[cfg(feature = "f32")]
+    test_atomic_float!(f32);
+    #[cfg(feature = "f64")]
+    test_atomic_float!(f64);
+
+    println!("Tests finished successfully");
+
+    #[allow(clippy::empty_loop)] // this test crate is #![no_std]
+    loop {}
+}
+
+#[inline(never)]
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
+    macro_rules! println {
+        ($($tt:tt)*) => {
+            use core::fmt::Write as _;
+            let _ = writeln!(simio::Console, $($tt)*);
+        };
+    }
+
+    println!("{info}"); // this println takes a lot of spaces but better panic message is useful...
+    #[allow(clippy::empty_loop)] // this test crate is #![no_std]
+    loop {}
+}
+
+#[no_mangle]
+extern "C" fn abort() -> ! {
+    panic!()
+}
+
+mod simio {
+    use core::{convert::Infallible, fmt};
+
+    pub struct Console;
+    impl Console {
+        fn write_str(&mut self, s: &str) {
+            // https://github.com/dlbeer/mspdebug/blob/v0.25/simio/simio_console.c#L130
+            let addr = 0x00FF_usize as *mut u8;
+            for &b in s.as_bytes() {
+                unsafe { addr.write_volatile(b) }
+            }
+        }
+    }
+    impl ufmt::uWrite for Console {
+        type Error = Infallible;
+        fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
+            self.write_str(s);
+            Ok(())
+        }
+    }
+    impl fmt::Write for Console {
+        fn write_str(&mut self, s: &str) -> fmt::Result {
+            self.write_str(s);
+            Ok(())
+        }
+    }
+}

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -372,6 +372,8 @@ build() {
                     armv4t* | thumbv4t*) test_dir=tests/gba ;;
                     arm* | thumb* | riscv*) test_dir=tests/no-std-qemu ;;
                     avr-unknown-gnu-atmega2560) test_dir=tests/avr ;; # tests/avr is for atmega2560 not atmega328
+                    msp430*) test_dir=tests/msp430 ;;
+                    xtensa*) test_dir=tests/xtensa ;;
                 esac
                 if [[ -n "${test_dir}" ]]; then
                     RUSTFLAGS="${target_rustflags}" \

--- a/tools/mspdebug-test-runner.sh
+++ b/tools/mspdebug-test-runner.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+set -CeEuo pipefail
+IFS=$'\n\t'
+
+bin="$1"
+stdout='.mspdebug.stdout'
+
+rm -f -- ./"${stdout}"
+touch -- ./"${stdout}"
+
+tail -s0 -f "${stdout}" &
+tail_pid=$!
+
+mspdebug -n sim &>>"${stdout}" <<EOF &
+simio add console serial
+prog ${bin}
+run
+EOF
+mspdebug_pid=$!
+
+cleanup() {
+    kill "${mspdebug_pid}"
+    kill "${tail_pid}"
+    rm -- "${stdout}"
+    exit "${code}"
+}
+
+code=1
+trap -- 'printf >&2 "%s\n" "${0##*/}: trapped SIGINT"; cleanup' SIGINT
+
+# Inspired by mgba-test-runner.
+while true; do
+    if grep -Fq 'panicked' "${stdout}"; then
+        code=101
+        break
+    fi
+    if grep -Fq 'Tests finished successfully' "${stdout}"; then
+        code=0
+        break
+    fi
+    sleep 0.1
+done
+
+cleanup


### PR DESCRIPTION
Except for the fact that I [split the test into 10+ runs due to size (still not enough to run the float test)](https://github.com/taiki-e/portable-atomic/blob/03220a72980d7d77c66d5a291ca9724ff6da046e/tools/no-std.sh#L287-L292), and that I had to use a [runner helper](https://github.com/taiki-e/portable-atomic/blob/03220a72980d7d77c66d5a291ca9724ff6da046e/tools/mspdebug-test-runner.sh) like the ones used in armv4t, this is generally the same as the tests for the other targets and It is the same and can be run on CI.


```
(mspdebug) run
Running. Press Ctrl+C to interrupt...
starting tests...
test test_atomic_i8 ... ok
test test_atomic_u8 ... ok
Tests finished successfully
```

(There may be a way to handle the size issue better, but I have not had time to investigate it sufficiently.)

Closes #161
FYI @cr1901