### PR TITLE
add CI comments related to commented-out LLVM version entries in test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,8 @@ jobs:
         # - LLVM 16 : stable 1.76 - 1.78, since https://github.com/rust-lang/rust/pull/117947
         # - LLVM 17 : stable 1.79 - 1.82, since https://github.com/rust-lang/rust/pull/122649
         # - LLVM 18 : stable 1.83 -     , since https://github.com/rust-lang/rust/pull/130487
+        # NOTE that some commented-out LLVM version entries are kept here, which may be temporarily uncommented if
+        # needed to investigate possible issues that may arise between LLVM and code generated for certain targets.
         include:
           - rust: '1.56'
           - rust: nightly-2021-08-21 # Rust 1.56, LLVM 12


### PR DESCRIPTION
coming from this comment: https://github.com/taiki-e/portable-atomic/pull/195#discussion_r1837022080

> These are heavy to always be enabled, but they will be temporarily uncommented to see if they are affected by the LLVM bug if the code for this target is changed.

If we need some more info in these comments, I would appreciate any pointers to what LLVM issue(s) this is related to.