### PR TITLE
ESP32: Only access PSRAM inside a critical section

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -47,6 +47,7 @@ devkitm
 dlfcn
 dlsym
 ecall
+Espressif
 espup
 exynos
 fild
@@ -140,6 +141,7 @@ picolibc
 prctl
 prefetcher
 PRIMASK
+PSRAM
 pstq
 quadword
 rcpc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1013,6 +1013,8 @@ jobs:
       #   if: matrix.rust == 'stable'
       - run: tools/no-std.sh +esp xtensa-esp32s2-none-elf
         if: matrix.rust == 'stable'
+      - run: tools/no-std.sh +esp xtensa-esp32s3-none-elf
+        if: matrix.rust == 'stable'
 
   miri:
     needs: tidy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -968,8 +968,7 @@ jobs:
             chmod +x "${HOME}"/aarch64-l4re-gcc/bin/l4image
             printf '%s\n' "${HOME}"/aarch64-l4re-gcc/bin >>"${GITHUB_PATH}"
           elif [[ "${RUST}" == "stable" ]]; then
-            # TODO: Use the latest toolchain once upstream bug fixed.
-            retry espup install --targets esp32s2 --toolchain-version 1.90.0
+            retry espup install --targets esp32s2
           fi
           retry curl --proto '=https' --tlsv1.2 -fsSL --retry 10 https://github.com/taiki-e/qemu/releases/download/patched-11.0.0-rc0/qemu-ubuntu-24.04.tar.xz \
             | tar xJf -
@@ -1296,7 +1295,6 @@ jobs:
             done
             "$@"
           }
-          # TODO: Use the latest toolchain once upstream bug fixed.
-          retry espup install --targets esp32s2 --toolchain-version 1.90.0
+          retry espup install --targets esp32s2
       - run: cargo test --manifest-path tests/asm-test/Cargo.toml
       - run: cargo +esp test --manifest-path tests/asm-test/Cargo.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Xtensa: route atomic read-modify-write operations on ESP32 / ESP32-S3 PSRAM addresses through a critical section. `Atomic*::IS_ALWAYS_LOCK_FREE` becomes `false` on these CPUs.
+
 ## [1.13.1] - 2026-01-31
 
 - Update to stabilized [PowerPC64](https://github.com/rust-lang/rust/pull/147996) inline assembly. ([92b02f8a](https://github.com/taiki-e/portable-atomic/commit/92b02f8a279327a1780cbe127d9effb2baae9b2f))

--- a/build.rs
+++ b/build.rs
@@ -56,12 +56,15 @@ fn main() {
         // Custom cfgs set by build script. Not public API.
         // grep -F 'cargo:rustc-cfg=' build.rs | grep -Ev '^ *//' | sed -E 's/^.*cargo:rustc-cfg=//; s/(=\\)?".*$//' | LC_ALL=C sort -u | tr '\n' ',' | sed -E 's/,$/\n/'
         println!(
-            "cargo:rustc-check-cfg=cfg(atomic_maybe_uninit_no_asm,portable_atomic_atomic_intrinsics,portable_atomic_disable_fiq,portable_atomic_force_amo,portable_atomic_ll_sc_rmw,portable_atomic_no_asm,portable_atomic_no_asm_maybe_uninit,portable_atomic_no_asm_syscall,portable_atomic_no_atomic_64,portable_atomic_no_atomic_cas,portable_atomic_no_atomic_load_store,portable_atomic_no_atomic_min_max,portable_atomic_no_cfg_target_has_atomic,portable_atomic_no_cmpxchg16b_intrinsic,portable_atomic_no_cmpxchg16b_target_feature,portable_atomic_no_const_mut_refs,portable_atomic_no_const_raw_ptr_deref,portable_atomic_no_const_transmute,portable_atomic_no_core_unwind_safe,portable_atomic_no_diagnostic_namespace,portable_atomic_no_strict_provenance,portable_atomic_no_strict_provenance_atomic_ptr,portable_atomic_no_stronger_failure_ordering,portable_atomic_no_track_caller,portable_atomic_no_unsafe_op_in_unsafe_fn,portable_atomic_pre_llvm_15,portable_atomic_pre_llvm_16,portable_atomic_pre_llvm_18,portable_atomic_pre_llvm_20,portable_atomic_s_mode,portable_atomic_sanitize_thread,portable_atomic_target_feature,portable_atomic_unsafe_assume_privileged,portable_atomic_unsafe_assume_single_core,portable_atomic_unstable_asm,portable_atomic_unstable_asm_experimental_arch,portable_atomic_unstable_cfg_target_has_atomic,portable_atomic_unstable_isa_attribute)"
+            "cargo:rustc-check-cfg=cfg(atomic_maybe_uninit_no_asm,portable_atomic_atomic_intrinsics,portable_atomic_disable_fiq,portable_atomic_force_amo,portable_atomic_ll_sc_rmw,portable_atomic_no_asm,portable_atomic_no_asm_maybe_uninit,portable_atomic_no_asm_syscall,portable_atomic_no_atomic_64,portable_atomic_no_atomic_cas,portable_atomic_no_atomic_load_store,portable_atomic_no_atomic_min_max,portable_atomic_no_cfg_target_has_atomic,portable_atomic_no_cmpxchg16b_intrinsic,portable_atomic_no_cmpxchg16b_target_feature,portable_atomic_no_const_mut_refs,portable_atomic_no_const_raw_ptr_deref,portable_atomic_no_const_transmute,portable_atomic_no_core_unwind_safe,portable_atomic_no_diagnostic_namespace,portable_atomic_no_strict_provenance,portable_atomic_no_strict_provenance_atomic_ptr,portable_atomic_no_stronger_failure_ordering,portable_atomic_no_track_caller,portable_atomic_no_unsafe_op_in_unsafe_fn,portable_atomic_pre_llvm_15,portable_atomic_pre_llvm_16,portable_atomic_pre_llvm_18,portable_atomic_pre_llvm_20,portable_atomic_s_mode,portable_atomic_sanitize_thread,portable_atomic_target_cpu,portable_atomic_target_feature,portable_atomic_unsafe_assume_privileged,portable_atomic_unsafe_assume_single_core,portable_atomic_unstable_asm,portable_atomic_unstable_asm_experimental_arch,portable_atomic_unstable_cfg_target_has_atomic,portable_atomic_unstable_isa_attribute)"
         );
         // TODO: handle multi-line target_feature_fallback
         // grep -F 'target_feature_fallback("' build.rs | grep -Ev '^ *//' | sed -E 's/^.*target_feature_fallback\(//; s/",.*$/"/' | LC_ALL=C sort -u | tr '\n' ',' | sed -E 's/,$/\n/'
         println!(
             r#"cargo:rustc-check-cfg=cfg(portable_atomic_target_feature,values("cmpxchg16b","distinct-ops","fast-serialization","load-store-on-cond","lse","lse128","lse2","lsfe","mclass","miscellaneous-extensions-3","quadword-atomics","rcpc3","rmw","v6","v7","zaamo","zabha","zacas"))"#
+        );
+        println!(
+            r#"cargo:rustc-check-cfg=cfg(portable_atomic_target_cpu,values("esp32","esp32s3"))"#
         );
     }
 
@@ -510,6 +513,33 @@ fn main() {
                 target_feature_fallback("rmw", xmegau);
             }
         }
+        "xtensa" => {
+            // ESP32 / ESP32-S3 advertise atomic CAS in core atomics, but LLVM's
+            // atomic instructions do not behave atomically on addresses backed by
+            // external (PSRAM / data bus) memory. The `src/imp/xtensa.rs` wrapper
+            // dispatches each operation based on the address at runtime; to
+            // select it we need to know which of the two affected CPUs we are
+            // targeting. Infer from `target-cpu`, or from the known Espressif
+            // target triples when no target-cpu is specified.
+            // ESP32-S2 has no atomic CAS at all and is handled by the generic
+            // no-CAS path, so it is intentionally absent here.
+            if let Some(cpu) = target_cpu() {
+                if cpu == "esp32" || cpu == "esp32s3" {
+                    target_cpu_fallback(&cpu);
+                }
+            } else {
+                let esp_cpu = match target {
+                    "xtensa-esp32-none-elf" | "xtensa-esp32-espidf" => Some("esp32"),
+                    "xtensa-esp32s3-none-elf" | "xtensa-esp32s3-espidf" => Some("esp32s3"),
+                    // ESP32-S2 does not have atomic CAS, so it is not affected by the issue the same way.
+                    // For other Xtensa CPUs, assume they are not affected.
+                    _ => None,
+                };
+                if let Some(cpu) = esp_cpu {
+                    target_cpu_fallback(cpu);
+                }
+            }
+        }
         _ => {}
     }
 }
@@ -566,6 +596,11 @@ fn target_cpu() -> Option<String> {
         }
     }
     cpu.map(str::to_owned)
+}
+
+// `target_cpu` is not a valid cfg option. Where there is absolutely no other option, inject a cfg fallback.
+fn target_cpu_fallback(cpu: &str) {
+    println!("cargo:rustc-cfg=portable_atomic_target_cpu=\"{}\"", cpu);
 }
 
 fn is_allowed_feature(name: &str) -> bool {

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -35,6 +35,13 @@
         not(target_has_atomic = "ptr"),
     )))
 )]
+// ESP32 and ESP32-S3 have native atomic CAS on internal memory but not on
+// PSRAM. Redirect this module to a wrapper, which exposes the same public API
+// and dispatches each operation based on the address at runtime.
+#[cfg_attr(
+    any(portable_atomic_target_cpu = "esp32", portable_atomic_target_cpu = "esp32s3"),
+    path = "xtensa.rs"
+)]
 mod core_atomic;
 
 // AVR

--- a/src/imp/xtensa.rs
+++ b/src/imp/xtensa.rs
@@ -1,0 +1,598 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/*
+PSRAM-aware atomics for ESP32 / ESP32-S3.
+
+These chips advertise native atomic CAS (Xtensa `S32C1I`) which works for
+internal SRAM, but the instruction does NOT behave atomically on addresses
+backed by the external data bus (PSRAM). Every operation therefore checks
+the target address at runtime and dispatches to either
+`core::sync::atomic::*` (fast path, when the atomic lives in internal
+memory) or a critical section (when it lives in PSRAM).
+
+Address ranges:
+- ESP32:    0x3F80_0000..0x3FC0_0000
+- ESP32-S3: 0x3C00_0000..0x3E00_0000
+
+This module is selected in place of `src/imp/core_atomic.rs` by a `#[path]`
+attribute in `src/imp/mod.rs`, so it exposes exactly the same public API.
+*/
+
+use core::{cell::UnsafeCell, marker::PhantomData, sync::atomic::Ordering};
+
+// See `src/imp/core_atomic.rs` for why this marker is necessary — it
+// prevents the `#[repr(transparent)]` wrapper below from inheriting
+// `RefUnwindSafe` via the std atomic auto-impl, so that portable-atomic's
+// public types carry `RefUnwindSafe` uniformly on every backend.
+struct NotRefUnwindSafe(UnsafeCell<()>);
+// SAFETY: marker type; the UnsafeCell value is never accessed.
+unsafe impl Sync for NotRefUnwindSafe {}
+
+// The external (PSRAM / data bus) address ranges that do not support
+// atomic RMW instructions on these CPUs.
+
+// https://documentation.espressif.com/esp32_technical_reference_manual_en.pdf, Table 3.3-4. External Memory Address Mapping
+#[cfg(portable_atomic_target_cpu = "esp32")]
+const PSRAM: core::ops::Range<usize> = 0x3F80_0000..0x3FC0_0000;
+
+// https://documentation.espressif.com/esp32-s3_technical_reference_manual_en.pdf, Table 4.3-2. External Memory Address Mapping
+#[cfg(portable_atomic_target_cpu = "esp32s3")]
+const PSRAM: core::ops::Range<usize> = 0x3C00_0000..0x3E00_0000;
+
+#[inline(always)]
+fn in_psram<T>(ptr: *const T) -> bool {
+    let addr = ptr as usize;
+    addr >= PSRAM.start && addr < PSRAM.end
+}
+
+#[cfg(not(feature = "critical-section"))]
+#[cold]
+#[inline(never)]
+#[track_caller]
+fn psram_rmw_without_cs() -> ! {
+    panic!(
+        "portable-atomic: atomic read-modify-write on PSRAM requires the \
+         `critical-section` feature on ESP32 / ESP32-S3"
+    );
+}
+
+// Run an RMW closure either natively (addr in internal memory) or under a
+// critical section (addr in PSRAM). When the `critical-section` feature is
+// disabled, the PSRAM path panics.
+//
+// `$ptr` is the backing raw pointer; the CS-path closure is an
+// `unsafe` block that uses `read_volatile`/`write_volatile` on it.
+macro_rules! rmw {
+    ($self:ident, $native:expr, |$ptr:ident| $cs:block) => {{
+        let $ptr: *mut _ = $self.as_ptr();
+        if in_psram($ptr) {
+            #[cfg(feature = "critical-section")]
+            {
+                critical_section::with(|_cs| {
+                    // SAFETY: inside a critical section, we have exclusive
+                    // access to `$ptr` and the pointer is valid because
+                    // we got it from `&self`. The accesses use volatile
+                    // reads/writes and so are not reordered with respect
+                    // to each other or with the CS entry/exit barriers.
+                    unsafe { $cs }
+                })
+            }
+            #[cfg(not(feature = "critical-section"))]
+            {
+                let _ = $ptr; // suppress unused warning for move-only closures
+                psram_rmw_without_cs()
+            }
+        } else {
+            $native
+        }
+    }};
+}
+
+// ---------------------------------------------------------------------------
+// AtomicPtr
+
+#[repr(transparent)]
+pub(crate) struct AtomicPtr<T> {
+    inner: core::sync::atomic::AtomicPtr<T>,
+    _not_ref_unwind_safe: PhantomData<NotRefUnwindSafe>,
+}
+impl<T> AtomicPtr<T> {
+    #[inline]
+    pub(crate) const fn new(v: *mut T) -> Self {
+        Self { inner: core::sync::atomic::AtomicPtr::new(v), _not_ref_unwind_safe: PhantomData }
+    }
+    #[inline]
+    pub(crate) fn is_lock_free() -> bool {
+        Self::IS_ALWAYS_LOCK_FREE
+    }
+    // Not lock-free: if the atomic happens to live in PSRAM, RMWs take a
+    // critical section. We can only give a conservative compile-time answer.
+    pub(crate) const IS_ALWAYS_LOCK_FREE: bool = false;
+
+    #[inline]
+    #[cfg_attr(any(debug_assertions, miri), track_caller)]
+    pub(crate) fn load(&self, order: Ordering) -> *mut T {
+        crate::utils::assert_load_ordering(order);
+        self.inner.load(order)
+    }
+    #[inline]
+    #[cfg_attr(any(debug_assertions, miri), track_caller)]
+    pub(crate) fn store(&self, ptr: *mut T, order: Ordering) {
+        crate::utils::assert_store_ordering(order);
+        self.inner.store(ptr, order);
+    }
+
+    #[inline]
+    #[cfg_attr(miri, track_caller)]
+    pub(crate) fn swap(&self, ptr: *mut T, order: Ordering) -> *mut T {
+        rmw!(self, self.inner.swap(ptr, order), |p| {
+            let prev = core::ptr::read_volatile(p);
+            core::ptr::write_volatile(p, ptr);
+            prev
+        })
+    }
+
+    #[inline]
+    #[cfg_attr(any(debug_assertions, miri), track_caller)]
+    pub(crate) fn compare_exchange(
+        &self,
+        current: *mut T,
+        new: *mut T,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<*mut T, *mut T> {
+        crate::utils::assert_compare_exchange_ordering(success, failure);
+        rmw!(self, self.inner.compare_exchange(current, new, success, failure), |p| {
+            let prev = core::ptr::read_volatile(p);
+            if prev == current {
+                core::ptr::write_volatile(p, new);
+                Ok(prev)
+            } else {
+                Err(prev)
+            }
+        })
+    }
+    #[inline]
+    #[cfg_attr(any(debug_assertions, miri), track_caller)]
+    pub(crate) fn compare_exchange_weak(
+        &self,
+        current: *mut T,
+        new: *mut T,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<*mut T, *mut T> {
+        crate::utils::assert_compare_exchange_ordering(success, failure);
+        rmw!(self, self.inner.compare_exchange_weak(current, new, success, failure), |p| {
+            let prev = core::ptr::read_volatile(p);
+            if prev == current {
+                core::ptr::write_volatile(p, new);
+                Ok(prev)
+            } else {
+                Err(prev)
+            }
+        })
+    }
+
+    #[inline]
+    #[cfg_attr(miri, track_caller)]
+    pub(crate) fn fetch_byte_add(&self, val: usize, order: Ordering) -> *mut T {
+        #[cfg(portable_atomic_no_strict_provenance)]
+        use crate::utils::ptr::PtrExt as _;
+        rmw!(
+            self,
+            {
+                #[cfg(not(portable_atomic_no_strict_provenance_atomic_ptr))]
+                {
+                    self.inner.fetch_byte_add(val, order)
+                }
+                #[cfg(portable_atomic_no_strict_provenance_atomic_ptr)]
+                {
+                    crate::utils::ptr::with_exposed_provenance_mut(
+                        self.as_atomic_usize().fetch_add(val, order),
+                    )
+                }
+            },
+            |p| {
+                let prev = core::ptr::read_volatile(p);
+                let next = prev.with_addr(prev.addr().wrapping_add(val));
+                core::ptr::write_volatile(p, next);
+                prev
+            }
+        )
+    }
+    #[inline]
+    #[cfg_attr(miri, track_caller)]
+    pub(crate) fn fetch_byte_sub(&self, val: usize, order: Ordering) -> *mut T {
+        #[cfg(portable_atomic_no_strict_provenance)]
+        use crate::utils::ptr::PtrExt as _;
+        rmw!(
+            self,
+            {
+                #[cfg(not(portable_atomic_no_strict_provenance_atomic_ptr))]
+                {
+                    self.inner.fetch_byte_sub(val, order)
+                }
+                #[cfg(portable_atomic_no_strict_provenance_atomic_ptr)]
+                {
+                    crate::utils::ptr::with_exposed_provenance_mut(
+                        self.as_atomic_usize().fetch_sub(val, order),
+                    )
+                }
+            },
+            |p| {
+                let prev = core::ptr::read_volatile(p);
+                let next = prev.with_addr(prev.addr().wrapping_sub(val));
+                core::ptr::write_volatile(p, next);
+                prev
+            }
+        )
+    }
+    #[inline]
+    #[cfg_attr(miri, track_caller)]
+    pub(crate) fn fetch_or(&self, val: usize, order: Ordering) -> *mut T {
+        #[cfg(portable_atomic_no_strict_provenance)]
+        use crate::utils::ptr::PtrExt as _;
+        rmw!(
+            self,
+            {
+                #[cfg(not(portable_atomic_no_strict_provenance_atomic_ptr))]
+                {
+                    self.inner.fetch_or(val, order)
+                }
+                #[cfg(portable_atomic_no_strict_provenance_atomic_ptr)]
+                {
+                    crate::utils::ptr::with_exposed_provenance_mut(
+                        self.as_atomic_usize().fetch_or(val, order),
+                    )
+                }
+            },
+            |p| {
+                let prev = core::ptr::read_volatile(p);
+                let next = prev.with_addr(prev.addr() | val);
+                core::ptr::write_volatile(p, next);
+                prev
+            }
+        )
+    }
+    #[inline]
+    #[cfg_attr(miri, track_caller)]
+    pub(crate) fn fetch_and(&self, val: usize, order: Ordering) -> *mut T {
+        #[cfg(portable_atomic_no_strict_provenance)]
+        use crate::utils::ptr::PtrExt as _;
+        rmw!(
+            self,
+            {
+                #[cfg(not(portable_atomic_no_strict_provenance_atomic_ptr))]
+                {
+                    self.inner.fetch_and(val, order)
+                }
+                #[cfg(portable_atomic_no_strict_provenance_atomic_ptr)]
+                {
+                    crate::utils::ptr::with_exposed_provenance_mut(
+                        self.as_atomic_usize().fetch_and(val, order),
+                    )
+                }
+            },
+            |p| {
+                let prev = core::ptr::read_volatile(p);
+                let next = prev.with_addr(prev.addr() & val);
+                core::ptr::write_volatile(p, next);
+                prev
+            }
+        )
+    }
+    #[inline]
+    #[cfg_attr(miri, track_caller)]
+    pub(crate) fn fetch_xor(&self, val: usize, order: Ordering) -> *mut T {
+        #[cfg(portable_atomic_no_strict_provenance)]
+        use crate::utils::ptr::PtrExt as _;
+        rmw!(
+            self,
+            {
+                #[cfg(not(portable_atomic_no_strict_provenance_atomic_ptr))]
+                {
+                    self.inner.fetch_xor(val, order)
+                }
+                #[cfg(portable_atomic_no_strict_provenance_atomic_ptr)]
+                {
+                    crate::utils::ptr::with_exposed_provenance_mut(
+                        self.as_atomic_usize().fetch_xor(val, order),
+                    )
+                }
+            },
+            |p| {
+                let prev = core::ptr::read_volatile(p);
+                let next = prev.with_addr(prev.addr() ^ val);
+                core::ptr::write_volatile(p, next);
+                prev
+            }
+        )
+    }
+
+    #[cfg(portable_atomic_no_strict_provenance_atomic_ptr)]
+    #[inline(always)]
+    fn as_atomic_usize(&self) -> &AtomicUsize {
+        static_assert!(
+            core::mem::size_of::<AtomicPtr<()>>() == core::mem::size_of::<AtomicUsize>()
+        );
+        static_assert!(
+            core::mem::align_of::<AtomicPtr<()>>() == core::mem::align_of::<AtomicUsize>()
+        );
+        // SAFETY: AtomicPtr and AtomicUsize have the same layout, and both
+        // route through the same PSRAM dispatch above.
+        unsafe { &*(self as *const Self as *const AtomicUsize) }
+    }
+
+    #[inline]
+    pub(crate) const fn as_ptr(&self) -> *mut *mut T {
+        // SAFETY: Self is #[repr(transparent)] and internally
+        // UnsafeCell<*mut T>. See also the equivalent trick in
+        // src/imp/core_atomic.rs.
+        unsafe { (*(self as *const Self as *const UnsafeCell<*mut T>)).get() }
+    }
+}
+impl_default_bit_opts!(AtomicPtr, usize);
+
+// ---------------------------------------------------------------------------
+// AtomicInt
+
+macro_rules! atomic_int {
+    ($atomic_type:ident, $int_type:ident, $align:literal) => {
+        #[repr(transparent)]
+        pub(crate) struct $atomic_type {
+            inner: core::sync::atomic::$atomic_type,
+            _not_ref_unwind_safe: PhantomData<NotRefUnwindSafe>,
+        }
+        impl $atomic_type {
+            #[inline]
+            pub(crate) const fn new(v: $int_type) -> Self {
+                Self {
+                    inner: core::sync::atomic::$atomic_type::new(v),
+                    _not_ref_unwind_safe: PhantomData,
+                }
+            }
+            #[inline]
+            pub(crate) fn is_lock_free() -> bool {
+                Self::IS_ALWAYS_LOCK_FREE
+            }
+            // We cannot promise lock-freedom without knowing the address
+            // at compile time; RMWs on PSRAM take a critical section.
+            pub(crate) const IS_ALWAYS_LOCK_FREE: bool = false;
+
+            #[inline]
+            #[cfg_attr(any(debug_assertions, miri), track_caller)]
+            pub(crate) fn load(&self, order: Ordering) -> $int_type {
+                crate::utils::assert_load_ordering(order);
+                self.inner.load(order)
+            }
+            #[inline]
+            #[cfg_attr(any(debug_assertions, miri), track_caller)]
+            pub(crate) fn store(&self, val: $int_type, order: Ordering) {
+                crate::utils::assert_store_ordering(order);
+                self.inner.store(val, order);
+            }
+
+            #[inline]
+            #[cfg_attr(miri, track_caller)]
+            pub(crate) fn swap(&self, val: $int_type, order: Ordering) -> $int_type {
+                rmw!(self, self.inner.swap(val, order), |p| {
+                    let prev = core::ptr::read_volatile(p);
+                    core::ptr::write_volatile(p, val);
+                    prev
+                })
+            }
+
+            #[inline]
+            #[cfg_attr(any(debug_assertions, miri), track_caller)]
+            pub(crate) fn compare_exchange(
+                &self,
+                current: $int_type,
+                new: $int_type,
+                success: Ordering,
+                failure: Ordering,
+            ) -> Result<$int_type, $int_type> {
+                crate::utils::assert_compare_exchange_ordering(success, failure);
+                rmw!(self, self.inner.compare_exchange(current, new, success, failure), |p| {
+                    let prev = core::ptr::read_volatile(p);
+                    if prev == current {
+                        core::ptr::write_volatile(p, new);
+                        Ok(prev)
+                    } else {
+                        Err(prev)
+                    }
+                })
+            }
+            #[inline]
+            #[cfg_attr(any(debug_assertions, miri), track_caller)]
+            pub(crate) fn compare_exchange_weak(
+                &self,
+                current: $int_type,
+                new: $int_type,
+                success: Ordering,
+                failure: Ordering,
+            ) -> Result<$int_type, $int_type> {
+                crate::utils::assert_compare_exchange_ordering(success, failure);
+                rmw!(self, self.inner.compare_exchange_weak(current, new, success, failure), |p| {
+                    let prev = core::ptr::read_volatile(p);
+                    if prev == current {
+                        core::ptr::write_volatile(p, new);
+                        Ok(prev)
+                    } else {
+                        Err(prev)
+                    }
+                })
+            }
+
+            #[allow(dead_code)]
+            #[inline]
+            #[cfg_attr(miri, track_caller)]
+            fn fetch_update_<F>(&self, order: Ordering, mut f: F) -> $int_type
+            where
+                F: FnMut($int_type) -> $int_type,
+            {
+                let mut prev = self.load(Ordering::Relaxed);
+                loop {
+                    let next = f(prev);
+                    match self.compare_exchange_weak(prev, next, order, Ordering::Relaxed) {
+                        Ok(x) => return x,
+                        Err(next_prev) => prev = next_prev,
+                    }
+                }
+            }
+
+            // Arithmetic RMWs ------------------------------------------------
+            #[inline]
+            #[cfg_attr(miri, track_caller)]
+            pub(crate) fn fetch_add(&self, val: $int_type, order: Ordering) -> $int_type {
+                rmw!(self, self.inner.fetch_add(val, order), |p| {
+                    let prev = core::ptr::read_volatile(p);
+                    core::ptr::write_volatile(p, prev.wrapping_add(val));
+                    prev
+                })
+            }
+            #[inline]
+            #[cfg_attr(miri, track_caller)]
+            pub(crate) fn fetch_sub(&self, val: $int_type, order: Ordering) -> $int_type {
+                rmw!(self, self.inner.fetch_sub(val, order), |p| {
+                    let prev = core::ptr::read_volatile(p);
+                    core::ptr::write_volatile(p, prev.wrapping_sub(val));
+                    prev
+                })
+            }
+
+            // Bitwise RMWs ---------------------------------------------------
+            #[inline]
+            #[cfg_attr(miri, track_caller)]
+            pub(crate) fn fetch_and(&self, val: $int_type, order: Ordering) -> $int_type {
+                rmw!(self, self.inner.fetch_and(val, order), |p| {
+                    let prev = core::ptr::read_volatile(p);
+                    core::ptr::write_volatile(p, prev & val);
+                    prev
+                })
+            }
+            #[inline]
+            #[cfg_attr(miri, track_caller)]
+            pub(crate) fn fetch_nand(&self, val: $int_type, order: Ordering) -> $int_type {
+                rmw!(self, self.inner.fetch_nand(val, order), |p| {
+                    let prev = core::ptr::read_volatile(p);
+                    core::ptr::write_volatile(p, !(prev & val));
+                    prev
+                })
+            }
+            #[inline]
+            #[cfg_attr(miri, track_caller)]
+            pub(crate) fn fetch_or(&self, val: $int_type, order: Ordering) -> $int_type {
+                rmw!(self, self.inner.fetch_or(val, order), |p| {
+                    let prev = core::ptr::read_volatile(p);
+                    core::ptr::write_volatile(p, prev | val);
+                    prev
+                })
+            }
+            #[inline]
+            #[cfg_attr(miri, track_caller)]
+            pub(crate) fn fetch_xor(&self, val: $int_type, order: Ordering) -> $int_type {
+                rmw!(self, self.inner.fetch_xor(val, order), |p| {
+                    let prev = core::ptr::read_volatile(p);
+                    core::ptr::write_volatile(p, prev ^ val);
+                    prev
+                })
+            }
+
+            // fetch_max / fetch_min -----------------------------------------
+            //
+            // The PSRAM arm performs the whole read-compute-write inside a
+            // single critical section. std's native min/max atomics are
+            // always available on xtensa (stabilized in 1.45; xtensa MSRV
+            // is 1.81+).
+            #[inline]
+            #[cfg_attr(miri, track_caller)]
+            pub(crate) fn fetch_max(&self, val: $int_type, order: Ordering) -> $int_type {
+                rmw!(self, self.inner.fetch_max(val, order), |p| {
+                    let prev = core::ptr::read_volatile(p);
+                    core::ptr::write_volatile(p, core::cmp::max(prev, val));
+                    prev
+                })
+            }
+            #[inline]
+            #[cfg_attr(miri, track_caller)]
+            pub(crate) fn fetch_min(&self, val: $int_type, order: Ordering) -> $int_type {
+                rmw!(self, self.inner.fetch_min(val, order), |p| {
+                    let prev = core::ptr::read_volatile(p);
+                    core::ptr::write_volatile(p, core::cmp::min(prev, val));
+                    prev
+                })
+            }
+
+            // Unary RMWs ----------------------------------------------------
+            #[inline]
+            #[cfg_attr(miri, track_caller)]
+            pub(crate) fn fetch_not(&self, order: Ordering) -> $int_type {
+                self.fetch_xor(!0, order)
+            }
+            #[inline]
+            #[cfg_attr(miri, track_caller)]
+            pub(crate) fn fetch_neg(&self, order: Ordering) -> $int_type {
+                // `core::sync::atomic::*` has no native fetch_neg, so the
+                // SRAM path is a CAS loop. The PSRAM path does the negate
+                // inside a single critical section.
+                rmw!(self, self.fetch_update_(order, $int_type::wrapping_neg), |p| {
+                    let prev = core::ptr::read_volatile(p);
+                    core::ptr::write_volatile(p, prev.wrapping_neg());
+                    prev
+                })
+            }
+            #[inline]
+            #[cfg_attr(miri, track_caller)]
+            pub(crate) fn not(&self, order: Ordering) {
+                self.fetch_not(order);
+            }
+            #[inline]
+            #[cfg_attr(miri, track_caller)]
+            pub(crate) fn neg(&self, order: Ordering) {
+                self.fetch_neg(order);
+            }
+
+            #[inline]
+            pub(crate) const fn as_ptr(&self) -> *mut $int_type {
+                // SAFETY: Self is #[repr(transparent)] and internally
+                // UnsafeCell<$int_type>.
+                unsafe { (*(self as *const Self as *const UnsafeCell<$int_type>)).get() }
+            }
+        }
+        impl_default_no_fetch_ops!($atomic_type, $int_type);
+        impl_default_bit_opts!($atomic_type, $int_type);
+
+        // Force the requested alignment just like `core::sync::atomic::*`.
+        // #[repr(transparent)] inherits the inner alignment; the asserts
+        // document the expected layout.
+        #[allow(dead_code)]
+        const _: () = {
+            if core::mem::align_of::<$atomic_type>() < $align {
+                panic!(concat!(stringify!($atomic_type), " has smaller alignment than expected"));
+            }
+        };
+    };
+}
+
+atomic_int!(AtomicIsize, isize, 4);
+atomic_int!(AtomicUsize, usize, 4);
+atomic_int!(AtomicI8, i8, 1);
+atomic_int!(AtomicU8, u8, 1);
+atomic_int!(AtomicI16, i16, 2);
+atomic_int!(AtomicU16, u16, 2);
+atomic_int!(AtomicI32, i32, 4);
+atomic_int!(AtomicU32, u32, 4);
+
+// espidf Xtensa targets expose 64-bit atomics via libatomic; wrap those too.
+// On bare-metal xtensa targets `target_has_atomic = "64"` is false and these
+// types are not emitted. `cfg(target_has_atomic = ...)` stabilized in Rust
+// 1.60; xtensa MSRV is 1.81+ so `portable_atomic_no_cfg_target_has_atomic`
+// is never set in this module.
+#[cfg(any(
+    target_has_atomic = "64",
+    not(any(target_pointer_width = "16", target_pointer_width = "32")),
+))]
+items!({
+    atomic_int!(AtomicI64, i64, 8);
+    atomic_int!(AtomicU64, u64, 8);
+});

--- a/tests/asm-test/asm/portable-atomic/xtensa_esp32s2.asm
+++ b/tests/asm-test/asm/portable-atomic/xtensa_esp32s2.asm
@@ -1,3963 +1,196 @@
-asm_test::load::bool::relaxed:
-        entry             a1, 32
-        l8ui              a8, a2, 0
-        movi.n            a2, 0
-        beq               a8, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::load::bool::acquire:
-        entry             a1, 32
-        l8ui              a8, a2, 0
-        movi.n            a2, 0
-        beq               a8, a2, 0f
-        movi.n            a2, 1
-0:
-        memw
-        retw.n
-
-asm_test::load::bool::seqcst:
-        entry             a1, 32
-        l8ui              a8, a2, 0
-        movi.n            a2, 0
-        beq               a8, a2, 0f
-        movi.n            a2, 1
-0:
-        memw
-        retw.n
-
-asm_test::load::u8::relaxed:
-        entry             a1, 32
-        l8ui              a2, a2, 0
-        retw.n
-
-asm_test::load::u8::acquire:
-        entry             a1, 32
-        l8ui              a2, a2, 0
-        memw
-        retw.n
-
-asm_test::load::u8::seqcst:
-        entry             a1, 32
-        l8ui              a2, a2, 0
-        memw
-        retw.n
-
-asm_test::load::u16::relaxed:
-        entry             a1, 32
-        l16ui             a2, a2, 0
-        retw.n
-
-asm_test::load::u16::acquire:
-        entry             a1, 32
-        l16ui             a2, a2, 0
-        memw
-        retw.n
-
-asm_test::load::u16::seqcst:
-        entry             a1, 32
-        l16ui             a2, a2, 0
-        memw
-        retw.n
-
-asm_test::load::u32::relaxed:
-        entry             a1, 32
-        l32i.n            a2, a2, 0
-        retw.n
-
-asm_test::load::u32::acquire:
-        entry             a1, 32
-        l32i.n            a2, a2, 0
-        memw
-        retw.n
-
-asm_test::load::u32::seqcst:
-        entry             a1, 32
-        l32i.n            a2, a2, 0
-        memw
-        retw.n
-
-asm_test::store::bool::relaxed:
-        entry             a1, 32
-        s8i               a3, a2, 0
-        retw.n
-
-asm_test::store::bool::release:
-        entry             a1, 32
-        memw
-        s8i               a3, a2, 0
-        retw.n
-
-asm_test::store::bool::seqcst:
-        entry             a1, 32
-        memw
-        s8i               a3, a2, 0
-        memw
-        retw.n
-
-asm_test::store::u8::relaxed:
-        entry             a1, 32
-        s8i               a3, a2, 0
-        retw.n
-
-asm_test::store::u8::release:
-        entry             a1, 32
-        memw
-        s8i               a3, a2, 0
-        retw.n
-
-asm_test::store::u8::seqcst:
-        entry             a1, 32
-        memw
-        s8i               a3, a2, 0
-        memw
-        retw.n
-
-asm_test::store::u16::relaxed:
-        entry             a1, 32
-        s16i              a3, a2, 0
-        retw.n
-
-asm_test::store::u16::release:
-        entry             a1, 32
-        memw
-        s16i              a3, a2, 0
-        retw.n
-
-asm_test::store::u16::seqcst:
-        entry             a1, 32
-        memw
-        s16i              a3, a2, 0
-        memw
-        retw.n
-
-asm_test::store::u32::relaxed:
-        entry             a1, 32
-        s32i.n            a3, a2, 0
-        retw.n
-
-asm_test::store::u32::release:
-        entry             a1, 32
-        memw
-        s32i.n            a3, a2, 0
-        retw.n
-
-asm_test::store::u32::seqcst:
-        entry             a1, 32
-        memw
-        s32i.n            a3, a2, 0
-        memw
-        retw.n
-
-asm_test::swap::bool::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        s8i               a3, a2, 0
-        wsr.ps            a8
-        rsync
-        movi.n            a2, 0
-        beq               a9, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::swap::bool::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        s8i               a3, a2, 0
-        wsr.ps            a8
-        rsync
-        movi.n            a2, 0
-        beq               a9, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::swap::bool::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        s8i               a3, a2, 0
-        wsr.ps            a8
-        rsync
-        movi.n            a2, 0
-        beq               a9, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::swap::bool::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        s8i               a3, a2, 0
-        wsr.ps            a8
-        rsync
-        movi.n            a2, 0
-        beq               a9, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::swap::bool::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        s8i               a3, a2, 0
-        wsr.ps            a8
-        rsync
-        movi.n            a2, 0
-        beq               a9, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::swap::u8::relaxed:
+asm_test::fetch_nand::u8::acqrel:
         entry             a1, 32
         rsil              a9, 15
         l8ui              a8, a2, 0
-        s8i               a3, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::swap::u8::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        s8i               a3, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::swap::u8::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        s8i               a3, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::swap::u8::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        s8i               a3, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::swap::u8::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        s8i               a3, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::swap::u16::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        s16i              a3, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::swap::u16::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        s16i              a3, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::swap::u16::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        s16i              a3, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::swap::u16::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        s16i              a3, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::swap::u16::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        s16i              a3, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::swap::u32::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        s32i.n            a3, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::swap::u32::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        s32i.n            a3, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::swap::u32::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        s32i.n            a3, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::swap::u32::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        s32i.n            a3, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::swap::u32::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        s32i.n            a3, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::compare_exchange::bool::relaxed_relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange::bool::relaxed_acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange::bool::relaxed_seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange::bool::acquire_relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange::bool::acquire_acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange::bool::acquire_seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange::bool::release_relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange::bool::release_acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange::bool::release_seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange::bool::acqrel_relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange::bool::acqrel_acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange::bool::acqrel_seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange::bool::seqcst_relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange::bool::seqcst_acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange::bool::seqcst_seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange::u8::relaxed_relaxed:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange::u8::relaxed_acquire:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange::u8::relaxed_seqcst:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange::u8::acquire_relaxed:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange::u8::acquire_acquire:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange::u8::acquire_seqcst:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange::u8::release_relaxed:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange::u8::release_acquire:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange::u8::release_seqcst:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange::u8::acqrel_relaxed:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange::u8::acqrel_acquire:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange::u8::acqrel_seqcst:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange::u8::seqcst_relaxed:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange::u8::seqcst_acquire:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange::u8::seqcst_seqcst:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-.literal.asm_test::compare_exchange::u16::relaxed_relaxed:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange::u16::relaxed_relaxed:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::relaxed_relaxed+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange::u16::relaxed_acquire:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange::u16::relaxed_acquire:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::relaxed_acquire+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange::u16::relaxed_seqcst:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange::u16::relaxed_seqcst:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::relaxed_seqcst+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange::u16::acquire_relaxed:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange::u16::acquire_relaxed:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::acquire_relaxed+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange::u16::acquire_acquire:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange::u16::acquire_acquire:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::acquire_acquire+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange::u16::acquire_seqcst:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange::u16::acquire_seqcst:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::acquire_seqcst+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange::u16::release_relaxed:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange::u16::release_relaxed:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::release_relaxed+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange::u16::release_acquire:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange::u16::release_acquire:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::release_acquire+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange::u16::release_seqcst:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange::u16::release_seqcst:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::release_seqcst+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange::u16::acqrel_relaxed:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange::u16::acqrel_relaxed:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::acqrel_relaxed+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange::u16::acqrel_acquire:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange::u16::acqrel_acquire:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::acqrel_acquire+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange::u16::acqrel_seqcst:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange::u16::acqrel_seqcst:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::acqrel_seqcst+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange::u16::seqcst_relaxed:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange::u16::seqcst_relaxed:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::seqcst_relaxed+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange::u16::seqcst_acquire:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange::u16::seqcst_acquire:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::seqcst_acquire+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange::u16::seqcst_seqcst:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange::u16::seqcst_seqcst:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::seqcst_seqcst+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::compare_exchange::u32::relaxed_relaxed:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange::u32::relaxed_acquire:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange::u32::relaxed_seqcst:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange::u32::acquire_relaxed:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange::u32::acquire_acquire:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange::u32::acquire_seqcst:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange::u32::release_relaxed:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange::u32::release_acquire:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange::u32::release_seqcst:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange::u32::acqrel_relaxed:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange::u32::acqrel_acquire:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange::u32::acqrel_seqcst:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange::u32::seqcst_relaxed:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange::u32::seqcst_acquire:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange::u32::seqcst_seqcst:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange_weak::bool::relaxed_relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange_weak::bool::relaxed_acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange_weak::bool::relaxed_seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange_weak::bool::acquire_relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange_weak::bool::acquire_acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange_weak::bool::acquire_seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange_weak::bool::release_relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange_weak::bool::release_acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange_weak::bool::release_seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange_weak::bool::acqrel_relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange_weak::bool::acqrel_acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange_weak::bool::acqrel_seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange_weak::bool::seqcst_relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange_weak::bool::seqcst_acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange_weak::bool::seqcst_seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        bne               a9, a3, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a8
-        rsync
-        movi.n            a10, 0
-        movi.n            a8, 1
-        mov.n             a2, a8
-        beq               a9, a3, 2f
-        beq               a9, a10, 3f
-1:
-        mov.n             a3, a8
-        retw.n
-2:
-        mov.n             a2, a10
-        bne               a9, a10, 1b
-3:
-        mov.n             a8, a10
-        mov.n             a3, a8
-        retw.n
-
-asm_test::compare_exchange_weak::u8::relaxed_relaxed:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange_weak::u8::relaxed_acquire:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange_weak::u8::relaxed_seqcst:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange_weak::u8::acquire_relaxed:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange_weak::u8::acquire_acquire:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange_weak::u8::acquire_seqcst:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange_weak::u8::release_relaxed:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange_weak::u8::release_acquire:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange_weak::u8::release_seqcst:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange_weak::u8::acqrel_relaxed:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange_weak::u8::acqrel_acquire:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange_weak::u8::acqrel_seqcst:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange_weak::u8::seqcst_relaxed:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange_weak::u8::seqcst_acquire:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-asm_test::compare_exchange_weak::u8::seqcst_seqcst:
-        entry             a1, 32
-        movi              a8, 255
-        and               a8, a3, a8
-        rsil              a9, 15
-        l8ui              a3, a2, 0
-        bne               a3, a8, 0f
-        s8i               a4, a2, 0
-0:
-        wsr.ps            a9
-        rsync
-        bne               a3, a8, 1f
-        movi.n            a2, 0
-        retw.n
-1:
-        movi.n            a2, 1
-        retw.n
-
-.literal.asm_test::compare_exchange_weak::u16::relaxed_relaxed:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange_weak::u16::relaxed_relaxed:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::relaxed_relaxed+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange_weak::u16::relaxed_acquire:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange_weak::u16::relaxed_acquire:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::relaxed_acquire+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange_weak::u16::relaxed_seqcst:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange_weak::u16::relaxed_seqcst:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::relaxed_seqcst+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange_weak::u16::acquire_relaxed:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange_weak::u16::acquire_relaxed:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::acquire_relaxed+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange_weak::u16::acquire_acquire:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange_weak::u16::acquire_acquire:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::acquire_acquire+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange_weak::u16::acquire_seqcst:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange_weak::u16::acquire_seqcst:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::acquire_seqcst+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange_weak::u16::release_relaxed:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange_weak::u16::release_relaxed:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::release_relaxed+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange_weak::u16::release_acquire:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange_weak::u16::release_acquire:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::release_acquire+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange_weak::u16::release_seqcst:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange_weak::u16::release_seqcst:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::release_seqcst+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange_weak::u16::acqrel_relaxed:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange_weak::u16::acqrel_relaxed:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::acqrel_relaxed+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange_weak::u16::acqrel_acquire:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange_weak::u16::acqrel_acquire:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::acqrel_acquire+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange_weak::u16::acqrel_seqcst:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange_weak::u16::acqrel_seqcst:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::acqrel_seqcst+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange_weak::u16::seqcst_relaxed:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange_weak::u16::seqcst_relaxed:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::seqcst_relaxed+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange_weak::u16::seqcst_acquire:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange_weak::u16::seqcst_acquire:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::seqcst_acquire+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-.literal.asm_test::compare_exchange_weak::u16::seqcst_seqcst:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::compare_exchange_weak::u16::seqcst_seqcst:
-0:
-        entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::seqcst_seqcst+0x81004136>)
-        and               a9, a3, a8
-        rsil              a8, 15
-        l16ui             a3, a2, 0
-        bne               a3, a9, 1f
-        s16i              a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-1:
-        movi.n            a2, 1
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::compare_exchange_weak::u32::relaxed_relaxed:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange_weak::u32::relaxed_acquire:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange_weak::u32::relaxed_seqcst:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange_weak::u32::acquire_relaxed:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange_weak::u32::acquire_acquire:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange_weak::u32::acquire_seqcst:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange_weak::u32::release_relaxed:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange_weak::u32::release_acquire:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange_weak::u32::release_seqcst:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange_weak::u32::acqrel_relaxed:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange_weak::u32::acqrel_acquire:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange_weak::u32::acqrel_seqcst:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange_weak::u32::seqcst_relaxed:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange_weak::u32::seqcst_acquire:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::compare_exchange_weak::u32::seqcst_seqcst:
-        entry             a1, 32
-        mov.n             a8, a3
-        rsil              a9, 15
-        l32i.n            a3, a2, 0
-        bne               a3, a8, 0f
-        s32i.n            a4, a2, 0
-        movi.n            a2, 0
-        wsr.ps            a9
-        rsync
-        retw.n
-0:
-        movi.n            a2, 1
-        wsr.ps            a9
-        rsync
-        retw.n
-
-asm_test::fetch_add::u8::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        add.n             a10, a8, a3
+        and               a10, a8, a3
+        movi.n            a11, -1
+        xor               a10, a10, a11
         s8i               a10, a2, 0
         wsr.ps            a9
         rsync
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_add::u8::acquire:
+asm_test::fetch_nand::u8::seqcst:
         entry             a1, 32
         rsil              a9, 15
         l8ui              a8, a2, 0
-        add.n             a10, a8, a3
+        and               a10, a8, a3
+        movi.n            a11, -1
+        xor               a10, a10, a11
         s8i               a10, a2, 0
         wsr.ps            a9
         rsync
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_add::u8::release:
+asm_test::fetch_nand::u8::acquire:
         entry             a1, 32
         rsil              a9, 15
         l8ui              a8, a2, 0
-        add.n             a10, a8, a3
+        and               a10, a8, a3
+        movi.n            a11, -1
+        xor               a10, a10, a11
         s8i               a10, a2, 0
         wsr.ps            a9
         rsync
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_add::u8::acqrel:
+asm_test::fetch_nand::u8::relaxed:
         entry             a1, 32
         rsil              a9, 15
         l8ui              a8, a2, 0
-        add.n             a10, a8, a3
+        and               a10, a8, a3
+        movi.n            a11, -1
+        xor               a10, a10, a11
         s8i               a10, a2, 0
         wsr.ps            a9
         rsync
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_add::u8::seqcst:
+asm_test::fetch_nand::u8::release:
         entry             a1, 32
         rsil              a9, 15
         l8ui              a8, a2, 0
-        add.n             a10, a8, a3
+        and               a10, a8, a3
+        movi.n            a11, -1
+        xor               a10, a10, a11
         s8i               a10, a2, 0
         wsr.ps            a9
         rsync
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_add::u16::relaxed:
+asm_test::fetch_nand::u16::acqrel:
         entry             a1, 32
         rsil              a9, 15
         l16ui             a8, a2, 0
-        add.n             a10, a8, a3
+        and               a10, a8, a3
+        movi.n            a11, -1
+        xor               a10, a10, a11
         s16i              a10, a2, 0
         wsr.ps            a9
         rsync
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_add::u16::acquire:
+asm_test::fetch_nand::u16::seqcst:
         entry             a1, 32
         rsil              a9, 15
         l16ui             a8, a2, 0
-        add.n             a10, a8, a3
+        and               a10, a8, a3
+        movi.n            a11, -1
+        xor               a10, a10, a11
         s16i              a10, a2, 0
         wsr.ps            a9
         rsync
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_add::u16::release:
+asm_test::fetch_nand::u16::acquire:
         entry             a1, 32
         rsil              a9, 15
         l16ui             a8, a2, 0
-        add.n             a10, a8, a3
+        and               a10, a8, a3
+        movi.n            a11, -1
+        xor               a10, a10, a11
         s16i              a10, a2, 0
         wsr.ps            a9
         rsync
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_add::u16::acqrel:
+asm_test::fetch_nand::u16::relaxed:
         entry             a1, 32
         rsil              a9, 15
         l16ui             a8, a2, 0
-        add.n             a10, a8, a3
+        and               a10, a8, a3
+        movi.n            a11, -1
+        xor               a10, a10, a11
         s16i              a10, a2, 0
         wsr.ps            a9
         rsync
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_add::u16::seqcst:
+asm_test::fetch_nand::u16::release:
         entry             a1, 32
         rsil              a9, 15
         l16ui             a8, a2, 0
-        add.n             a10, a8, a3
+        and               a10, a8, a3
+        movi.n            a11, -1
+        xor               a10, a10, a11
         s16i              a10, a2, 0
         wsr.ps            a9
         rsync
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_add::u32::relaxed:
+asm_test::fetch_nand::u32::acqrel:
         entry             a1, 32
         rsil              a9, 15
         l32i.n            a8, a2, 0
-        add.n             a10, a8, a3
+        and               a10, a8, a3
+        movi.n            a11, -1
+        xor               a10, a10, a11
         s32i.n            a10, a2, 0
         wsr.ps            a9
         rsync
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_add::u32::acquire:
+asm_test::fetch_nand::u32::seqcst:
         entry             a1, 32
         rsil              a9, 15
         l32i.n            a8, a2, 0
-        add.n             a10, a8, a3
+        and               a10, a8, a3
+        movi.n            a11, -1
+        xor               a10, a10, a11
         s32i.n            a10, a2, 0
         wsr.ps            a9
         rsync
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_add::u32::release:
+asm_test::fetch_nand::u32::acquire:
         entry             a1, 32
         rsil              a9, 15
         l32i.n            a8, a2, 0
-        add.n             a10, a8, a3
+        and               a10, a8, a3
+        movi.n            a11, -1
+        xor               a10, a10, a11
         s32i.n            a10, a2, 0
         wsr.ps            a9
         rsync
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_add::u32::acqrel:
+asm_test::fetch_nand::u32::relaxed:
         entry             a1, 32
         rsil              a9, 15
         l32i.n            a8, a2, 0
-        add.n             a10, a8, a3
+        and               a10, a8, a3
+        movi.n            a11, -1
+        xor               a10, a10, a11
         s32i.n            a10, a2, 0
         wsr.ps            a9
         rsync
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_add::u32::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        add.n             a10, a8, a3
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::add::u8::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        add.n             a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::add::u8::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        add.n             a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::add::u8::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        add.n             a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::add::u8::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        add.n             a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::add::u8::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        add.n             a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::add::u16::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        add.n             a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::add::u16::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        add.n             a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::add::u16::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        add.n             a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::add::u16::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        add.n             a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::add::u16::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        add.n             a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::add::u32::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        add.n             a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::add::u32::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        add.n             a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::add::u32::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        add.n             a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::add::u32::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        add.n             a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::add::u32::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        add.n             a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::fetch_sub::u8::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        sub               a10, a8, a3
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_sub::u8::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        sub               a10, a8, a3
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_sub::u8::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        sub               a10, a8, a3
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_sub::u8::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        sub               a10, a8, a3
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_sub::u8::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        sub               a10, a8, a3
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_sub::u16::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        sub               a10, a8, a3
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_sub::u16::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        sub               a10, a8, a3
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_sub::u16::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        sub               a10, a8, a3
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_sub::u16::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        sub               a10, a8, a3
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_sub::u16::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        sub               a10, a8, a3
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_sub::u32::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        sub               a10, a8, a3
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_sub::u32::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        sub               a10, a8, a3
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_sub::u32::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        sub               a10, a8, a3
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_sub::u32::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        sub               a10, a8, a3
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_sub::u32::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        sub               a10, a8, a3
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::sub::u8::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        sub               a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::sub::u8::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        sub               a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::sub::u8::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        sub               a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::sub::u8::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        sub               a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::sub::u8::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        sub               a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::sub::u16::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        sub               a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::sub::u16::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        sub               a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::sub::u16::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        sub               a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::sub::u16::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        sub               a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::sub::u16::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        sub               a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::sub::u32::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        sub               a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::sub::u32::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        sub               a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::sub::u32::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        sub               a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::sub::u32::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        sub               a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::sub::u32::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        sub               a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::fetch_and::bool::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        and               a10, a3, a9
-        s8i               a10, a2, 0
-        wsr.ps            a8
-        rsync
-        movi.n            a2, 0
-        beq               a9, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::fetch_and::bool::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        and               a10, a3, a9
-        s8i               a10, a2, 0
-        wsr.ps            a8
-        rsync
-        movi.n            a2, 0
-        beq               a9, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::fetch_and::bool::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        and               a10, a3, a9
-        s8i               a10, a2, 0
-        wsr.ps            a8
-        rsync
-        movi.n            a2, 0
-        beq               a9, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::fetch_and::bool::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        and               a10, a3, a9
-        s8i               a10, a2, 0
-        wsr.ps            a8
-        rsync
-        movi.n            a2, 0
-        beq               a9, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::fetch_and::bool::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        and               a10, a3, a9
-        s8i               a10, a2, 0
-        wsr.ps            a8
-        rsync
-        movi.n            a2, 0
-        beq               a9, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::fetch_and::u8::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        and               a10, a8, a3
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_and::u8::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        and               a10, a8, a3
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_and::u8::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        and               a10, a8, a3
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_and::u8::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        and               a10, a8, a3
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_and::u8::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        and               a10, a8, a3
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_and::u16::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        and               a10, a8, a3
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_and::u16::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        and               a10, a8, a3
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_and::u16::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        and               a10, a8, a3
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_and::u16::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        and               a10, a8, a3
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_and::u16::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        and               a10, a8, a3
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_and::u32::relaxed:
+asm_test::fetch_nand::u32::release:
         entry             a1, 32
         rsil              a9, 15
         l32i.n            a8, a2, 0
         and               a10, a8, a3
+        movi.n            a11, -1
+        xor               a10, a10, a11
         s32i.n            a10, a2, 0
         wsr.ps            a9
         rsync
         mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_and::u32::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        and               a10, a8, a3
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_and::u32::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        and               a10, a8, a3
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_and::u32::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        and               a10, a8, a3
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_and::u32::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        and               a10, a8, a3
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::and::u8::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        and               a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::and::u8::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        and               a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::and::u8::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        and               a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::and::u8::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        and               a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::and::u8::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        and               a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::and::u16::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        and               a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::and::u16::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        and               a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::and::u16::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        and               a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::and::u16::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        and               a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::and::u16::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        and               a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::and::u32::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        and               a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::and::u32::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        and               a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::and::u32::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        and               a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::and::u32::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        and               a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::and::u32::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        and               a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::fetch_nand::bool::relaxed:
-        entry             a1, 32
-        mov.n             a8, a2
-        rsil              a10, 15
-        l8ui              a9, a8, 0
-        movi.n            a2, 1
-        beqz              a3, 0f
-        movi.n            a11, 1
-        xor               a11, a9, a11
-        s8i               a11, a8, 0
-        wsr.ps            a10
-        rsync
-        movi              a8, 255
-        and               a9, a9, a8
-        movi.n            a8, 0
-        beq               a9, a8, 1f
-        j                 2f
-0:
-        s8i               a2, a8, 0
-        wsr.ps            a10
-        rsync
-        movi              a8, 255
-        and               a9, a9, a8
-        movi.n            a8, 0
-        bne               a9, a8, 2f
-1:
-        mov.n             a2, a8
-2:
-        retw.n
-
-asm_test::fetch_nand::bool::acquire:
-        entry             a1, 32
-        mov.n             a8, a2
-        rsil              a10, 15
-        l8ui              a9, a8, 0
-        movi.n            a2, 1
-        beqz              a3, 0f
-        movi.n            a11, 1
-        xor               a11, a9, a11
-        s8i               a11, a8, 0
-        wsr.ps            a10
-        rsync
-        movi              a8, 255
-        and               a9, a9, a8
-        movi.n            a8, 0
-        beq               a9, a8, 1f
-        j                 2f
-0:
-        s8i               a2, a8, 0
-        wsr.ps            a10
-        rsync
-        movi              a8, 255
-        and               a9, a9, a8
-        movi.n            a8, 0
-        bne               a9, a8, 2f
-1:
-        mov.n             a2, a8
-2:
-        retw.n
-
-asm_test::fetch_nand::bool::release:
-        entry             a1, 32
-        mov.n             a8, a2
-        rsil              a10, 15
-        l8ui              a9, a8, 0
-        movi.n            a2, 1
-        beqz              a3, 0f
-        movi.n            a11, 1
-        xor               a11, a9, a11
-        s8i               a11, a8, 0
-        wsr.ps            a10
-        rsync
-        movi              a8, 255
-        and               a9, a9, a8
-        movi.n            a8, 0
-        beq               a9, a8, 1f
-        j                 2f
-0:
-        s8i               a2, a8, 0
-        wsr.ps            a10
-        rsync
-        movi              a8, 255
-        and               a9, a9, a8
-        movi.n            a8, 0
-        bne               a9, a8, 2f
-1:
-        mov.n             a2, a8
-2:
         retw.n
 
 asm_test::fetch_nand::bool::acqrel:
@@ -4020,1943 +253,94 @@ asm_test::fetch_nand::bool::seqcst:
 2:
         retw.n
 
-asm_test::fetch_nand::u8::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        and               a10, a8, a3
-        movi.n            a11, -1
-        xor               a10, a10, a11
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_nand::u8::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        and               a10, a8, a3
-        movi.n            a11, -1
-        xor               a10, a10, a11
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_nand::u8::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        and               a10, a8, a3
-        movi.n            a11, -1
-        xor               a10, a10, a11
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_nand::u8::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        and               a10, a8, a3
-        movi.n            a11, -1
-        xor               a10, a10, a11
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_nand::u8::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        and               a10, a8, a3
-        movi.n            a11, -1
-        xor               a10, a10, a11
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_nand::u16::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        and               a10, a8, a3
-        movi.n            a11, -1
-        xor               a10, a10, a11
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_nand::u16::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        and               a10, a8, a3
-        movi.n            a11, -1
-        xor               a10, a10, a11
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_nand::u16::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        and               a10, a8, a3
-        movi.n            a11, -1
-        xor               a10, a10, a11
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_nand::u16::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        and               a10, a8, a3
-        movi.n            a11, -1
-        xor               a10, a10, a11
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_nand::u16::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        and               a10, a8, a3
-        movi.n            a11, -1
-        xor               a10, a10, a11
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_nand::u32::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        and               a10, a8, a3
-        movi.n            a11, -1
-        xor               a10, a10, a11
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_nand::u32::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        and               a10, a8, a3
-        movi.n            a11, -1
-        xor               a10, a10, a11
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_nand::u32::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        and               a10, a8, a3
-        movi.n            a11, -1
-        xor               a10, a10, a11
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_nand::u32::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        and               a10, a8, a3
-        movi.n            a11, -1
-        xor               a10, a10, a11
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_nand::u32::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        and               a10, a8, a3
-        movi.n            a11, -1
-        xor               a10, a10, a11
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_or::bool::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        or                a10, a9, a3
-        s8i               a10, a2, 0
-        wsr.ps            a8
-        rsync
-        movi.n            a2, 0
-        beq               a9, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::fetch_or::bool::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        or                a10, a9, a3
-        s8i               a10, a2, 0
-        wsr.ps            a8
-        rsync
-        movi.n            a2, 0
-        beq               a9, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::fetch_or::bool::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        or                a10, a9, a3
-        s8i               a10, a2, 0
-        wsr.ps            a8
-        rsync
-        movi.n            a2, 0
-        beq               a9, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::fetch_or::bool::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        or                a10, a9, a3
-        s8i               a10, a2, 0
-        wsr.ps            a8
-        rsync
-        movi.n            a2, 0
-        beq               a9, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::fetch_or::bool::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        or                a10, a9, a3
-        s8i               a10, a2, 0
-        wsr.ps            a8
-        rsync
-        movi.n            a2, 0
-        beq               a9, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::fetch_or::u8::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        or                a10, a8, a3
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_or::u8::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        or                a10, a8, a3
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_or::u8::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        or                a10, a8, a3
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_or::u8::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        or                a10, a8, a3
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_or::u8::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        or                a10, a8, a3
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_or::u16::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        or                a10, a8, a3
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_or::u16::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        or                a10, a8, a3
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_or::u16::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        or                a10, a8, a3
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_or::u16::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        or                a10, a8, a3
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_or::u16::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        or                a10, a8, a3
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_or::u32::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        or                a10, a8, a3
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_or::u32::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        or                a10, a8, a3
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_or::u32::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        or                a10, a8, a3
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_or::u32::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        or                a10, a8, a3
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_or::u32::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        or                a10, a8, a3
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::or::u8::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        or                a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::or::u8::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        or                a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::or::u8::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        or                a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::or::u8::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        or                a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::or::u8::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        or                a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::or::u16::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        or                a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::or::u16::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        or                a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::or::u16::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        or                a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::or::u16::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        or                a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::or::u16::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        or                a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::or::u32::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        or                a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::or::u32::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        or                a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::or::u32::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        or                a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::or::u32::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        or                a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::or::u32::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        or                a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::fetch_xor::bool::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        xor               a10, a9, a3
-        s8i               a10, a2, 0
-        wsr.ps            a8
-        rsync
-        movi.n            a2, 0
-        beq               a9, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::fetch_xor::bool::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        xor               a10, a9, a3
-        s8i               a10, a2, 0
-        wsr.ps            a8
-        rsync
-        movi.n            a2, 0
-        beq               a9, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::fetch_xor::bool::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        xor               a10, a9, a3
-        s8i               a10, a2, 0
-        wsr.ps            a8
-        rsync
-        movi.n            a2, 0
-        beq               a9, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::fetch_xor::bool::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        xor               a10, a9, a3
-        s8i               a10, a2, 0
-        wsr.ps            a8
-        rsync
-        movi.n            a2, 0
-        beq               a9, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::fetch_xor::bool::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        xor               a10, a9, a3
-        s8i               a10, a2, 0
-        wsr.ps            a8
-        rsync
-        movi.n            a2, 0
-        beq               a9, a2, 0f
-        movi.n            a2, 1
-0:
-        retw.n
-
-asm_test::fetch_xor::u8::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        xor               a10, a8, a3
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_xor::u8::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        xor               a10, a8, a3
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_xor::u8::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        xor               a10, a8, a3
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_xor::u8::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        xor               a10, a8, a3
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_xor::u8::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        xor               a10, a8, a3
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_xor::u16::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        xor               a10, a8, a3
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_xor::u16::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        xor               a10, a8, a3
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_xor::u16::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        xor               a10, a8, a3
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_xor::u16::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        xor               a10, a8, a3
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_xor::u16::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        xor               a10, a8, a3
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_xor::u32::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        xor               a10, a8, a3
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_xor::u32::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        xor               a10, a8, a3
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_xor::u32::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        xor               a10, a8, a3
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_xor::u32::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        xor               a10, a8, a3
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_xor::u32::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        xor               a10, a8, a3
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::xor::u8::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        xor               a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::xor::u8::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        xor               a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::xor::u8::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        xor               a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::xor::u8::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        xor               a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::xor::u8::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        xor               a9, a9, a3
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::xor::u16::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        xor               a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::xor::u16::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        xor               a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::xor::u16::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        xor               a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::xor::u16::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        xor               a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::xor::u16::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        xor               a9, a9, a3
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::xor::u32::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        xor               a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::xor::u32::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        xor               a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::xor::u32::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        xor               a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::xor::u32::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        xor               a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::xor::u32::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        xor               a9, a9, a3
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::fetch_not::bool::relaxed:
+asm_test::fetch_nand::bool::acquire:
         entry             a1, 32
         mov.n             a8, a2
-        rsil              a9, 15
-        l8ui              a10, a8, 0
-        movi.n            a2, 1
-        xor               a11, a10, a2
-        s8i               a11, a8, 0
-        wsr.ps            a9
-        rsync
-        movi.n            a8, 0
-        bne               a10, a8, 0f
-        mov.n             a2, a8
-0:
-        retw.n
-
-asm_test::fetch_not::bool::acquire:
-        entry             a1, 32
-        mov.n             a8, a2
-        rsil              a9, 15
-        l8ui              a10, a8, 0
-        movi.n            a2, 1
-        xor               a11, a10, a2
-        s8i               a11, a8, 0
-        wsr.ps            a9
-        rsync
-        movi.n            a8, 0
-        bne               a10, a8, 0f
-        mov.n             a2, a8
-0:
-        retw.n
-
-asm_test::fetch_not::bool::release:
-        entry             a1, 32
-        mov.n             a8, a2
-        rsil              a9, 15
-        l8ui              a10, a8, 0
-        movi.n            a2, 1
-        xor               a11, a10, a2
-        s8i               a11, a8, 0
-        wsr.ps            a9
-        rsync
-        movi.n            a8, 0
-        bne               a10, a8, 0f
-        mov.n             a2, a8
-0:
-        retw.n
-
-asm_test::fetch_not::bool::acqrel:
-        entry             a1, 32
-        mov.n             a8, a2
-        rsil              a9, 15
-        l8ui              a10, a8, 0
-        movi.n            a2, 1
-        xor               a11, a10, a2
-        s8i               a11, a8, 0
-        wsr.ps            a9
-        rsync
-        movi.n            a8, 0
-        bne               a10, a8, 0f
-        mov.n             a2, a8
-0:
-        retw.n
-
-asm_test::fetch_not::bool::seqcst:
-        entry             a1, 32
-        mov.n             a8, a2
-        rsil              a9, 15
-        l8ui              a10, a8, 0
-        movi.n            a2, 1
-        xor               a11, a10, a2
-        s8i               a11, a8, 0
-        wsr.ps            a9
-        rsync
-        movi.n            a8, 0
-        bne               a10, a8, 0f
-        mov.n             a2, a8
-0:
-        retw.n
-
-asm_test::fetch_not::u8::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        movi.n            a10, -1
-        xor               a10, a8, a10
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_not::u8::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        movi.n            a10, -1
-        xor               a10, a8, a10
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_not::u8::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        movi.n            a10, -1
-        xor               a10, a8, a10
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_not::u8::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        movi.n            a10, -1
-        xor               a10, a8, a10
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_not::u8::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        movi.n            a10, -1
-        xor               a10, a8, a10
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_not::u16::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        movi.n            a10, -1
-        xor               a10, a8, a10
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_not::u16::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        movi.n            a10, -1
-        xor               a10, a8, a10
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_not::u16::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        movi.n            a10, -1
-        xor               a10, a8, a10
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_not::u16::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        movi.n            a10, -1
-        xor               a10, a8, a10
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_not::u16::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        movi.n            a10, -1
-        xor               a10, a8, a10
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_not::u32::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        movi.n            a10, -1
-        xor               a10, a8, a10
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_not::u32::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        movi.n            a10, -1
-        xor               a10, a8, a10
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_not::u32::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        movi.n            a10, -1
-        xor               a10, a8, a10
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_not::u32::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        movi.n            a10, -1
-        xor               a10, a8, a10
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_not::u32::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        movi.n            a10, -1
-        xor               a10, a8, a10
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::not::u8::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        movi.n            a10, -1
-        xor               a9, a9, a10
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::not::u8::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        movi.n            a10, -1
-        xor               a9, a9, a10
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::not::u8::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        movi.n            a10, -1
-        xor               a9, a9, a10
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::not::u8::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        movi.n            a10, -1
-        xor               a9, a9, a10
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::not::u8::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        movi.n            a10, -1
-        xor               a9, a9, a10
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::not::u16::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        movi.n            a10, -1
-        xor               a9, a9, a10
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::not::u16::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        movi.n            a10, -1
-        xor               a9, a9, a10
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::not::u16::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        movi.n            a10, -1
-        xor               a9, a9, a10
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::not::u16::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        movi.n            a10, -1
-        xor               a9, a9, a10
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::not::u16::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        movi.n            a10, -1
-        xor               a9, a9, a10
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::not::u32::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        movi.n            a10, -1
-        xor               a9, a9, a10
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::not::u32::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        movi.n            a10, -1
-        xor               a9, a9, a10
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::not::u32::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        movi.n            a10, -1
-        xor               a9, a9, a10
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::not::u32::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        movi.n            a10, -1
-        xor               a9, a9, a10
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::not::u32::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        movi.n            a10, -1
-        xor               a9, a9, a10
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::fetch_neg::u8::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        neg               a10, a8
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_neg::u8::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        neg               a10, a8
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_neg::u8::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        neg               a10, a8
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_neg::u8::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        neg               a10, a8
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_neg::u8::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l8ui              a8, a2, 0
-        neg               a10, a8
-        s8i               a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_neg::u16::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        neg               a10, a8
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_neg::u16::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        neg               a10, a8
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_neg::u16::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        neg               a10, a8
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_neg::u16::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        neg               a10, a8
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_neg::u16::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l16ui             a8, a2, 0
-        neg               a10, a8
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_neg::u32::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        neg               a10, a8
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_neg::u32::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        neg               a10, a8
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_neg::u32::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        neg               a10, a8
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_neg::u32::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        neg               a10, a8
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_neg::u32::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        neg               a10, a8
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::neg::u8::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        neg               a9, a9
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::neg::u8::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        neg               a9, a9
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::neg::u8::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        neg               a9, a9
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::neg::u8::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        neg               a9, a9
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::neg::u8::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l8ui              a9, a2, 0
-        neg               a9, a9
-        s8i               a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::neg::u16::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        neg               a9, a9
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::neg::u16::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        neg               a9, a9
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::neg::u16::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        neg               a9, a9
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::neg::u16::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        neg               a9, a9
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::neg::u16::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l16ui             a9, a2, 0
-        neg               a9, a9
-        s16i              a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::neg::u32::relaxed:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        neg               a9, a9
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::neg::u32::acquire:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        neg               a9, a9
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::neg::u32::release:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        neg               a9, a9
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::neg::u32::acqrel:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        neg               a9, a9
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::neg::u32::seqcst:
-        entry             a1, 32
-        rsil              a8, 15
-        l32i.n            a9, a2, 0
-        neg               a9, a9
-        s32i.n            a9, a2, 0
-        wsr.ps            a8
-        rsync
-        retw.n
-
-asm_test::fetch_max::i8::relaxed:
-        entry             a1, 32
-        slli              a8, a3, 24
-        srai              a9, a8, 24
         rsil              a10, 15
-        l8ui              a8, a2, 0
-        slli              a11, a8, 24
-        srai              a11, a11, 24
-        max               a9, a9, a11
-        s8i               a9, a2, 0
+        l8ui              a9, a8, 0
+        movi.n            a2, 1
+        beqz              a3, 0f
+        movi.n            a11, 1
+        xor               a11, a9, a11
+        s8i               a11, a8, 0
         wsr.ps            a10
         rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_max::i8::acquire:
-        entry             a1, 32
-        slli              a8, a3, 24
-        srai              a9, a8, 24
-        rsil              a10, 15
-        l8ui              a8, a2, 0
-        slli              a11, a8, 24
-        srai              a11, a11, 24
-        max               a9, a9, a11
-        s8i               a9, a2, 0
-        wsr.ps            a10
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_max::i8::release:
-        entry             a1, 32
-        slli              a8, a3, 24
-        srai              a9, a8, 24
-        rsil              a10, 15
-        l8ui              a8, a2, 0
-        slli              a11, a8, 24
-        srai              a11, a11, 24
-        max               a9, a9, a11
-        s8i               a9, a2, 0
-        wsr.ps            a10
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_max::i8::acqrel:
-        entry             a1, 32
-        slli              a8, a3, 24
-        srai              a9, a8, 24
-        rsil              a10, 15
-        l8ui              a8, a2, 0
-        slli              a11, a8, 24
-        srai              a11, a11, 24
-        max               a9, a9, a11
-        s8i               a9, a2, 0
-        wsr.ps            a10
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_max::i8::seqcst:
-        entry             a1, 32
-        slli              a8, a3, 24
-        srai              a9, a8, 24
-        rsil              a10, 15
-        l8ui              a8, a2, 0
-        slli              a11, a8, 24
-        srai              a11, a11, 24
-        max               a9, a9, a11
-        s8i               a9, a2, 0
-        wsr.ps            a10
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_max::i16::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l16si             a8, a2, 0
-        slli              a10, a3, 16
-        srai              a10, a10, 16
-        max               a10, a10, a8
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_max::i16::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l16si             a8, a2, 0
-        slli              a10, a3, 16
-        srai              a10, a10, 16
-        max               a10, a10, a8
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_max::i16::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l16si             a8, a2, 0
-        slli              a10, a3, 16
-        srai              a10, a10, 16
-        max               a10, a10, a8
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_max::i16::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l16si             a8, a2, 0
-        slli              a10, a3, 16
-        srai              a10, a10, 16
-        max               a10, a10, a8
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_max::i16::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l16si             a8, a2, 0
-        slli              a10, a3, 16
-        srai              a10, a10, 16
-        max               a10, a10, a8
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_max::i32::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        max               a10, a3, a8
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_max::i32::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        max               a10, a3, a8
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_max::i32::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        max               a10, a3, a8
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_max::i32::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        max               a10, a3, a8
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_max::i32::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        max               a10, a3, a8
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_umax::u8::relaxed:
-        entry             a1, 32
         movi              a8, 255
-        and               a9, a3, a8
-        rsil              a10, 15
-        l8ui              a8, a2, 0
-        maxu              a9, a9, a8
-        s8i               a9, a2, 0
+        and               a9, a9, a8
+        movi.n            a8, 0
+        beq               a9, a8, 1f
+        j                 2f
+0:
+        s8i               a2, a8, 0
         wsr.ps            a10
         rsync
+        movi              a8, 255
+        and               a9, a9, a8
+        movi.n            a8, 0
+        bne               a9, a8, 2f
+1:
         mov.n             a2, a8
+2:
         retw.n
 
-asm_test::fetch_umax::u8::acquire:
+asm_test::fetch_nand::bool::relaxed:
         entry             a1, 32
-        movi              a8, 255
-        and               a9, a3, a8
+        mov.n             a8, a2
         rsil              a10, 15
-        l8ui              a8, a2, 0
-        maxu              a9, a9, a8
-        s8i               a9, a2, 0
+        l8ui              a9, a8, 0
+        movi.n            a2, 1
+        beqz              a3, 0f
+        movi.n            a11, 1
+        xor               a11, a9, a11
+        s8i               a11, a8, 0
         wsr.ps            a10
         rsync
+        movi              a8, 255
+        and               a9, a9, a8
+        movi.n            a8, 0
+        beq               a9, a8, 1f
+        j                 2f
+0:
+        s8i               a2, a8, 0
+        wsr.ps            a10
+        rsync
+        movi              a8, 255
+        and               a9, a9, a8
+        movi.n            a8, 0
+        bne               a9, a8, 2f
+1:
         mov.n             a2, a8
+2:
         retw.n
 
-asm_test::fetch_umax::u8::release:
+asm_test::fetch_nand::bool::release:
         entry             a1, 32
-        movi              a8, 255
-        and               a9, a3, a8
+        mov.n             a8, a2
         rsil              a10, 15
-        l8ui              a8, a2, 0
-        maxu              a9, a9, a8
-        s8i               a9, a2, 0
+        l8ui              a9, a8, 0
+        movi.n            a2, 1
+        beqz              a3, 0f
+        movi.n            a11, 1
+        xor               a11, a9, a11
+        s8i               a11, a8, 0
         wsr.ps            a10
         rsync
+        movi              a8, 255
+        and               a9, a9, a8
+        movi.n            a8, 0
+        beq               a9, a8, 1f
+        j                 2f
+0:
+        s8i               a2, a8, 0
+        wsr.ps            a10
+        rsync
+        movi              a8, 255
+        and               a9, a9, a8
+        movi.n            a8, 0
+        bne               a9, a8, 2f
+1:
         mov.n             a2, a8
+2:
         retw.n
 
 asm_test::fetch_umax::u8::acqrel:
@@ -5985,55 +369,40 @@ asm_test::fetch_umax::u8::seqcst:
         mov.n             a2, a8
         retw.n
 
-.literal.asm_test::fetch_umax::u16::relaxed:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::fetch_umax::u16::relaxed:
-0:
+asm_test::fetch_umax::u8::acquire:
         entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::fetch_umax::u16::relaxed+0x81004136>)
+        movi              a8, 255
         and               a9, a3, a8
         rsil              a10, 15
-        l16ui             a8, a2, 0
+        l8ui              a8, a2, 0
         maxu              a9, a9, a8
-        s16i              a9, a2, 0
+        s8i               a9, a2, 0
         wsr.ps            a10
         rsync
         mov.n             a2, a8
         retw.n
 
-.literal.asm_test::fetch_umax::u16::acquire:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::fetch_umax::u16::acquire:
-0:
+asm_test::fetch_umax::u8::relaxed:
         entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::fetch_umax::u16::acquire+0x81004136>)
+        movi              a8, 255
         and               a9, a3, a8
         rsil              a10, 15
-        l16ui             a8, a2, 0
+        l8ui              a8, a2, 0
         maxu              a9, a9, a8
-        s16i              a9, a2, 0
+        s8i               a9, a2, 0
         wsr.ps            a10
         rsync
         mov.n             a2, a8
         retw.n
 
-.literal.asm_test::fetch_umax::u16::release:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::fetch_umax::u16::release:
-0:
+asm_test::fetch_umax::u8::release:
         entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::fetch_umax::u16::release+0x81004136>)
+        movi              a8, 255
         and               a9, a3, a8
         rsil              a10, 15
-        l16ui             a8, a2, 0
+        l8ui              a8, a2, 0
         maxu              a9, a9, a8
-        s16i              a9, a2, 0
+        s8i               a9, a2, 0
         wsr.ps            a10
         rsync
         mov.n             a2, a8
@@ -6075,35 +444,56 @@ asm_test::fetch_umax::u16::seqcst:
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_umax::u32::relaxed:
+.literal.asm_test::fetch_umax::u16::acquire:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::fetch_umax::u16::acquire:
+0:
         entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        maxu              a10, a3, a8
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
+        l32r              a8, 0b (81004136 <asm_test::fetch_umax::u16::acquire+0x81004136>)
+        and               a9, a3, a8
+        rsil              a10, 15
+        l16ui             a8, a2, 0
+        maxu              a9, a9, a8
+        s16i              a9, a2, 0
+        wsr.ps            a10
         rsync
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_umax::u32::acquire:
+.literal.asm_test::fetch_umax::u16::relaxed:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::fetch_umax::u16::relaxed:
+0:
         entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        maxu              a10, a3, a8
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
+        l32r              a8, 0b (81004136 <asm_test::fetch_umax::u16::relaxed+0x81004136>)
+        and               a9, a3, a8
+        rsil              a10, 15
+        l16ui             a8, a2, 0
+        maxu              a9, a9, a8
+        s16i              a9, a2, 0
+        wsr.ps            a10
         rsync
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_umax::u32::release:
+.literal.asm_test::fetch_umax::u16::release:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::fetch_umax::u16::release:
+0:
         entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        maxu              a10, a3, a8
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
+        l32r              a8, 0b (81004136 <asm_test::fetch_umax::u16::release+0x81004136>)
+        and               a9, a3, a8
+        rsil              a10, 15
+        l16ui             a8, a2, 0
+        maxu              a9, a9, a8
+        s16i              a9, a2, 0
+        wsr.ps            a10
         rsync
         mov.n             a2, a8
         retw.n
@@ -6130,236 +520,35 @@ asm_test::fetch_umax::u32::seqcst:
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_min::i8::relaxed:
-        entry             a1, 32
-        slli              a8, a3, 24
-        srai              a9, a8, 24
-        rsil              a10, 15
-        l8ui              a8, a2, 0
-        slli              a11, a8, 24
-        srai              a11, a11, 24
-        min               a9, a9, a11
-        s8i               a9, a2, 0
-        wsr.ps            a10
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_min::i8::acquire:
-        entry             a1, 32
-        slli              a8, a3, 24
-        srai              a9, a8, 24
-        rsil              a10, 15
-        l8ui              a8, a2, 0
-        slli              a11, a8, 24
-        srai              a11, a11, 24
-        min               a9, a9, a11
-        s8i               a9, a2, 0
-        wsr.ps            a10
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_min::i8::release:
-        entry             a1, 32
-        slli              a8, a3, 24
-        srai              a9, a8, 24
-        rsil              a10, 15
-        l8ui              a8, a2, 0
-        slli              a11, a8, 24
-        srai              a11, a11, 24
-        min               a9, a9, a11
-        s8i               a9, a2, 0
-        wsr.ps            a10
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_min::i8::acqrel:
-        entry             a1, 32
-        slli              a8, a3, 24
-        srai              a9, a8, 24
-        rsil              a10, 15
-        l8ui              a8, a2, 0
-        slli              a11, a8, 24
-        srai              a11, a11, 24
-        min               a9, a9, a11
-        s8i               a9, a2, 0
-        wsr.ps            a10
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_min::i8::seqcst:
-        entry             a1, 32
-        slli              a8, a3, 24
-        srai              a9, a8, 24
-        rsil              a10, 15
-        l8ui              a8, a2, 0
-        slli              a11, a8, 24
-        srai              a11, a11, 24
-        min               a9, a9, a11
-        s8i               a9, a2, 0
-        wsr.ps            a10
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_min::i16::relaxed:
-        entry             a1, 32
-        rsil              a9, 15
-        l16si             a8, a2, 0
-        slli              a10, a3, 16
-        srai              a10, a10, 16
-        min               a10, a10, a8
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_min::i16::acquire:
-        entry             a1, 32
-        rsil              a9, 15
-        l16si             a8, a2, 0
-        slli              a10, a3, 16
-        srai              a10, a10, 16
-        min               a10, a10, a8
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_min::i16::release:
-        entry             a1, 32
-        rsil              a9, 15
-        l16si             a8, a2, 0
-        slli              a10, a3, 16
-        srai              a10, a10, 16
-        min               a10, a10, a8
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_min::i16::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l16si             a8, a2, 0
-        slli              a10, a3, 16
-        srai              a10, a10, 16
-        min               a10, a10, a8
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_min::i16::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l16si             a8, a2, 0
-        slli              a10, a3, 16
-        srai              a10, a10, 16
-        min               a10, a10, a8
-        s16i              a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_min::i32::relaxed:
+asm_test::fetch_umax::u32::acquire:
         entry             a1, 32
         rsil              a9, 15
         l32i.n            a8, a2, 0
-        min               a10, a3, a8
+        maxu              a10, a3, a8
         s32i.n            a10, a2, 0
         wsr.ps            a9
         rsync
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_min::i32::acquire:
+asm_test::fetch_umax::u32::relaxed:
         entry             a1, 32
         rsil              a9, 15
         l32i.n            a8, a2, 0
-        min               a10, a3, a8
+        maxu              a10, a3, a8
         s32i.n            a10, a2, 0
         wsr.ps            a9
         rsync
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_min::i32::release:
+asm_test::fetch_umax::u32::release:
         entry             a1, 32
         rsil              a9, 15
         l32i.n            a8, a2, 0
-        min               a10, a3, a8
+        maxu              a10, a3, a8
         s32i.n            a10, a2, 0
         wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_min::i32::acqrel:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        min               a10, a3, a8
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_min::i32::seqcst:
-        entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        min               a10, a3, a8
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_umin::u8::relaxed:
-        entry             a1, 32
-        movi              a8, 255
-        and               a9, a3, a8
-        rsil              a10, 15
-        l8ui              a8, a2, 0
-        minu              a9, a9, a8
-        s8i               a9, a2, 0
-        wsr.ps            a10
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_umin::u8::acquire:
-        entry             a1, 32
-        movi              a8, 255
-        and               a9, a3, a8
-        rsil              a10, 15
-        l8ui              a8, a2, 0
-        minu              a9, a9, a8
-        s8i               a9, a2, 0
-        wsr.ps            a10
-        rsync
-        mov.n             a2, a8
-        retw.n
-
-asm_test::fetch_umin::u8::release:
-        entry             a1, 32
-        movi              a8, 255
-        and               a9, a3, a8
-        rsil              a10, 15
-        l8ui              a8, a2, 0
-        minu              a9, a9, a8
-        s8i               a9, a2, 0
-        wsr.ps            a10
         rsync
         mov.n             a2, a8
         retw.n
@@ -6390,55 +579,40 @@ asm_test::fetch_umin::u8::seqcst:
         mov.n             a2, a8
         retw.n
 
-.literal.asm_test::fetch_umin::u16::relaxed:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::fetch_umin::u16::relaxed:
-0:
+asm_test::fetch_umin::u8::acquire:
         entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::fetch_umin::u16::relaxed+0x81004136>)
+        movi              a8, 255
         and               a9, a3, a8
         rsil              a10, 15
-        l16ui             a8, a2, 0
+        l8ui              a8, a2, 0
         minu              a9, a9, a8
-        s16i              a9, a2, 0
+        s8i               a9, a2, 0
         wsr.ps            a10
         rsync
         mov.n             a2, a8
         retw.n
 
-.literal.asm_test::fetch_umin::u16::acquire:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::fetch_umin::u16::acquire:
-0:
+asm_test::fetch_umin::u8::relaxed:
         entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::fetch_umin::u16::acquire+0x81004136>)
+        movi              a8, 255
         and               a9, a3, a8
         rsil              a10, 15
-        l16ui             a8, a2, 0
+        l8ui              a8, a2, 0
         minu              a9, a9, a8
-        s16i              a9, a2, 0
+        s8i               a9, a2, 0
         wsr.ps            a10
         rsync
         mov.n             a2, a8
         retw.n
 
-.literal.asm_test::fetch_umin::u16::release:
-        .byte             0xff
-        .byte             0xff
-
-asm_test::fetch_umin::u16::release:
-0:
+asm_test::fetch_umin::u8::release:
         entry             a1, 32
-        l32r              a8, 0b (81004136 <asm_test::fetch_umin::u16::release+0x81004136>)
+        movi              a8, 255
         and               a9, a3, a8
         rsil              a10, 15
-        l16ui             a8, a2, 0
+        l8ui              a8, a2, 0
         minu              a9, a9, a8
-        s16i              a9, a2, 0
+        s8i               a9, a2, 0
         wsr.ps            a10
         rsync
         mov.n             a2, a8
@@ -6480,35 +654,56 @@ asm_test::fetch_umin::u16::seqcst:
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_umin::u32::relaxed:
+.literal.asm_test::fetch_umin::u16::acquire:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::fetch_umin::u16::acquire:
+0:
         entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        minu              a10, a3, a8
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
+        l32r              a8, 0b (81004136 <asm_test::fetch_umin::u16::acquire+0x81004136>)
+        and               a9, a3, a8
+        rsil              a10, 15
+        l16ui             a8, a2, 0
+        minu              a9, a9, a8
+        s16i              a9, a2, 0
+        wsr.ps            a10
         rsync
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_umin::u32::acquire:
+.literal.asm_test::fetch_umin::u16::relaxed:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::fetch_umin::u16::relaxed:
+0:
         entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        minu              a10, a3, a8
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
+        l32r              a8, 0b (81004136 <asm_test::fetch_umin::u16::relaxed+0x81004136>)
+        and               a9, a3, a8
+        rsil              a10, 15
+        l16ui             a8, a2, 0
+        minu              a9, a9, a8
+        s16i              a9, a2, 0
+        wsr.ps            a10
         rsync
         mov.n             a2, a8
         retw.n
 
-asm_test::fetch_umin::u32::release:
+.literal.asm_test::fetch_umin::u16::release:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::fetch_umin::u16::release:
+0:
         entry             a1, 32
-        rsil              a9, 15
-        l32i.n            a8, a2, 0
-        minu              a10, a3, a8
-        s32i.n            a10, a2, 0
-        wsr.ps            a9
+        l32r              a8, 0b (81004136 <asm_test::fetch_umin::u16::release+0x81004136>)
+        and               a9, a3, a8
+        rsil              a10, 15
+        l16ui             a8, a2, 0
+        minu              a9, a9, a8
+        s16i              a9, a2, 0
+        wsr.ps            a10
         rsync
         mov.n             a2, a8
         retw.n
@@ -6533,4 +728,5809 @@ asm_test::fetch_umin::u32::seqcst:
         wsr.ps            a9
         rsync
         mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_umin::u32::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        minu              a10, a3, a8
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_umin::u32::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        minu              a10, a3, a8
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_umin::u32::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        minu              a10, a3, a8
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::compare_exchange::u8::acqrel_seqcst:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange::u8::seqcst_seqcst:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange::u8::acqrel_acquire:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange::u8::acqrel_relaxed:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange::u8::acquire_seqcst:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange::u8::relaxed_seqcst:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange::u8::release_seqcst:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange::u8::seqcst_acquire:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange::u8::seqcst_relaxed:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange::u8::acquire_acquire:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange::u8::acquire_relaxed:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange::u8::relaxed_acquire:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange::u8::relaxed_relaxed:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange::u8::release_acquire:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange::u8::release_relaxed:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+.literal.asm_test::compare_exchange::u16::acqrel_seqcst:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange::u16::acqrel_seqcst:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::acqrel_seqcst+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange::u16::seqcst_seqcst:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange::u16::seqcst_seqcst:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::seqcst_seqcst+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange::u16::acqrel_acquire:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange::u16::acqrel_acquire:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::acqrel_acquire+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange::u16::acqrel_relaxed:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange::u16::acqrel_relaxed:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::acqrel_relaxed+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange::u16::acquire_seqcst:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange::u16::acquire_seqcst:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::acquire_seqcst+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange::u16::relaxed_seqcst:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange::u16::relaxed_seqcst:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::relaxed_seqcst+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange::u16::release_seqcst:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange::u16::release_seqcst:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::release_seqcst+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange::u16::seqcst_acquire:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange::u16::seqcst_acquire:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::seqcst_acquire+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange::u16::seqcst_relaxed:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange::u16::seqcst_relaxed:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::seqcst_relaxed+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange::u16::acquire_acquire:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange::u16::acquire_acquire:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::acquire_acquire+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange::u16::acquire_relaxed:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange::u16::acquire_relaxed:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::acquire_relaxed+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange::u16::relaxed_acquire:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange::u16::relaxed_acquire:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::relaxed_acquire+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange::u16::relaxed_relaxed:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange::u16::relaxed_relaxed:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::relaxed_relaxed+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange::u16::release_acquire:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange::u16::release_acquire:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::release_acquire+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange::u16::release_relaxed:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange::u16::release_relaxed:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange::u16::release_relaxed+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::compare_exchange::u32::acqrel_seqcst:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange::u32::seqcst_seqcst:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange::u32::acqrel_acquire:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange::u32::acqrel_relaxed:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange::u32::acquire_seqcst:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange::u32::relaxed_seqcst:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange::u32::release_seqcst:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange::u32::seqcst_acquire:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange::u32::seqcst_relaxed:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange::u32::acquire_acquire:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange::u32::acquire_relaxed:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange::u32::relaxed_acquire:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange::u32::relaxed_relaxed:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange::u32::release_acquire:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange::u32::release_relaxed:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange::bool::acqrel_seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange::bool::seqcst_seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange::bool::acqrel_acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange::bool::acqrel_relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange::bool::acquire_seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange::bool::relaxed_seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange::bool::release_seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange::bool::seqcst_acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange::bool::seqcst_relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange::bool::acquire_acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange::bool::acquire_relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange::bool::relaxed_acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange::bool::relaxed_relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange::bool::release_acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange::bool::release_relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange_weak::u8::acqrel_seqcst:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange_weak::u8::seqcst_seqcst:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange_weak::u8::acqrel_acquire:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange_weak::u8::acqrel_relaxed:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange_weak::u8::acquire_seqcst:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange_weak::u8::relaxed_seqcst:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange_weak::u8::release_seqcst:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange_weak::u8::seqcst_acquire:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange_weak::u8::seqcst_relaxed:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange_weak::u8::acquire_acquire:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange_weak::u8::acquire_relaxed:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange_weak::u8::relaxed_acquire:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange_weak::u8::relaxed_relaxed:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange_weak::u8::release_acquire:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+asm_test::compare_exchange_weak::u8::release_relaxed:
+        entry             a1, 32
+        movi              a8, 255
+        and               a8, a3, a8
+        rsil              a9, 15
+        l8ui              a3, a2, 0
+        bne               a3, a8, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a9
+        rsync
+        bne               a3, a8, 1f
+        movi.n            a2, 0
+        retw.n
+1:
+        movi.n            a2, 1
+        retw.n
+
+.literal.asm_test::compare_exchange_weak::u16::acqrel_seqcst:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange_weak::u16::acqrel_seqcst:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::acqrel_seqcst+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange_weak::u16::seqcst_seqcst:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange_weak::u16::seqcst_seqcst:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::seqcst_seqcst+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange_weak::u16::acqrel_acquire:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange_weak::u16::acqrel_acquire:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::acqrel_acquire+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange_weak::u16::acqrel_relaxed:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange_weak::u16::acqrel_relaxed:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::acqrel_relaxed+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange_weak::u16::acquire_seqcst:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange_weak::u16::acquire_seqcst:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::acquire_seqcst+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange_weak::u16::relaxed_seqcst:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange_weak::u16::relaxed_seqcst:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::relaxed_seqcst+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange_weak::u16::release_seqcst:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange_weak::u16::release_seqcst:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::release_seqcst+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange_weak::u16::seqcst_acquire:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange_weak::u16::seqcst_acquire:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::seqcst_acquire+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange_weak::u16::seqcst_relaxed:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange_weak::u16::seqcst_relaxed:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::seqcst_relaxed+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange_weak::u16::acquire_acquire:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange_weak::u16::acquire_acquire:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::acquire_acquire+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange_weak::u16::acquire_relaxed:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange_weak::u16::acquire_relaxed:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::acquire_relaxed+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange_weak::u16::relaxed_acquire:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange_weak::u16::relaxed_acquire:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::relaxed_acquire+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange_weak::u16::relaxed_relaxed:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange_weak::u16::relaxed_relaxed:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::relaxed_relaxed+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange_weak::u16::release_acquire:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange_weak::u16::release_acquire:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::release_acquire+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+.literal.asm_test::compare_exchange_weak::u16::release_relaxed:
+        .byte             0xff
+        .byte             0xff
+
+asm_test::compare_exchange_weak::u16::release_relaxed:
+0:
+        entry             a1, 32
+        l32r              a8, 0b (81004136 <asm_test::compare_exchange_weak::u16::release_relaxed+0x81004136>)
+        and               a9, a3, a8
+        rsil              a8, 15
+        l16ui             a3, a2, 0
+        bne               a3, a9, 1f
+        s16i              a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+1:
+        movi.n            a2, 1
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::compare_exchange_weak::u32::acqrel_seqcst:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange_weak::u32::seqcst_seqcst:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange_weak::u32::acqrel_acquire:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange_weak::u32::acqrel_relaxed:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange_weak::u32::acquire_seqcst:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange_weak::u32::relaxed_seqcst:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange_weak::u32::release_seqcst:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange_weak::u32::seqcst_acquire:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange_weak::u32::seqcst_relaxed:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange_weak::u32::acquire_acquire:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange_weak::u32::acquire_relaxed:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange_weak::u32::relaxed_acquire:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange_weak::u32::relaxed_relaxed:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange_weak::u32::release_acquire:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange_weak::u32::release_relaxed:
+        entry             a1, 32
+        mov.n             a8, a3
+        rsil              a9, 15
+        l32i.n            a3, a2, 0
+        bne               a3, a8, 0f
+        s32i.n            a4, a2, 0
+        movi.n            a2, 0
+        wsr.ps            a9
+        rsync
+        retw.n
+0:
+        movi.n            a2, 1
+        wsr.ps            a9
+        rsync
+        retw.n
+
+asm_test::compare_exchange_weak::bool::acqrel_seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange_weak::bool::seqcst_seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange_weak::bool::acqrel_acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange_weak::bool::acqrel_relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange_weak::bool::acquire_seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange_weak::bool::relaxed_seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange_weak::bool::release_seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange_weak::bool::seqcst_acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange_weak::bool::seqcst_relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange_weak::bool::acquire_acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange_weak::bool::acquire_relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange_weak::bool::relaxed_acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange_weak::bool::relaxed_relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange_weak::bool::release_acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::compare_exchange_weak::bool::release_relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        bne               a9, a3, 0f
+        s8i               a4, a2, 0
+0:
+        wsr.ps            a8
+        rsync
+        movi.n            a10, 0
+        movi.n            a8, 1
+        mov.n             a2, a8
+        beq               a9, a3, 2f
+        beq               a9, a10, 3f
+1:
+        mov.n             a3, a8
+        retw.n
+2:
+        mov.n             a2, a10
+        bne               a9, a10, 1b
+3:
+        mov.n             a8, a10
+        mov.n             a3, a8
+        retw.n
+
+asm_test::or::u8::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        or                a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::or::u8::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        or                a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::or::u8::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        or                a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::or::u8::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        or                a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::or::u8::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        or                a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::or::u16::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        or                a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::or::u16::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        or                a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::or::u16::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        or                a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::or::u16::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        or                a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::or::u16::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        or                a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::or::u32::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        or                a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::or::u32::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        or                a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::or::u32::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        or                a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::or::u32::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        or                a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::or::u32::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        or                a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::add::u8::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        add.n             a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::add::u8::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        add.n             a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::add::u8::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        add.n             a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::add::u8::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        add.n             a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::add::u8::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        add.n             a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::add::u16::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        add.n             a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::add::u16::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        add.n             a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::add::u16::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        add.n             a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::add::u16::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        add.n             a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::add::u16::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        add.n             a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::add::u32::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        add.n             a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::add::u32::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        add.n             a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::add::u32::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        add.n             a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::add::u32::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        add.n             a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::add::u32::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        add.n             a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::and::u8::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        and               a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::and::u8::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        and               a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::and::u8::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        and               a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::and::u8::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        and               a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::and::u8::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        and               a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::and::u16::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        and               a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::and::u16::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        and               a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::and::u16::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        and               a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::and::u16::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        and               a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::and::u16::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        and               a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::and::u32::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        and               a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::and::u32::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        and               a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::and::u32::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        and               a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::and::u32::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        and               a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::and::u32::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        and               a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::neg::u8::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        neg               a9, a9
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::neg::u8::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        neg               a9, a9
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::neg::u8::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        neg               a9, a9
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::neg::u8::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        neg               a9, a9
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::neg::u8::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        neg               a9, a9
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::neg::u16::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        neg               a9, a9
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::neg::u16::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        neg               a9, a9
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::neg::u16::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        neg               a9, a9
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::neg::u16::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        neg               a9, a9
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::neg::u16::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        neg               a9, a9
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::neg::u32::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        neg               a9, a9
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::neg::u32::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        neg               a9, a9
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::neg::u32::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        neg               a9, a9
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::neg::u32::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        neg               a9, a9
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::neg::u32::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        neg               a9, a9
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::not::u8::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        movi.n            a10, -1
+        xor               a9, a9, a10
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::not::u8::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        movi.n            a10, -1
+        xor               a9, a9, a10
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::not::u8::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        movi.n            a10, -1
+        xor               a9, a9, a10
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::not::u8::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        movi.n            a10, -1
+        xor               a9, a9, a10
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::not::u8::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        movi.n            a10, -1
+        xor               a9, a9, a10
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::not::u16::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        movi.n            a10, -1
+        xor               a9, a9, a10
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::not::u16::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        movi.n            a10, -1
+        xor               a9, a9, a10
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::not::u16::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        movi.n            a10, -1
+        xor               a9, a9, a10
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::not::u16::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        movi.n            a10, -1
+        xor               a9, a9, a10
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::not::u16::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        movi.n            a10, -1
+        xor               a9, a9, a10
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::not::u32::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        movi.n            a10, -1
+        xor               a9, a9, a10
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::not::u32::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        movi.n            a10, -1
+        xor               a9, a9, a10
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::not::u32::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        movi.n            a10, -1
+        xor               a9, a9, a10
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::not::u32::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        movi.n            a10, -1
+        xor               a9, a9, a10
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::not::u32::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        movi.n            a10, -1
+        xor               a9, a9, a10
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::sub::u8::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        sub               a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::sub::u8::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        sub               a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::sub::u8::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        sub               a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::sub::u8::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        sub               a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::sub::u8::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        sub               a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::sub::u16::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        sub               a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::sub::u16::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        sub               a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::sub::u16::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        sub               a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::sub::u16::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        sub               a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::sub::u16::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        sub               a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::sub::u32::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        sub               a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::sub::u32::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        sub               a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::sub::u32::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        sub               a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::sub::u32::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        sub               a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::sub::u32::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        sub               a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::xor::u8::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        xor               a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::xor::u8::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        xor               a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::xor::u8::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        xor               a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::xor::u8::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        xor               a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::xor::u8::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        xor               a9, a9, a3
+        s8i               a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::xor::u16::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        xor               a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::xor::u16::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        xor               a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::xor::u16::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        xor               a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::xor::u16::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        xor               a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::xor::u16::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l16ui             a9, a2, 0
+        xor               a9, a9, a3
+        s16i              a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::xor::u32::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        xor               a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::xor::u32::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        xor               a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::xor::u32::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        xor               a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::xor::u32::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        xor               a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::xor::u32::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l32i.n            a9, a2, 0
+        xor               a9, a9, a3
+        s32i.n            a9, a2, 0
+        wsr.ps            a8
+        rsync
+        retw.n
+
+asm_test::load::u8::seqcst:
+        entry             a1, 32
+        l8ui              a2, a2, 0
+        memw
+        retw.n
+
+asm_test::load::u8::acquire:
+        entry             a1, 32
+        l8ui              a2, a2, 0
+        memw
+        retw.n
+
+asm_test::load::u8::relaxed:
+        entry             a1, 32
+        l8ui              a2, a2, 0
+        retw.n
+
+asm_test::load::u16::seqcst:
+        entry             a1, 32
+        l16ui             a2, a2, 0
+        memw
+        retw.n
+
+asm_test::load::u16::acquire:
+        entry             a1, 32
+        l16ui             a2, a2, 0
+        memw
+        retw.n
+
+asm_test::load::u16::relaxed:
+        entry             a1, 32
+        l16ui             a2, a2, 0
+        retw.n
+
+asm_test::load::u32::seqcst:
+        entry             a1, 32
+        l32i.n            a2, a2, 0
+        memw
+        retw.n
+
+asm_test::load::u32::acquire:
+        entry             a1, 32
+        l32i.n            a2, a2, 0
+        memw
+        retw.n
+
+asm_test::load::u32::relaxed:
+        entry             a1, 32
+        l32i.n            a2, a2, 0
+        retw.n
+
+asm_test::load::bool::seqcst:
+        entry             a1, 32
+        l8ui              a8, a2, 0
+        movi.n            a2, 0
+        beq               a8, a2, 0f
+        movi.n            a2, 1
+0:
+        memw
+        retw.n
+
+asm_test::load::bool::acquire:
+        entry             a1, 32
+        l8ui              a8, a2, 0
+        movi.n            a2, 0
+        beq               a8, a2, 0f
+        movi.n            a2, 1
+0:
+        memw
+        retw.n
+
+asm_test::load::bool::relaxed:
+        entry             a1, 32
+        l8ui              a8, a2, 0
+        movi.n            a2, 0
+        beq               a8, a2, 0f
+        movi.n            a2, 1
+0:
+        retw.n
+
+asm_test::swap::u8::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        s8i               a3, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::swap::u8::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        s8i               a3, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::swap::u8::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        s8i               a3, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::swap::u8::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        s8i               a3, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::swap::u8::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        s8i               a3, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::swap::u16::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        s16i              a3, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::swap::u16::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        s16i              a3, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::swap::u16::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        s16i              a3, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::swap::u16::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        s16i              a3, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::swap::u16::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        s16i              a3, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::swap::u32::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        s32i.n            a3, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::swap::u32::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        s32i.n            a3, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::swap::u32::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        s32i.n            a3, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::swap::u32::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        s32i.n            a3, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::swap::u32::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        s32i.n            a3, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::swap::bool::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        s8i               a3, a2, 0
+        wsr.ps            a8
+        rsync
+        movi.n            a2, 0
+        beq               a9, a2, 0f
+        movi.n            a2, 1
+0:
+        retw.n
+
+asm_test::swap::bool::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        s8i               a3, a2, 0
+        wsr.ps            a8
+        rsync
+        movi.n            a2, 0
+        beq               a9, a2, 0f
+        movi.n            a2, 1
+0:
+        retw.n
+
+asm_test::swap::bool::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        s8i               a3, a2, 0
+        wsr.ps            a8
+        rsync
+        movi.n            a2, 0
+        beq               a9, a2, 0f
+        movi.n            a2, 1
+0:
+        retw.n
+
+asm_test::swap::bool::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        s8i               a3, a2, 0
+        wsr.ps            a8
+        rsync
+        movi.n            a2, 0
+        beq               a9, a2, 0f
+        movi.n            a2, 1
+0:
+        retw.n
+
+asm_test::swap::bool::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        s8i               a3, a2, 0
+        wsr.ps            a8
+        rsync
+        movi.n            a2, 0
+        beq               a9, a2, 0f
+        movi.n            a2, 1
+0:
+        retw.n
+
+asm_test::store::u8::seqcst:
+        entry             a1, 32
+        memw
+        s8i               a3, a2, 0
+        memw
+        retw.n
+
+asm_test::store::u8::relaxed:
+        entry             a1, 32
+        s8i               a3, a2, 0
+        retw.n
+
+asm_test::store::u8::release:
+        entry             a1, 32
+        memw
+        s8i               a3, a2, 0
+        retw.n
+
+asm_test::store::u16::seqcst:
+        entry             a1, 32
+        memw
+        s16i              a3, a2, 0
+        memw
+        retw.n
+
+asm_test::store::u16::relaxed:
+        entry             a1, 32
+        s16i              a3, a2, 0
+        retw.n
+
+asm_test::store::u16::release:
+        entry             a1, 32
+        memw
+        s16i              a3, a2, 0
+        retw.n
+
+asm_test::store::u32::seqcst:
+        entry             a1, 32
+        memw
+        s32i.n            a3, a2, 0
+        memw
+        retw.n
+
+asm_test::store::u32::relaxed:
+        entry             a1, 32
+        s32i.n            a3, a2, 0
+        retw.n
+
+asm_test::store::u32::release:
+        entry             a1, 32
+        memw
+        s32i.n            a3, a2, 0
+        retw.n
+
+asm_test::store::bool::seqcst:
+        entry             a1, 32
+        memw
+        s8i               a3, a2, 0
+        memw
+        retw.n
+
+asm_test::store::bool::relaxed:
+        entry             a1, 32
+        s8i               a3, a2, 0
+        retw.n
+
+asm_test::store::bool::release:
+        entry             a1, 32
+        memw
+        s8i               a3, a2, 0
+        retw.n
+
+asm_test::fetch_or::u8::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        or                a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_or::u8::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        or                a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_or::u8::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        or                a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_or::u8::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        or                a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_or::u8::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        or                a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_or::u16::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        or                a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_or::u16::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        or                a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_or::u16::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        or                a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_or::u16::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        or                a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_or::u16::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        or                a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_or::u32::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        or                a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_or::u32::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        or                a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_or::u32::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        or                a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_or::u32::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        or                a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_or::u32::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        or                a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_or::bool::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        or                a10, a9, a3
+        s8i               a10, a2, 0
+        wsr.ps            a8
+        rsync
+        movi.n            a2, 0
+        beq               a9, a2, 0f
+        movi.n            a2, 1
+0:
+        retw.n
+
+asm_test::fetch_or::bool::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        or                a10, a9, a3
+        s8i               a10, a2, 0
+        wsr.ps            a8
+        rsync
+        movi.n            a2, 0
+        beq               a9, a2, 0f
+        movi.n            a2, 1
+0:
+        retw.n
+
+asm_test::fetch_or::bool::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        or                a10, a9, a3
+        s8i               a10, a2, 0
+        wsr.ps            a8
+        rsync
+        movi.n            a2, 0
+        beq               a9, a2, 0f
+        movi.n            a2, 1
+0:
+        retw.n
+
+asm_test::fetch_or::bool::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        or                a10, a9, a3
+        s8i               a10, a2, 0
+        wsr.ps            a8
+        rsync
+        movi.n            a2, 0
+        beq               a9, a2, 0f
+        movi.n            a2, 1
+0:
+        retw.n
+
+asm_test::fetch_or::bool::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        or                a10, a9, a3
+        s8i               a10, a2, 0
+        wsr.ps            a8
+        rsync
+        movi.n            a2, 0
+        beq               a9, a2, 0f
+        movi.n            a2, 1
+0:
+        retw.n
+
+asm_test::fetch_add::u8::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        add.n             a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_add::u8::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        add.n             a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_add::u8::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        add.n             a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_add::u8::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        add.n             a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_add::u8::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        add.n             a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_add::u16::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        add.n             a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_add::u16::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        add.n             a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_add::u16::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        add.n             a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_add::u16::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        add.n             a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_add::u16::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        add.n             a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_add::u32::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        add.n             a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_add::u32::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        add.n             a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_add::u32::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        add.n             a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_add::u32::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        add.n             a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_add::u32::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        add.n             a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_and::u8::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        and               a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_and::u8::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        and               a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_and::u8::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        and               a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_and::u8::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        and               a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_and::u8::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        and               a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_and::u16::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        and               a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_and::u16::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        and               a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_and::u16::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        and               a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_and::u16::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        and               a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_and::u16::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        and               a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_and::u32::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        and               a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_and::u32::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        and               a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_and::u32::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        and               a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_and::u32::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        and               a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_and::u32::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        and               a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_and::bool::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        and               a10, a3, a9
+        s8i               a10, a2, 0
+        wsr.ps            a8
+        rsync
+        movi.n            a2, 0
+        beq               a9, a2, 0f
+        movi.n            a2, 1
+0:
+        retw.n
+
+asm_test::fetch_and::bool::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        and               a10, a3, a9
+        s8i               a10, a2, 0
+        wsr.ps            a8
+        rsync
+        movi.n            a2, 0
+        beq               a9, a2, 0f
+        movi.n            a2, 1
+0:
+        retw.n
+
+asm_test::fetch_and::bool::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        and               a10, a3, a9
+        s8i               a10, a2, 0
+        wsr.ps            a8
+        rsync
+        movi.n            a2, 0
+        beq               a9, a2, 0f
+        movi.n            a2, 1
+0:
+        retw.n
+
+asm_test::fetch_and::bool::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        and               a10, a3, a9
+        s8i               a10, a2, 0
+        wsr.ps            a8
+        rsync
+        movi.n            a2, 0
+        beq               a9, a2, 0f
+        movi.n            a2, 1
+0:
+        retw.n
+
+asm_test::fetch_and::bool::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        and               a10, a3, a9
+        s8i               a10, a2, 0
+        wsr.ps            a8
+        rsync
+        movi.n            a2, 0
+        beq               a9, a2, 0f
+        movi.n            a2, 1
+0:
+        retw.n
+
+asm_test::fetch_max::i8::acqrel:
+        entry             a1, 32
+        slli              a8, a3, 24
+        srai              a9, a8, 24
+        rsil              a10, 15
+        l8ui              a8, a2, 0
+        slli              a11, a8, 24
+        srai              a11, a11, 24
+        max               a9, a9, a11
+        s8i               a9, a2, 0
+        wsr.ps            a10
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_max::i8::seqcst:
+        entry             a1, 32
+        slli              a8, a3, 24
+        srai              a9, a8, 24
+        rsil              a10, 15
+        l8ui              a8, a2, 0
+        slli              a11, a8, 24
+        srai              a11, a11, 24
+        max               a9, a9, a11
+        s8i               a9, a2, 0
+        wsr.ps            a10
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_max::i8::acquire:
+        entry             a1, 32
+        slli              a8, a3, 24
+        srai              a9, a8, 24
+        rsil              a10, 15
+        l8ui              a8, a2, 0
+        slli              a11, a8, 24
+        srai              a11, a11, 24
+        max               a9, a9, a11
+        s8i               a9, a2, 0
+        wsr.ps            a10
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_max::i8::relaxed:
+        entry             a1, 32
+        slli              a8, a3, 24
+        srai              a9, a8, 24
+        rsil              a10, 15
+        l8ui              a8, a2, 0
+        slli              a11, a8, 24
+        srai              a11, a11, 24
+        max               a9, a9, a11
+        s8i               a9, a2, 0
+        wsr.ps            a10
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_max::i8::release:
+        entry             a1, 32
+        slli              a8, a3, 24
+        srai              a9, a8, 24
+        rsil              a10, 15
+        l8ui              a8, a2, 0
+        slli              a11, a8, 24
+        srai              a11, a11, 24
+        max               a9, a9, a11
+        s8i               a9, a2, 0
+        wsr.ps            a10
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_max::i16::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l16si             a8, a2, 0
+        slli              a10, a3, 16
+        srai              a10, a10, 16
+        max               a10, a10, a8
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_max::i16::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l16si             a8, a2, 0
+        slli              a10, a3, 16
+        srai              a10, a10, 16
+        max               a10, a10, a8
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_max::i16::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l16si             a8, a2, 0
+        slli              a10, a3, 16
+        srai              a10, a10, 16
+        max               a10, a10, a8
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_max::i16::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l16si             a8, a2, 0
+        slli              a10, a3, 16
+        srai              a10, a10, 16
+        max               a10, a10, a8
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_max::i16::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l16si             a8, a2, 0
+        slli              a10, a3, 16
+        srai              a10, a10, 16
+        max               a10, a10, a8
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_max::i32::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        max               a10, a3, a8
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_max::i32::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        max               a10, a3, a8
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_max::i32::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        max               a10, a3, a8
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_max::i32::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        max               a10, a3, a8
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_max::i32::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        max               a10, a3, a8
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_min::i8::acqrel:
+        entry             a1, 32
+        slli              a8, a3, 24
+        srai              a9, a8, 24
+        rsil              a10, 15
+        l8ui              a8, a2, 0
+        slli              a11, a8, 24
+        srai              a11, a11, 24
+        min               a9, a9, a11
+        s8i               a9, a2, 0
+        wsr.ps            a10
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_min::i8::seqcst:
+        entry             a1, 32
+        slli              a8, a3, 24
+        srai              a9, a8, 24
+        rsil              a10, 15
+        l8ui              a8, a2, 0
+        slli              a11, a8, 24
+        srai              a11, a11, 24
+        min               a9, a9, a11
+        s8i               a9, a2, 0
+        wsr.ps            a10
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_min::i8::acquire:
+        entry             a1, 32
+        slli              a8, a3, 24
+        srai              a9, a8, 24
+        rsil              a10, 15
+        l8ui              a8, a2, 0
+        slli              a11, a8, 24
+        srai              a11, a11, 24
+        min               a9, a9, a11
+        s8i               a9, a2, 0
+        wsr.ps            a10
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_min::i8::relaxed:
+        entry             a1, 32
+        slli              a8, a3, 24
+        srai              a9, a8, 24
+        rsil              a10, 15
+        l8ui              a8, a2, 0
+        slli              a11, a8, 24
+        srai              a11, a11, 24
+        min               a9, a9, a11
+        s8i               a9, a2, 0
+        wsr.ps            a10
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_min::i8::release:
+        entry             a1, 32
+        slli              a8, a3, 24
+        srai              a9, a8, 24
+        rsil              a10, 15
+        l8ui              a8, a2, 0
+        slli              a11, a8, 24
+        srai              a11, a11, 24
+        min               a9, a9, a11
+        s8i               a9, a2, 0
+        wsr.ps            a10
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_min::i16::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l16si             a8, a2, 0
+        slli              a10, a3, 16
+        srai              a10, a10, 16
+        min               a10, a10, a8
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_min::i16::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l16si             a8, a2, 0
+        slli              a10, a3, 16
+        srai              a10, a10, 16
+        min               a10, a10, a8
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_min::i16::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l16si             a8, a2, 0
+        slli              a10, a3, 16
+        srai              a10, a10, 16
+        min               a10, a10, a8
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_min::i16::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l16si             a8, a2, 0
+        slli              a10, a3, 16
+        srai              a10, a10, 16
+        min               a10, a10, a8
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_min::i16::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l16si             a8, a2, 0
+        slli              a10, a3, 16
+        srai              a10, a10, 16
+        min               a10, a10, a8
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_min::i32::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        min               a10, a3, a8
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_min::i32::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        min               a10, a3, a8
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_min::i32::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        min               a10, a3, a8
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_min::i32::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        min               a10, a3, a8
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_min::i32::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        min               a10, a3, a8
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_neg::u8::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        neg               a10, a8
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_neg::u8::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        neg               a10, a8
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_neg::u8::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        neg               a10, a8
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_neg::u8::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        neg               a10, a8
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_neg::u8::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        neg               a10, a8
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_neg::u16::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        neg               a10, a8
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_neg::u16::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        neg               a10, a8
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_neg::u16::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        neg               a10, a8
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_neg::u16::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        neg               a10, a8
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_neg::u16::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        neg               a10, a8
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_neg::u32::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        neg               a10, a8
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_neg::u32::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        neg               a10, a8
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_neg::u32::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        neg               a10, a8
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_neg::u32::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        neg               a10, a8
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_neg::u32::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        neg               a10, a8
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_not::u8::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        movi.n            a10, -1
+        xor               a10, a8, a10
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_not::u8::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        movi.n            a10, -1
+        xor               a10, a8, a10
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_not::u8::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        movi.n            a10, -1
+        xor               a10, a8, a10
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_not::u8::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        movi.n            a10, -1
+        xor               a10, a8, a10
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_not::u8::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        movi.n            a10, -1
+        xor               a10, a8, a10
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_not::u16::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        movi.n            a10, -1
+        xor               a10, a8, a10
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_not::u16::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        movi.n            a10, -1
+        xor               a10, a8, a10
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_not::u16::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        movi.n            a10, -1
+        xor               a10, a8, a10
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_not::u16::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        movi.n            a10, -1
+        xor               a10, a8, a10
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_not::u16::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        movi.n            a10, -1
+        xor               a10, a8, a10
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_not::u32::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        movi.n            a10, -1
+        xor               a10, a8, a10
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_not::u32::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        movi.n            a10, -1
+        xor               a10, a8, a10
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_not::u32::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        movi.n            a10, -1
+        xor               a10, a8, a10
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_not::u32::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        movi.n            a10, -1
+        xor               a10, a8, a10
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_not::u32::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        movi.n            a10, -1
+        xor               a10, a8, a10
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_not::bool::acqrel:
+        entry             a1, 32
+        mov.n             a8, a2
+        rsil              a9, 15
+        l8ui              a10, a8, 0
+        movi.n            a2, 1
+        xor               a11, a10, a2
+        s8i               a11, a8, 0
+        wsr.ps            a9
+        rsync
+        movi.n            a8, 0
+        bne               a10, a8, 0f
+        mov.n             a2, a8
+0:
+        retw.n
+
+asm_test::fetch_not::bool::seqcst:
+        entry             a1, 32
+        mov.n             a8, a2
+        rsil              a9, 15
+        l8ui              a10, a8, 0
+        movi.n            a2, 1
+        xor               a11, a10, a2
+        s8i               a11, a8, 0
+        wsr.ps            a9
+        rsync
+        movi.n            a8, 0
+        bne               a10, a8, 0f
+        mov.n             a2, a8
+0:
+        retw.n
+
+asm_test::fetch_not::bool::acquire:
+        entry             a1, 32
+        mov.n             a8, a2
+        rsil              a9, 15
+        l8ui              a10, a8, 0
+        movi.n            a2, 1
+        xor               a11, a10, a2
+        s8i               a11, a8, 0
+        wsr.ps            a9
+        rsync
+        movi.n            a8, 0
+        bne               a10, a8, 0f
+        mov.n             a2, a8
+0:
+        retw.n
+
+asm_test::fetch_not::bool::relaxed:
+        entry             a1, 32
+        mov.n             a8, a2
+        rsil              a9, 15
+        l8ui              a10, a8, 0
+        movi.n            a2, 1
+        xor               a11, a10, a2
+        s8i               a11, a8, 0
+        wsr.ps            a9
+        rsync
+        movi.n            a8, 0
+        bne               a10, a8, 0f
+        mov.n             a2, a8
+0:
+        retw.n
+
+asm_test::fetch_not::bool::release:
+        entry             a1, 32
+        mov.n             a8, a2
+        rsil              a9, 15
+        l8ui              a10, a8, 0
+        movi.n            a2, 1
+        xor               a11, a10, a2
+        s8i               a11, a8, 0
+        wsr.ps            a9
+        rsync
+        movi.n            a8, 0
+        bne               a10, a8, 0f
+        mov.n             a2, a8
+0:
+        retw.n
+
+asm_test::fetch_sub::u8::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        sub               a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_sub::u8::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        sub               a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_sub::u8::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        sub               a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_sub::u8::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        sub               a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_sub::u8::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        sub               a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_sub::u16::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        sub               a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_sub::u16::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        sub               a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_sub::u16::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        sub               a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_sub::u16::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        sub               a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_sub::u16::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        sub               a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_sub::u32::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        sub               a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_sub::u32::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        sub               a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_sub::u32::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        sub               a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_sub::u32::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        sub               a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_sub::u32::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        sub               a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_xor::u8::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        xor               a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_xor::u8::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        xor               a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_xor::u8::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        xor               a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_xor::u8::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        xor               a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_xor::u8::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l8ui              a8, a2, 0
+        xor               a10, a8, a3
+        s8i               a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_xor::u16::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        xor               a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_xor::u16::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        xor               a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_xor::u16::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        xor               a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_xor::u16::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        xor               a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_xor::u16::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l16ui             a8, a2, 0
+        xor               a10, a8, a3
+        s16i              a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_xor::u32::acqrel:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        xor               a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_xor::u32::seqcst:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        xor               a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_xor::u32::acquire:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        xor               a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_xor::u32::relaxed:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        xor               a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_xor::u32::release:
+        entry             a1, 32
+        rsil              a9, 15
+        l32i.n            a8, a2, 0
+        xor               a10, a8, a3
+        s32i.n            a10, a2, 0
+        wsr.ps            a9
+        rsync
+        mov.n             a2, a8
+        retw.n
+
+asm_test::fetch_xor::bool::acqrel:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        xor               a10, a9, a3
+        s8i               a10, a2, 0
+        wsr.ps            a8
+        rsync
+        movi.n            a2, 0
+        beq               a9, a2, 0f
+        movi.n            a2, 1
+0:
+        retw.n
+
+asm_test::fetch_xor::bool::seqcst:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        xor               a10, a9, a3
+        s8i               a10, a2, 0
+        wsr.ps            a8
+        rsync
+        movi.n            a2, 0
+        beq               a9, a2, 0f
+        movi.n            a2, 1
+0:
+        retw.n
+
+asm_test::fetch_xor::bool::acquire:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        xor               a10, a9, a3
+        s8i               a10, a2, 0
+        wsr.ps            a8
+        rsync
+        movi.n            a2, 0
+        beq               a9, a2, 0f
+        movi.n            a2, 1
+0:
+        retw.n
+
+asm_test::fetch_xor::bool::relaxed:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        xor               a10, a9, a3
+        s8i               a10, a2, 0
+        wsr.ps            a8
+        rsync
+        movi.n            a2, 0
+        beq               a9, a2, 0f
+        movi.n            a2, 1
+0:
+        retw.n
+
+asm_test::fetch_xor::bool::release:
+        entry             a1, 32
+        rsil              a8, 15
+        l8ui              a9, a2, 0
+        xor               a10, a9, a3
+        s8i               a10, a2, 0
+        wsr.ps            a8
+        rsync
+        movi.n            a2, 0
+        beq               a9, a2, 0f
+        movi.n            a2, 1
+0:
         retw.n

--- a/tests/asm-test/asm/portable-atomic/xtensa_esp32s2.asm
+++ b/tests/asm-test/asm/portable-atomic/xtensa_esp32s2.asm
@@ -5322,12 +5322,10 @@ asm_test::fetch_and::bool::release:
 
 asm_test::fetch_max::i8::acqrel:
         entry             a1, 32
-        slli              a8, a3, 24
-        srai              a9, a8, 24
+        sext              a9, a3, 7
         rsil              a10, 15
         l8ui              a8, a2, 0
-        slli              a11, a8, 24
-        srai              a11, a11, 24
+        sext              a11, a8, 7
         max               a9, a9, a11
         s8i               a9, a2, 0
         wsr.ps            a10
@@ -5337,12 +5335,10 @@ asm_test::fetch_max::i8::acqrel:
 
 asm_test::fetch_max::i8::seqcst:
         entry             a1, 32
-        slli              a8, a3, 24
-        srai              a9, a8, 24
+        sext              a9, a3, 7
         rsil              a10, 15
         l8ui              a8, a2, 0
-        slli              a11, a8, 24
-        srai              a11, a11, 24
+        sext              a11, a8, 7
         max               a9, a9, a11
         s8i               a9, a2, 0
         wsr.ps            a10
@@ -5352,12 +5348,10 @@ asm_test::fetch_max::i8::seqcst:
 
 asm_test::fetch_max::i8::acquire:
         entry             a1, 32
-        slli              a8, a3, 24
-        srai              a9, a8, 24
+        sext              a9, a3, 7
         rsil              a10, 15
         l8ui              a8, a2, 0
-        slli              a11, a8, 24
-        srai              a11, a11, 24
+        sext              a11, a8, 7
         max               a9, a9, a11
         s8i               a9, a2, 0
         wsr.ps            a10
@@ -5367,12 +5361,10 @@ asm_test::fetch_max::i8::acquire:
 
 asm_test::fetch_max::i8::relaxed:
         entry             a1, 32
-        slli              a8, a3, 24
-        srai              a9, a8, 24
+        sext              a9, a3, 7
         rsil              a10, 15
         l8ui              a8, a2, 0
-        slli              a11, a8, 24
-        srai              a11, a11, 24
+        sext              a11, a8, 7
         max               a9, a9, a11
         s8i               a9, a2, 0
         wsr.ps            a10
@@ -5382,12 +5374,10 @@ asm_test::fetch_max::i8::relaxed:
 
 asm_test::fetch_max::i8::release:
         entry             a1, 32
-        slli              a8, a3, 24
-        srai              a9, a8, 24
+        sext              a9, a3, 7
         rsil              a10, 15
         l8ui              a8, a2, 0
-        slli              a11, a8, 24
-        srai              a11, a11, 24
+        sext              a11, a8, 7
         max               a9, a9, a11
         s8i               a9, a2, 0
         wsr.ps            a10
@@ -5399,8 +5389,7 @@ asm_test::fetch_max::i16::acqrel:
         entry             a1, 32
         rsil              a9, 15
         l16si             a8, a2, 0
-        slli              a10, a3, 16
-        srai              a10, a10, 16
+        sext              a10, a3, 15
         max               a10, a10, a8
         s16i              a10, a2, 0
         wsr.ps            a9
@@ -5412,8 +5401,7 @@ asm_test::fetch_max::i16::seqcst:
         entry             a1, 32
         rsil              a9, 15
         l16si             a8, a2, 0
-        slli              a10, a3, 16
-        srai              a10, a10, 16
+        sext              a10, a3, 15
         max               a10, a10, a8
         s16i              a10, a2, 0
         wsr.ps            a9
@@ -5425,8 +5413,7 @@ asm_test::fetch_max::i16::acquire:
         entry             a1, 32
         rsil              a9, 15
         l16si             a8, a2, 0
-        slli              a10, a3, 16
-        srai              a10, a10, 16
+        sext              a10, a3, 15
         max               a10, a10, a8
         s16i              a10, a2, 0
         wsr.ps            a9
@@ -5438,8 +5425,7 @@ asm_test::fetch_max::i16::relaxed:
         entry             a1, 32
         rsil              a9, 15
         l16si             a8, a2, 0
-        slli              a10, a3, 16
-        srai              a10, a10, 16
+        sext              a10, a3, 15
         max               a10, a10, a8
         s16i              a10, a2, 0
         wsr.ps            a9
@@ -5451,8 +5437,7 @@ asm_test::fetch_max::i16::release:
         entry             a1, 32
         rsil              a9, 15
         l16si             a8, a2, 0
-        slli              a10, a3, 16
-        srai              a10, a10, 16
+        sext              a10, a3, 15
         max               a10, a10, a8
         s16i              a10, a2, 0
         wsr.ps            a9
@@ -5517,12 +5502,10 @@ asm_test::fetch_max::i32::release:
 
 asm_test::fetch_min::i8::acqrel:
         entry             a1, 32
-        slli              a8, a3, 24
-        srai              a9, a8, 24
+        sext              a9, a3, 7
         rsil              a10, 15
         l8ui              a8, a2, 0
-        slli              a11, a8, 24
-        srai              a11, a11, 24
+        sext              a11, a8, 7
         min               a9, a9, a11
         s8i               a9, a2, 0
         wsr.ps            a10
@@ -5532,12 +5515,10 @@ asm_test::fetch_min::i8::acqrel:
 
 asm_test::fetch_min::i8::seqcst:
         entry             a1, 32
-        slli              a8, a3, 24
-        srai              a9, a8, 24
+        sext              a9, a3, 7
         rsil              a10, 15
         l8ui              a8, a2, 0
-        slli              a11, a8, 24
-        srai              a11, a11, 24
+        sext              a11, a8, 7
         min               a9, a9, a11
         s8i               a9, a2, 0
         wsr.ps            a10
@@ -5547,12 +5528,10 @@ asm_test::fetch_min::i8::seqcst:
 
 asm_test::fetch_min::i8::acquire:
         entry             a1, 32
-        slli              a8, a3, 24
-        srai              a9, a8, 24
+        sext              a9, a3, 7
         rsil              a10, 15
         l8ui              a8, a2, 0
-        slli              a11, a8, 24
-        srai              a11, a11, 24
+        sext              a11, a8, 7
         min               a9, a9, a11
         s8i               a9, a2, 0
         wsr.ps            a10
@@ -5562,12 +5541,10 @@ asm_test::fetch_min::i8::acquire:
 
 asm_test::fetch_min::i8::relaxed:
         entry             a1, 32
-        slli              a8, a3, 24
-        srai              a9, a8, 24
+        sext              a9, a3, 7
         rsil              a10, 15
         l8ui              a8, a2, 0
-        slli              a11, a8, 24
-        srai              a11, a11, 24
+        sext              a11, a8, 8
         min               a9, a9, a11
         s8i               a9, a2, 0
         wsr.ps            a10
@@ -5577,12 +5554,10 @@ asm_test::fetch_min::i8::relaxed:
 
 asm_test::fetch_min::i8::release:
         entry             a1, 32
-        slli              a8, a3, 24
-        srai              a9, a8, 24
+        sext              a9, a3, 7
         rsil              a10, 15
         l8ui              a8, a2, 0
-        slli              a11, a8, 24
-        srai              a11, a11, 24
+        sext              a11, a8, 7
         min               a9, a9, a11
         s8i               a9, a2, 0
         wsr.ps            a10
@@ -5594,8 +5569,7 @@ asm_test::fetch_min::i16::acqrel:
         entry             a1, 32
         rsil              a9, 15
         l16si             a8, a2, 0
-        slli              a10, a3, 16
-        srai              a10, a10, 16
+        sext              a10, a3, 15
         min               a10, a10, a8
         s16i              a10, a2, 0
         wsr.ps            a9
@@ -5607,8 +5581,7 @@ asm_test::fetch_min::i16::seqcst:
         entry             a1, 32
         rsil              a9, 15
         l16si             a8, a2, 0
-        slli              a10, a3, 16
-        srai              a10, a10, 16
+        sext              a10, a3, 15
         min               a10, a10, a8
         s16i              a10, a2, 0
         wsr.ps            a9
@@ -5620,8 +5593,7 @@ asm_test::fetch_min::i16::acquire:
         entry             a1, 32
         rsil              a9, 15
         l16si             a8, a2, 0
-        slli              a10, a3, 16
-        srai              a10, a10, 16
+        sext              a10, a3, 15
         min               a10, a10, a8
         s16i              a10, a2, 0
         wsr.ps            a9
@@ -5633,8 +5605,7 @@ asm_test::fetch_min::i16::relaxed:
         entry             a1, 32
         rsil              a9, 15
         l16si             a8, a2, 0
-        slli              a10, a3, 16
-        srai              a10, a10, 16
+        sext              a10, a3, 15
         min               a10, a10, a8
         s16i              a10, a2, 0
         wsr.ps            a9
@@ -5646,8 +5617,7 @@ asm_test::fetch_min::i16::release:
         entry             a1, 32
         rsil              a9, 15
         l16si             a8, a2, 0
-        slli              a10, a3, 16
-        srai              a10, a10, 16
+        sext              a10, a3, 15
         min               a10, a10, a8
         s16i              a10, a2, 0
         wsr.ps            a9

--- a/tests/asm-test/asm/portable-atomic/xtensa_esp32s2.asm
+++ b/tests/asm-test/asm/portable-atomic/xtensa_esp32s2.asm
@@ -5544,7 +5544,7 @@ asm_test::fetch_min::i8::relaxed:
         sext              a9, a3, 7
         rsil              a10, 15
         l8ui              a8, a2, 0
-        sext              a11, a8, 8
+        sext              a11, a8, 7
         min               a9, a9, a11
         s8i               a9, a2, 0
         wsr.ps            a10

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -414,6 +414,9 @@ build() {
           armv[4-5]t* | thumbv[4-5]t* | thumbv6m* | riscv??[ie]-*-none* | riscv??[ie]m-*-none* | riscv??[ie]mc-*-none* | xtensa-esp32s2-*)
             target_rustflags+=" --cfg portable_atomic_unsafe_assume_single_core"
             ;;
+          xtensa-esp32*)
+            # At this time, these chips require critical-section to be enabled, which is incompatible with the single-core and privileged assumptions.
+            ;;
         esac
       fi
       # TODO: handle SIGILL and ERR


### PR DESCRIPTION
Second attempt of trying to progress on https://github.com/esp-rs/esp-hal/issues/2027, an alternative approach to #225. This PR has (almost) entirely been generated by Cursor/Claude, with minimal touchups from me after reading through what changes were made. I tried my bst to make sure it's not entirely nonsense, though I don't necessarily understand everything (especially `NotRefUnwindSafe`).

The key differences from the previous PR are:
- It doesn't try to reuse the critical section implementation. This limits changes to existing code _considerably_, especially it allows not changing the `cfg` maze. Not making a mess also allows us to make changes like supporting unsafe-assume-single-core easier in the future.
- The PR **replaces** `core_atomic` with a similar-ish implementation for the affected chips.
- The PR doesn't attempt to rewrite everything in assembly, but instead uses `core::sync::atomic`. I'm walking back on assembly for the time being to allow progressing on this issue in any (limited) way.
- If `critical-section` is not enabled, access to PSRAM will panic. Trying to force-require the feature is a weird state to me, although I can flip it into a compile error easily enough if preferred.