### PR TITLE
atomic128: use the new `intrinsics::atomic_load`

### DIFF
--- a/src/imp/atomic128/intrinsics.rs
+++ b/src/imp/atomic128/intrinsics.rs
@@ -61,6 +61,8 @@ fn strongest_failure_ordering(order: Ordering) -> Ordering {
 #[inline]
 #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
 unsafe fn atomic_load(src: *mut u128, order: Ordering) -> u128 {
+    use intrinsics::AtomicOrdering;
+
     #[cfg(target_arch = "x86_64")]
     // SAFETY: the caller must uphold the safety contract.
     unsafe {
@@ -73,9 +75,9 @@ unsafe fn atomic_load(src: *mut u128, order: Ordering) -> u128 {
     // SAFETY: the caller must uphold the safety contract.
     unsafe {
         match order {
-            Acquire => intrinsics::atomic_load_acquire(src),
-            Relaxed => intrinsics::atomic_load_relaxed(src),
-            SeqCst => intrinsics::atomic_load_seqcst(src),
+            Acquire => intrinsics::atomic_load::<_, { AtomicOrdering::Acquire }>(src),
+            Relaxed => intrinsics::atomic_load::<_, { AtomicOrdering::Relaxed }>(src),
+            SeqCst => intrinsics::atomic_load::<_, { AtomicOrdering::SeqCst }>(src),
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
In rust-lang/rust#141507, the `atomic_load_{ordering}` intrinsics were gated behind the `bootstrap` config and replaced with a single `atomic_load` intrinsic. This breaks running Miri on this crate with a recent nightly version:

```
error[E0425]: cannot find function `atomic_load_acquire` in module `intrinsics`
   --> src/imp/atomic128/intrinsics.rs:76:36
    |
76  |             Acquire => intrinsics::atomic_load_acquire(src),
    |                                    ^^^^^^^^^^^^^^^^^^^ help: a function with a similar name exists: `atomic_and_acquire`
    |
   ::: /Users/jan/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/intrinsics/mod.rs:656:1
    |
656 | pub unsafe fn atomic_and_acquire<T: Copy>(dst: *mut T, src: T) -> T;
    | -------------------------------------------------------------------- similarly named function `atomic_and_acquire` defined here
    |
note: found an item that was configured out
   --> /Users/jan/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/intrinsics/mod.rs:437:15
    |
437 | pub unsafe fn atomic_load_acquire<T: Copy>(src: *const T) -> T;
    |               ^^^^^^^^^^^^^^^^^^^
note: the item is gated here
   --> /Users/jan/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/intrinsics/mod.rs:436:1
    |
436 | #[cfg(bootstrap)]
    | ^^^^^^^^^^^^^^^^^

[...]
```

 This PR moves the portable-atomic crate to that new intrinsic to unbreak Miri.