### PR TITLE
CI: pin libc in dev-dependencies for Rust pre-1.63

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
     ignore:
       # For test on old rustc.
       - dependency-name: crossbeam-utils
+      - dependency-name: libc
     labels: []
     groups:
       cargo:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ sptr = "0.3"
 static_assertions = "1"
 
 [target.'cfg(unix)'.dev-dependencies]
-libc = "0.2"
+libc = "=0.2.163" # newer libc requires Rust 1.63
 
 [target.'cfg(windows)'.dev-dependencies]
 windows-sys = { version = "0.59", features = [


### PR DESCRIPTION
Hope this will fix CI build in PR #196 etc.