### PR TITLE
CI: update label for test-bsd job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,7 +486,7 @@ jobs:
 
   test-bsd:
     needs: tidy
-    name: test (${{ matrix.target }}${{ matrix.version }})
+    name: BSD OS test (${{ matrix.target }}${{ matrix.version }})
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
rationale: I think it would be easier for a new developer looking into the CI to understand that this is a different job from the larger `test` job.

This is a TODO item I found while working on PR #195.