### PR TITLE
aarch64: Support FEAT_LSFE

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -69,6 +69,9 @@ lcgr
 ldar
 ldaxp
 ldclrp
+ldfadd
+ldfmaxnm
+ldfminnm
 ldiapp
 ldrexd
 ldsetp
@@ -182,6 +185,7 @@ versatilepb
 virt
 vmlinux
 vmovdqa
+vreg
 vtable
 vtables
 wfxt

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ See the [`atomic128` module's readme](https://github.com/taiki-e/portable-atomic
   - When unstable `--cfg portable_atomic_unstable_f128` is also enabled, `AtomicF128` for [unstable `f128`](https://github.com/rust-lang/rust/issues/116909) is also provided.
 
   Note:
-  - Most of `fetch_*` operations of atomic floats are implemented using CAS loops, which can be slower than equivalent operations of atomic integers. (AArch64 with FEAT_LSFE and GPU targets have atomic instructions for float, [so we plan to use these instructions for them in the future.](https://github.com/taiki-e/portable-atomic/issues/34))
+  - Atomic float's `fetch_{add,sub,min,max}` are usually implemented using CAS loops, which can be slower than equivalent operations of atomic integers. As an exception, AArch64 with FEAT_LSFE and GPU targets have atomic float instructions and we use them on AArch64 when `lsfe` target feature is available at compile-time. We [plan to use atomic float instructions for GPU targets as well in the future.](https://github.com/taiki-e/portable-atomic/issues/34))
   - Unstable cfgs are outside of the normal semver guarantees and minor or patch versions of portable-atomic may make breaking changes to them at any time.
 
 - **`std`**<br>

--- a/build.rs
+++ b/build.rs
@@ -48,7 +48,7 @@ fn main() {
 
     if version.minor >= 80 {
         println!(
-            r#"cargo:rustc-check-cfg=cfg(target_feature,values("fast-serialization","load-store-on-cond","distinct-ops","miscellaneous-extensions-3"))"#
+            r#"cargo:rustc-check-cfg=cfg(target_feature,values("lsfe","fast-serialization","load-store-on-cond","distinct-ops","miscellaneous-extensions-3"))"#
         );
 
         // Custom cfgs set by build script. Not public API.
@@ -59,7 +59,7 @@ fn main() {
         // TODO: handle multi-line target_feature_fallback
         // grep -F 'target_feature_fallback("' build.rs | grep -Ev '^ *//' | sed -E 's/^.*target_feature_fallback\(//; s/",.*$/"/' | LC_ALL=C sort -u | tr '\n' ',' | sed -E 's/,$/\n/'
         println!(
-            r#"cargo:rustc-check-cfg=cfg(portable_atomic_target_feature,values("cmpxchg16b","distinct-ops","fast-serialization","load-store-on-cond","lse","lse128","lse2","mclass","miscellaneous-extensions-3","quadword-atomics","rcpc3","v6","zaamo","zabha","zacas"))"#
+            r#"cargo:rustc-check-cfg=cfg(portable_atomic_target_feature,values("cmpxchg16b","distinct-ops","fast-serialization","load-store-on-cond","lse","lse128","lse2","lsfe","mclass","miscellaneous-extensions-3","quadword-atomics","rcpc3","v6","zaamo","zabha","zacas"))"#
         );
     }
 
@@ -286,6 +286,9 @@ fn main() {
                     target_feature_fallback("lse", lse);
                 }
             }
+            // As of rustc 1.85, target_feature "lsfe" is not available on rustc side:
+            // https://github.com/rust-lang/rust/blob/1.85.0/compiler/rustc_target/src/target_features.rs
+            target_feature_fallback("lsfe", false);
 
             // As of Apple M1/M1 Pro, on Apple hardware, CAS-loop-based RMW is much slower than
             // LL/SC-loop-based RMW: https://github.com/taiki-e/portable-atomic/pull/89

--- a/src/imp/atomic128/aarch64.rs
+++ b/src/imp/atomic128/aarch64.rs
@@ -434,10 +434,10 @@ macro_rules! atomic_rmw_inst {
     };
     ($op:ident, $order:ident, write = $write:ident) => {
         match $order {
-            Ordering::Relaxed => $op!("2", ""),
-            Ordering::Acquire => $op!("a", ""),
-            Ordering::Release => $op!("6", ""),
-            Ordering::AcqRel => $op!("e", ""),
+            Ordering::Relaxed => $op!("2", ""), // ""
+            Ordering::Acquire => $op!("a", ""), // "a"
+            Ordering::Release => $op!("6", ""), // "l"
+            Ordering::AcqRel => $op!("e", ""),  // "al"
             // In MSVC environments, SeqCst stores/writes needs fences after writes.
             // https://reviews.llvm.org/D141748
             #[cfg(target_env = "msvc")]

--- a/src/imp/detect/aarch64_apple.rs
+++ b/src/imp/detect/aarch64_apple.rs
@@ -98,6 +98,8 @@ fn _detect(info: &mut CpuInfo) {
     check!(lse, "hw.optional.arm.FEAT_LSE" || "hw.optional.armv8_1_atomics");
     check!(lse2, "hw.optional.arm.FEAT_LSE2");
     check!(lse128, "hw.optional.arm.FEAT_LSE128");
+    #[cfg(test)]
+    check!(lsfe, "hw.optional.arm.FEAT_LSFE");
     check!(rcpc3, "hw.optional.arm.FEAT_LRCPC3");
 }
 
@@ -257,6 +259,7 @@ mod tests {
             (c!("hw.optional.armv8_1_atomics"), Some(1)),
             (c!("hw.optional.arm.FEAT_LSE2"), Some(1)),
             (c!("hw.optional.arm.FEAT_LSE128"), None),
+            (c!("hw.optional.arm.FEAT_LSFE"), None),
             (c!("hw.optional.arm.FEAT_LRCPC"), Some(1)),
             (c!("hw.optional.arm.FEAT_LRCPC2"), Some(1)),
             (c!("hw.optional.arm.FEAT_LRCPC3"), None),

--- a/src/imp/detect/common.rs
+++ b/src/imp/detect/common.rs
@@ -119,6 +119,13 @@ flags! {
     // > If FEAT_LSE128 is implemented, then FEAT_LSE is implemented.
     #[cfg_attr(not(test), allow(dead_code))]
     lse128("lse128", any(target_feature /* nightly */, portable_atomic_target_feature)),
+    // FEAT_LSFE, Large System Float Extension
+    // https://developer.arm.com/documentation/109697/2024_12/Feature-descriptions/The-Armv9-6-architecture-extension
+    // > This feature is supported in AArch64 state only.
+    // > FEAT_LSFE is OPTIONAL from Armv9.3.
+    // > If FEAT_LSFE is implemented, then FEAT_FP is implemented.
+    #[cfg(test)]
+    lsfe("lsfe", any(target_feature /* N/A */, portable_atomic_target_feature)),
 }
 
 // LLVM definitions: https://github.com/llvm/llvm-project/blob/llvmorg-20.1.0/llvm/lib/Target/PowerPC/PPC.td

--- a/src/imp/float/aarch64.rs
+++ b/src/imp/float/aarch64.rs
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/*
+Atomic float implementation based on AArch64 with FEAT_LSFE.
+
+This module provides atomic float implementations using FEAT_LSFE instructions.
+
+Generated asm:
+- aarch64 (+lsfe) https://godbolt.org/z/7vaxeofv1
+*/
+
+#[cfg(not(portable_atomic_no_asm))]
+use core::arch::asm;
+use core::sync::atomic::Ordering;
+
+#[cfg(portable_atomic_unstable_f16)]
+use super::int::AtomicF16;
+#[cfg(portable_atomic_unstable_f128)]
+use super::int::AtomicF128;
+use super::int::{AtomicF32, AtomicF64};
+
+// TODO: optimize no return cases:
+// https://developer.arm.com/documentation/ddi0602/2024-12/SIMD-FP-Instructions/STFADD--STFADDL--Floating-point-atomic-add-in-memory--without-return-
+// https://developer.arm.com/documentation/ddi0602/2024-12/SIMD-FP-Instructions/STFMAXNM--STFMAXNML--Floating-point-atomic-maximum-number-in-memory--without-return-
+// https://developer.arm.com/documentation/ddi0602/2024-12/SIMD-FP-Instructions/STFMINNM--STFMINNML--Floating-point-atomic-minimum-number-in-memory--without-return-
+
+#[cfg(not(portable_atomic_pre_llvm_20))]
+macro_rules! start_lsfe {
+    () => {
+        ".arch_extension lsfe"
+    };
+}
+
+#[cfg(not(portable_atomic_pre_llvm_20))]
+macro_rules! atomic_rmw {
+    ($op:ident, $order:ident) => {
+        atomic_rmw!($op, $order, write = $order)
+    };
+    ($op:ident, $order:ident, write = $write:ident) => {
+        match $order {
+            Ordering::Relaxed => $op!("", "", ""),
+            Ordering::Acquire => $op!("a", "", ""),
+            Ordering::Release => $op!("", "l", ""),
+            Ordering::AcqRel => $op!("a", "l", ""),
+            // In MSVC environments, SeqCst stores/writes needs fences after writes.
+            // https://reviews.llvm.org/D141748
+            #[cfg(target_env = "msvc")]
+            Ordering::SeqCst if $write == Ordering::SeqCst => $op!("a", "l", "dmb ish"),
+            // AcqRel and SeqCst RMWs are equivalent in non-MSVC environments.
+            Ordering::SeqCst => $op!("a", "l", ""),
+            _ => unreachable!(),
+        }
+    };
+}
+#[cfg(portable_atomic_pre_llvm_20)]
+macro_rules! atomic_rmw_inst {
+    ($op:ident, $order:ident) => {
+        atomic_rmw_inst!($op, $order, write = $order)
+    };
+    ($op:ident, $order:ident, write = $write:ident) => {
+        match $order {
+            Ordering::Relaxed => $op!("2", ""), // ""
+            Ordering::Acquire => $op!("a", ""), // "a"
+            Ordering::Release => $op!("6", ""), // "l"
+            Ordering::AcqRel => $op!("e", ""),  // "al"
+            // In MSVC environments, SeqCst stores/writes needs fences after writes.
+            // https://reviews.llvm.org/D141748
+            #[cfg(target_env = "msvc")]
+            Ordering::SeqCst if $write == Ordering::SeqCst => $op!("e", "dmb ish"),
+            // AcqRel and SeqCst RMWs are equivalent in non-MSVC environments.
+            Ordering::SeqCst => $op!("e", ""),
+            _ => unreachable!(),
+        }
+    };
+}
+
+macro_rules! atomic_float {
+    ($atomic_type:ident, $float_type:ident, $modifier:tt, $inst_modifier:tt) => {
+        impl $atomic_type {
+            #[inline]
+            pub(crate) fn fetch_add(&self, val: $float_type, order: Ordering) -> $float_type {
+                let dst = self.as_ptr();
+                let out;
+                // SAFETY: any data races are prevented by atomic intrinsics and the raw
+                // pointer passed in is valid because we got it from a reference.
+                //
+                // Refs: https://developer.arm.com/documentation/ddi0602/2024-12/SIMD-FP-Instructions/LDFADD--LDFADDA--LDFADDAL--LDFADDL--Floating-point-atomic-add-in-memory-
+                unsafe {
+                    #[cfg(not(portable_atomic_pre_llvm_20))]
+                    macro_rules! add {
+                        ($acquire:tt, $release:tt, $fence:tt) => {
+                            asm!(
+                                start_lsfe!(),
+                                concat!("ldfadd", $acquire, $release, " {out:", $modifier, "}, {val:", $modifier, "}, [{dst}]"),
+                                $fence,
+                                dst = in(reg) ptr_reg!(dst),
+                                val = in(vreg) val,
+                                out = lateout(vreg) out,
+                                options(nostack),
+                            )
+                        };
+                    }
+                    #[cfg(not(portable_atomic_pre_llvm_20))]
+                    atomic_rmw!(add, order);
+                    // LLVM supports FEAT_LSFE instructions on LLVM 20+, so use .inst directive on old LLVM.
+                    // https://github.com/llvm/llvm-project/commit/67ff5ba9af9754261abe11d762af11532a816126
+                    #[cfg(portable_atomic_pre_llvm_20)]
+                    macro_rules! add {
+                        ($order:tt, $fence:tt) => {
+                            asm!(
+                                // ldfadd{,a,l,al} {h,s,d}0, {h,s,d}1, [x2]
+                                concat!(".inst 0x", $inst_modifier, "c", $order, "00041"),
+                                $fence,
+                                in("x2") ptr_reg!(dst),
+                                in("v1") val,
+                                out("v0") out,
+                                options(nostack),
+                            )
+                        };
+                    }
+                    #[cfg(portable_atomic_pre_llvm_20)]
+                    atomic_rmw_inst!(add, order);
+                }
+                out
+            }
+            #[inline]
+            pub(crate) fn fetch_sub(&self, val: $float_type, order: Ordering) -> $float_type {
+                // There is no atomic sub instruction, so add `-val`.
+                self.fetch_add(-val, order)
+            }
+            #[inline]
+            pub(crate) fn fetch_max(&self, val: $float_type, order: Ordering) -> $float_type {
+                let dst = self.as_ptr();
+                let out;
+                // SAFETY: any data races are prevented by atomic intrinsics and the raw
+                // pointer passed in is valid because we got it from a reference.
+                //
+                // Refs: https://developer.arm.com/documentation/ddi0602/2024-12/SIMD-FP-Instructions/LDFMAXNM--LDFMAXNMA--LDFMAXNMAL--LDFMAXNML--Floating-point-atomic-maximum-number-in-memory-
+                unsafe {
+                    #[cfg(not(portable_atomic_pre_llvm_20))]
+                    macro_rules! max {
+                        ($acquire:tt, $release:tt, $fence:tt) => {
+                            asm!(
+                                start_lsfe!(),
+                                concat!("ldfmaxnm", $acquire, $release, " {out:", $modifier, "}, {val:", $modifier, "}, [{dst}]"),
+                                $fence,
+                                dst = in(reg) ptr_reg!(dst),
+                                val = in(vreg) val,
+                                out = lateout(vreg) out,
+                                options(nostack),
+                            )
+                        };
+                    }
+                    #[cfg(not(portable_atomic_pre_llvm_20))]
+                    atomic_rmw!(max, order);
+                    // LLVM supports FEAT_LSFE instructions on LLVM 20+, so use .inst directive on old LLVM.
+                    // https://github.com/llvm/llvm-project/commit/67ff5ba9af9754261abe11d762af11532a816126
+                    #[cfg(portable_atomic_pre_llvm_20)]
+                    macro_rules! max {
+                        ($order:tt, $fence:tt) => {
+                            asm!(
+                                // ldfmaxnm{,a,l,al} {h,s,d}0, {h,s,d}1, [x2]
+                                concat!(".inst 0x", $inst_modifier, "c", $order, "06041"),
+                                $fence,
+                                in("x2") ptr_reg!(dst),
+                                in("v1") val,
+                                out("v0") out,
+                                options(nostack),
+                            )
+                        };
+                    }
+                    #[cfg(portable_atomic_pre_llvm_20)]
+                    atomic_rmw_inst!(max, order);
+                }
+                out
+            }
+            #[inline]
+            pub(crate) fn fetch_min(&self, val: $float_type, order: Ordering) -> $float_type {
+                let dst = self.as_ptr();
+                let out;
+                // SAFETY: any data races are prevented by atomic intrinsics and the raw
+                // pointer passed in is valid because we got it from a reference.
+                //
+                // Refs: https://developer.arm.com/documentation/ddi0602/2024-12/SIMD-FP-Instructions/LDFMINNM--LDFMINNMA--LDFMINNMAL--LDFMINNML--Floating-point-atomic-minimum-number-in-memory-
+                unsafe {
+                    #[cfg(not(portable_atomic_pre_llvm_20))]
+                    macro_rules! min {
+                        ($acquire:tt, $release:tt, $fence:tt) => {
+                            asm!(
+                                start_lsfe!(),
+                                concat!("ldfminnm", $acquire, $release, " {out:", $modifier, "}, {val:", $modifier, "}, [{dst}]"),
+                                $fence,
+                                dst = in(reg) ptr_reg!(dst),
+                                val = in(vreg) val,
+                                out = lateout(vreg) out,
+                                options(nostack),
+                            )
+                        };
+                    }
+                    #[cfg(not(portable_atomic_pre_llvm_20))]
+                    atomic_rmw!(min, order);
+                    // LLVM supports FEAT_LSFE instructions on LLVM 20+, so use .inst directive on old LLVM.
+                    // https://github.com/llvm/llvm-project/commit/67ff5ba9af9754261abe11d762af11532a816126
+                    #[cfg(portable_atomic_pre_llvm_20)]
+                    macro_rules! min {
+                        ($order:tt, $fence:tt) => {
+                            asm!(
+                                // ldfminnm{,a,l,al} {h,s,d}0, {h,s,d}1, [x2]
+                                concat!(".inst 0x", $inst_modifier, "c", $order, "07041"),
+                                $fence,
+                                in("x2") ptr_reg!(dst),
+                                in("v1") val,
+                                out("v0") out,
+                                options(nostack),
+                            )
+                        };
+                    }
+                    #[cfg(portable_atomic_pre_llvm_20)]
+                    atomic_rmw_inst!(min, order);
+                }
+                out
+            }
+        }
+    };
+}
+
+#[cfg(portable_atomic_unstable_f16)]
+atomic_float!(AtomicF16, f16, "h", "7");
+atomic_float!(AtomicF32, f32, "s", "b");
+atomic_float!(AtomicF64, f64, "d", "f");
+
+#[cfg(portable_atomic_unstable_f128)]
+impl AtomicF128 {
+    #[inline]
+    pub(crate) fn fetch_add(&self, val: f128, order: Ordering) -> f128 {
+        self.fetch_update_(order, |x| x + val)
+    }
+    #[inline]
+    pub(crate) fn fetch_sub(&self, val: f128, order: Ordering) -> f128 {
+        self.fetch_update_(order, |x| x - val)
+    }
+    #[inline]
+    pub(super) fn fetch_update_<F>(&self, order: Ordering, mut f: F) -> f128
+    where
+        F: FnMut(f128) -> f128,
+    {
+        // This is a private function and all instances of `f` only operate on the value
+        // loaded, so there is no need to synchronize the first load/failed CAS.
+        let mut prev = self.load(Ordering::Relaxed);
+        loop {
+            let next = f(prev);
+            match self.compare_exchange_weak(prev, next, order, Ordering::Relaxed) {
+                Ok(x) => return x,
+                Err(next_prev) => prev = next_prev,
+            }
+        }
+    }
+    #[inline]
+    pub(crate) fn fetch_max(&self, val: f128, order: Ordering) -> f128 {
+        self.fetch_update_(order, |x| x.max(val))
+    }
+    #[inline]
+    pub(crate) fn fetch_min(&self, val: f128, order: Ordering) -> f128 {
+        self.fetch_update_(order, |x| x.min(val))
+    }
+}

--- a/src/imp/float/int.rs
+++ b/src/imp/float/int.rs
@@ -9,7 +9,8 @@ Note that most of `fetch_*` operations of atomic floats are implemented using
 CAS loops, which can be slower than equivalent operations of atomic integers.
 
 AArch64 with FEAT_LSFE and GPU targets have atomic instructions for float.
-Both will use architecture-specific implementations instead of this implementation in the
+See aarch64.rs for AArch64 with FEAT_LSFE.
+GPU targets will also use architecture-specific implementations instead of this implementation in the
 future: https://github.com/taiki-e/portable-atomic/issues/34 / https://github.com/taiki-e/portable-atomic/pull/45
 */
 
@@ -138,18 +139,39 @@ macro_rules! atomic_float {
                 }
             }
 
+            #[cfg(not(all(
+                any(target_arch = "aarch64", target_arch = "arm64ec"),
+                any(target_feature = "lsfe", portable_atomic_target_feature = "lsfe"),
+                target_feature = "neon", // for vreg
+                not(any(miri, portable_atomic_sanitize_thread)),
+                any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
+            )))]
             #[inline]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
             pub(crate) fn fetch_add(&self, val: $float_type, order: Ordering) -> $float_type {
                 self.fetch_update_(order, |x| x + val)
             }
 
+            #[cfg(not(all(
+                any(target_arch = "aarch64", target_arch = "arm64ec"),
+                any(target_feature = "lsfe", portable_atomic_target_feature = "lsfe"),
+                target_feature = "neon", // for vreg
+                not(any(miri, portable_atomic_sanitize_thread)),
+                any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
+            )))]
             #[inline]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
             pub(crate) fn fetch_sub(&self, val: $float_type, order: Ordering) -> $float_type {
                 self.fetch_update_(order, |x| x - val)
             }
 
+            #[cfg(not(all(
+                any(target_arch = "aarch64", target_arch = "arm64ec"),
+                any(target_feature = "lsfe", portable_atomic_target_feature = "lsfe"),
+                target_feature = "neon", // for vreg
+                not(any(miri, portable_atomic_sanitize_thread)),
+                any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
+            )))]
             #[inline]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
             fn fetch_update_<F>(&self, order: Ordering, mut f: F) -> $float_type
@@ -168,12 +190,26 @@ macro_rules! atomic_float {
                 }
             }
 
+            #[cfg(not(all(
+                any(target_arch = "aarch64", target_arch = "arm64ec"),
+                any(target_feature = "lsfe", portable_atomic_target_feature = "lsfe"),
+                target_feature = "neon", // for vreg
+                not(any(miri, portable_atomic_sanitize_thread)),
+                any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
+            )))]
             #[inline]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
             pub(crate) fn fetch_max(&self, val: $float_type, order: Ordering) -> $float_type {
                 self.fetch_update_(order, |x| x.max(val))
             }
 
+            #[cfg(not(all(
+                any(target_arch = "aarch64", target_arch = "arm64ec"),
+                any(target_feature = "lsfe", portable_atomic_target_feature = "lsfe"),
+                target_feature = "neon", // for vreg
+                not(any(miri, portable_atomic_sanitize_thread)),
+                any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
+            )))]
             #[inline]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
             pub(crate) fn fetch_min(&self, val: $float_type, order: Ordering) -> $float_type {

--- a/src/imp/float/mod.rs
+++ b/src/imp/float/mod.rs
@@ -8,6 +8,15 @@ Atomic float implementations
 
 mod int;
 
+#[cfg(all(
+    any(target_arch = "aarch64", target_arch = "arm64ec"),
+    any(target_feature = "lsfe", portable_atomic_target_feature = "lsfe"),
+    target_feature = "neon", // for vreg
+    not(any(miri, portable_atomic_sanitize_thread)),
+    any(not(portable_atomic_no_asm), portable_atomic_unstable_asm),
+))]
+mod aarch64;
+
 #[cfg(portable_atomic_unstable_f16)]
 cfg_has_atomic_16! {
     pub(crate) use self::int::AtomicF16;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ See the [`atomic128` module's readme](https://github.com/taiki-e/portable-atomic
   - When unstable `--cfg portable_atomic_unstable_f128` is also enabled, `AtomicF128` for [unstable `f128`](https://github.com/rust-lang/rust/issues/116909) is also provided.
 
   Note:
-  - Most of `fetch_*` operations of atomic floats are implemented using CAS loops, which can be slower than equivalent operations of atomic integers. (AArch64 with FEAT_LSFE and GPU targets have atomic instructions for float, [so we plan to use these instructions for them in the future.](https://github.com/taiki-e/portable-atomic/issues/34))
+  - Atomic float's `fetch_{add,sub,min,max}` are usually implemented using CAS loops, which can be slower than equivalent operations of atomic integers. As an exception, AArch64 with FEAT_LSFE and GPU targets have atomic float instructions and we use them on AArch64 when `lsfe` target feature is available at compile-time. We [plan to use atomic float instructions for GPU targets as well in the future.](https://github.com/taiki-e/portable-atomic/issues/34))
   - Unstable cfgs are outside of the normal semver guarantees and minor or patch versions of portable-atomic may make breaking changes to them at any time.
 
 - **`std`**<br>

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -649,6 +649,9 @@ build() {
       CARGO_TARGET_DIR="${target_dir}/lse128-rcpc3" \
         RUSTFLAGS="${target_rustflags} -C target-feature=+lse2,+lse128,+rcpc3" \
         x_cargo "${args[@]}" "$@"
+      CARGO_TARGET_DIR="${target_dir}/lsfe" \
+        RUSTFLAGS="${target_rustflags} -C target-feature=+lsfe" \
+        x_cargo "${args[@]}" "$@"
       ;;
     powerpc64-*)
       # powerpc64le- (little-endian) is skipped because it is pwr8 by default


### PR DESCRIPTION
Armv9.6 added atomic float instructions for binary{16,32,64} and bfloat16 as FEAT_LSFE (Large System Float Extension).

This PR optimizes AArch64 {16,32,64}-bit atomic float add/sub/max/min when FEAT_LSFE is enabled.

LLVM's assembly support for FEAT_LSFE needs LLVM 20 (https://github.com/llvm/llvm-project/commit/67ff5ba9af9754261abe11d762af11532a816126), so use .inst directive on LLVM 19 or older.

Run-time detection is also implemented, but at this time it is only used in testing. AFAIK no CPUs actually implement this feature yet, so we will only refer to the feature available at compile time at this time.